### PR TITLE
fix(local): dryRunPlan teaches the engine floor instead of relaying clap

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Honesty is typed in: `cost.min_path_total_usd` is a FLOOR and
 `has_unbounded` lives beside it; an unpriced model's `usd` stays `null`
 (never coerced to 0); an unknown `report_version` degrades to warnings,
 never throws; a parse-fatal file returns a typed PARSE finding on both
-engine voices (plain-text 0.99.0 and the later JSON form).
+engine voices (plain-text 0.99.0 and the later JSON form). Where a
+method needs a NEWER engine than the last tag (`dryRunPlan()` → the
+machine dry-run, engine #370, first release after 0.99.0), an older
+binary's refusal is translated into an error that names the floor and
+the probed version — never a raw clap message.
 
 - Zero runtime dependencies (uses native `fetch`)
 - Full TypeScript types aligned with nika serve OpenAPI 3.1 spec

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -159,11 +159,27 @@ export class LocalNika {
    * `nika run <file> --dry-run --json` — the #370 plan object
    * (`plan_version: 1`). A DIRTY file answers the check report on the
    * refusal path — surfaced as a typed rejection carrying that report.
+   *
+   * Min engine: the first release after 0.99.0 (engine #370). An older
+   * binary's clap refusal is translated into a teaching error naming
+   * the probed version — never the raw flag-pair message.
    */
   async dryRunPlan(file: string): Promise<LocalPlan> {
     const r = await this.capture(['run', file, '--dry-run', '--json']);
     const raw = tryJson(r.stdout) as Record<string, unknown> | null;
     if (!raw) {
+      // The released-binary skew (#12): engines tagged ≤0.99.0 predate the
+      // machine dry-run (engine #370) and clap refuses the flag pair. Teach
+      // the floor instead of relaying the raw refusal.
+      if (r.stderr.includes('cannot be used with')) {
+        const version = await this.version().catch(() => 'unknown');
+        throw new Error(
+          `dryRunPlan() needs the engine's machine dry-run (run --dry-run --json, ` +
+            `first released AFTER 0.99.0) — this binary is ${version}. ` +
+            `Upgrade the engine (brew upgrade supernovae-st/tap/nika) or use check() ` +
+            `for the audit surface it already ships.`,
+        );
+      }
       throw new Error(`dry-run emitted no JSON (exit ${r.exitCode}): ${r.stderr.trim()}`);
     }
     if (!('plan_version' in raw)) {

--- a/test/fixtures/fake-nika.mjs
+++ b/test/fixtures/fake-nika.mjs
@@ -51,6 +51,12 @@ if (argv[0] === 'check') {
   process.exit(0);
 }
 
+if (argv[0] === 'run' && has('--dry-run') && has('--json') && file.includes('pre370')) {
+  // The RELEASED 0.99.0 voice: clap refuses the pair before reading the file.
+  console.error("error: the argument '--dry-run' cannot be used with '--json'");
+  process.exit(2);
+}
+
 if (argv[0] === 'run' && has('--dry-run') && has('--json')) {
   if (file.includes('dirty')) {
     // The refusal path answers the CHECK report (report_version key).

--- a/test/local.test.ts
+++ b/test/local.test.ts
@@ -102,6 +102,12 @@ describe.skipIf(!posix)('LocalNika · canned engine', () => {
     });
   });
 
+  it('dryRunPlan on a pre-#370 binary: the error teaches the floor, names the version', async () => {
+    await expect(nika.dryRunPlan('pre370.nika.yaml')).rejects.toThrow(
+      /needs the engine's machine dry-run.*this binary is nika 0\.99\.0.*brew upgrade/s,
+    );
+  });
+
   it('test + traceVerify map their exits', async () => {
     expect((await nika.test('golden-ok.nika.yaml')).passed).toBe(true);
     expect((await nika.test('golden-bad.nika.yaml')).passed).toBe(false);


### PR DESCRIPTION
Fresh-consumer e2e (#12): the released 0.99.0 binary predates the machine dry-run (engine #370, merged post-tag) — `dryRunPlan()` was the one skewed method of an otherwise-green driver, surfacing the raw clap refusal.

- **The error teaches**: the driver recognizes the refusal voice, probes `version()`, and names the floor + the binary + the two exits (upgrade · use `check()`)
- **The floor is stated**: docstring + README min-engine rule
- **The fixture speaks the RELEASED voice verbatim** (the issue's capture) — 112/112 green

The third suggestion (coverage script proving every driver method against the RELEASED binary) is a separate e2e harness — deliberately not taken here.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)