### PR TITLE
ci(release): remove the dead nika-release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: Release
 on:
-  # Triggered automatically by nika's release workflow
-  repository_dispatch:
-    types: [nika-release]
-
-  # Manual trigger for standalone releases
+  # Manual releases only for now: the engine's release workflow never
+  # emitted the old `repository_dispatch: nika-release` (dead wiring,
+  # 2026-07-09 audit) - it returns when the SDK rides the release train.
   workflow_dispatch:
     inputs:
       version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Release: the `repository_dispatch: nika-release` trigger — the engine's
+  release workflow never emitted it (dead wiring, 2026-07-09 audit).
+  Releases stay manual (`workflow_dispatch`, with `dry_run`) until the
+  SDK rides the engine release train.
+
+
 The SDK tracks the `nika serve` HTTP surface. The engine ships the
 Diamond rewrite (`supernovae-st/nika`, v0.9x releasing — 0.96.0 at time
 of writing). `nika serve` will re-admit to the workspace during the v0.9x arc;


### PR DESCRIPTION
Re-scoped from #3: main independently landed the better CI fix for the serve-dependent jobs (advisory soft-fail with an honest "flip back to a hard gate when serve ships" note) — superior to removal, kept as-is.

What remains from the audit finding (**DP1-11**): the `repository_dispatch: nika-release` trigger — the engine's release workflow never emits it (verified: build/release/bump-formula only). Dead wiring removed; releases stay manual (`workflow_dispatch` + `dry_run`) until the SDK rides the engine release train. CHANGELOG documents it.

🦋