### PR TITLE
docs(readme): hand out the integrations map

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ for await (const event of nika.jobs.stream(jobId, {
 
 ## Links
 
+- **Every door in one page** — install paths, IDEs, agents, skills, MCP, CI, SDKs: [docs.nika.sh/integrations/everywhere](https://docs.nika.sh/integrations/everywhere)
 - Engine: [github.com/supernovae-st/nika](https://github.com/supernovae-st/nika) (Rust, AGPL-3.0-or-later)
 - Language spec: [github.com/supernovae-st/nika-spec](https://github.com/supernovae-st/nika-spec) (Apache-2.0)
 - Docs: [docs.nika.sh](https://docs.nika.sh)


### PR DESCRIPTION
One line in the links section: the categorized map of every surface (docs.nika.sh/integrations/everywhere) — same routing as engine#387, the kit, docs and the vscode storefront. API-commit route.