### PR TITLE
style: em dashes out, house middots in

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ engine voices (plain-text 0.99.0 and the later JSON form). Where a
 method needs a NEWER engine than the last tag (`dryRunPlan()` → the
 machine dry-run, engine #370, first release after 0.99.0), an older
 binary's refusal is translated into an error that names the floor and
-the probed version — never a raw clap message.
+the probed version · never a raw clap message.
 
 - Zero runtime dependencies (uses native `fetch`)
 - Full TypeScript types aligned with nika serve OpenAPI 3.1 spec


### PR DESCRIPTION
Em dashes out, house middots in. Typography only, zero content change.

Part of the fleet-wide anti-slop pass (studio copy canon 2026-07-13): the
spaced em dash is the most-recognized AI-slop tell of 2026 (WP:AIDASH), the
house separator is the middot.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
