### PR TITLE
fix(streaming): join multiple data: lines in one SSE event

### DIFF
--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -130,9 +130,15 @@ async function* streamOnce(
         let eventId: string | undefined;
 
         for (const line of lines) {
-          // Handle both "data: value" and "data:value" (SSE spec)
+          // Handle both "data: value" and "data:value" (SSE spec). Multiple
+          // data: lines in ONE event are JOINED with '\n' per the spec — the
+          // previous code kept only the last line, silently dropping the head
+          // of any multi-line payload. nika serve emits single-line JSON today
+          // so this was latent, but a spec-compliant producer (or a
+          // pretty-printed reply) would otherwise arrive truncated + unparseable.
           if (line.startsWith('data:')) {
-            data = line[5] === ' ' ? line.slice(6) : line.slice(5);
+            const value = line[5] === ' ' ? line.slice(6) : line.slice(5);
+            data = data === undefined ? value : `${data}\n${value}`;
           }
           // Parse id: field for reconnect tracking
           if (line.startsWith('id:')) {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -69,6 +69,29 @@ describe('streamEvents', () => {
     }
   });
 
+  it('joins multiple data: lines in one event with newlines (SSE spec)', async () => {
+    // A spec-compliant producer may split one JSON payload across several
+    // data: lines; they must be re-joined with '\n' before parsing. The old
+    // code kept only the last line, dropping the head and failing to parse.
+    const fetchFn = vi.fn().mockResolvedValueOnce(
+      sseResponse([
+        'event: completed\ndata: {"type":"completed",\ndata: "job_id":"j1",\ndata: "output":"multi"}\n\n',
+      ]),
+    );
+    const client = makeApiClient(fetchFn as typeof fetch);
+
+    const events = [];
+    for await (const event of streamEvents(client, 'j1')) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('completed');
+    if (events[0].type === 'completed') {
+      expect(events[0].output).toBe('multi');
+    }
+  });
+
   it('stops on terminal event (completed)', async () => {
     const fetchFn = vi.fn().mockResolvedValueOnce(
       sseResponse([


### PR DESCRIPTION
Per the SSE spec, several `data:` lines within one event carry ONE payload joined by `\n`. The parser kept only the *last* line, so a multi-line JSON reply arrived with its head dropped and failed to parse (the event was silently skipped). `nika serve` emits single-line JSON today so this was latent — but a spec-compliant producer or a pretty-printed reply would lose events. New test proves a three-line payload reassembles; without the fix only the tail survives and the event never arrives. Full suite green (97).

🤖 Generated with [Claude Code](https://claude.com/claude-code)