### PR TITLE
test: w1 the map — fixtures speak the key-is-identity grammar

### DIFF
--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -86,7 +86,7 @@ function createMockServer(state: MockState) {
       const name = decodeURIComponent(sourceMatch[1]);
       if (name === 'translate.nika.yaml') {
         res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end('schema: "nika/workflow@0.12"\nworkflow: translate\ndescription: "Translate files"');
+        res.end('schema: "nika/workflow@0.12"\nworkflow:\n  id: translate\n  description: "Translate files"');
         return;
       }
       json(res, { error: `Workflow not found: ${name}` }, 404);
@@ -592,7 +592,7 @@ describe('E2E: nika-client v2 against mock server', () => {
 
       const yaml = await client.workflows.source('translate.nika.yaml');
       expect(yaml).toContain('nika/workflow@0.12');
-      expect(yaml).toContain('workflow: translate');
+      expect(yaml).toContain('  id: translate');
     });
   });
 

--- a/test/local.e2e.test.ts
+++ b/test/local.e2e.test.ts
@@ -24,12 +24,13 @@ function realNika(): string | null {
 const BIN = realNika();
 
 const WF = `nika: v1
-workflow: sdk-live
+workflow:
+  id: sdk-live
 model: mock/echo
 tasks:
-  - id: fetch
+  fetch:
     exec: { command: ["echo", "data"] }
-  - id: think
+  think:
     depends_on: [fetch]
     infer: { prompt: "sum \${{ tasks.fetch.output }}", max_tokens: 30 }
 `;


### PR DESCRIPTION
Lockstep with nika-spec#87 (`ac503458`) + engine#581/#582 — the two SDK fixtures take the map form; the SDK API surface is untouched (its `workflow` fields carry machine formats W1 left byte-stable). **112/112** against the W1 engine build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)