### PR TITLE
test(e2e): the local harness speaks w2 — the binding is the edge

### DIFF
--- a/test/local.e2e.test.ts
+++ b/test/local.e2e.test.ts
@@ -31,8 +31,9 @@ tasks:
   fetch:
     exec: { command: ["echo", "data"] }
   think:
-    depends_on: [fetch]
-    infer: { prompt: "sum \${{ tasks.fetch.output }}", max_tokens: 30 }
+    with:
+      data: \${{ tasks.fetch.output }}
+    infer: { prompt: "sum \${{ with.data }}", max_tokens: 30 }
 `;
 
 describe.skipIf(!BIN)('LocalNika · live engine (skip-honest)', () => {


### PR DESCRIPTION
One fixture: the local e2e's shared-context read hoists into a `with:` binding (the w2 boundary — `depends_on` is dead, the binding IS the edge). 112/112 against the w2 engine binary; `plan` shape and `report_version` are untouched, proven by the suite.

Part of the W2 « the flow » window (spec#94 · engine PR pending — merge AFTER the engine lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)