### PR TITLE
docs(local): add exit 4 (paused) to the engine CLI exit-code contract

### DIFF
--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -13,9 +13,9 @@
  * Zero dependencies. Process spawning is deliberately `spawn` with an
  * ARGV ARRAY and no shell (`exec`/shell-string forms are banned here —
  * the workflow path is attacker-adjacent input, and argv+no-shell is
- * the injection-safe form). Exit codes are the spec §4 contract (0 ok ·
- * 1 workflow failed · 2 file findings · 3 environment), mapped, never
- * guessed.
+ * the injection-safe form). Exit codes are the engine CLI exit-code
+ * contract (locked · additive-only): 0 ok · 1 workflow failed · 2 file
+ * findings · 3 environment · 4 paused, mapped, never guessed.
  */
 
 import { spawn } from 'node:child_process';

--- a/src/local/types.ts
+++ b/src/local/types.ts
@@ -68,7 +68,8 @@ export interface LocalCheckReport {
    * plain-text voice the driver synthesizes the one row. */
   findings: LocalFinding[];
   permits: LocalPermits | null;
-  /** Spec §4: 0 ok · 2 file findings · 3 environment. */
+  /** The engine CLI exit-code contract (locked · additive-only), for
+   * `check`: 0 ok · 2 file findings · 3 environment. */
   exitCode: number;
   /** Driver-level honesty notes (unknown report_version · missing
    * sections) — never exceptions. */
@@ -87,7 +88,10 @@ export interface NikaEvent {
 
 /** The run outcome after the stream closes. */
 export interface LocalRunOutcome {
-  /** Spec §4: 0 ok · 1 workflow failed · 2 findings · 3 environment. */
+  /** The engine CLI exit-code contract (locked · additive-only), for
+   * `run`: 0 ok · 1 workflow failed · 2 findings · 3 environment ·
+   * 4 paused (nika:prompt durable pause · ADR-099 · resume via
+   * RunOptions.resume). */
   exitCode: number;
   ok: boolean;
   events: NikaEvent[];
@@ -102,7 +106,8 @@ export interface TraceVerdict {
   output: string;
 }
 
-/** `nika test` (mock golden · offline). Exit 0 pass · others per §4. */
+/** `nika test` (mock golden · offline). Exit 0 pass · others per the
+ * engine CLI exit-code contract. */
 export interface GoldenVerdict {
   passed: boolean;
   exitCode: number;


### PR DESCRIPTION
## What

Additive **doc-only** correction to the `LocalNika` exit-code contract (`src/local/`). No runtime code changed.

## Why (audit F-03c evidence)

The engine's locked CLI exit contract is:

```
0 ok · 1 workflow failed · 2 file findings · 3 environment · 4 paused
```

Exit **4 = paused** is the durable-pause code (`nika:prompt` · ADR-099), resumed with `--resume <trace> --answer k=v`. The driver already targets it — `RunOptions.resume` folds `--resume <trace>` in `runFlags()`.

Two defects in the shipped docs (0.104.0):

1. **Exit 4 (paused) was missing** from every place the contract is enumerated.
2. **`spec §4` is a phantom anchor.** `nika-spec` ships no numbered §4 exit table — the numeric table is the **engine** CLI contract (`crate-specs/nika-cli`), not a spec clause.

## What changed

- `src/local/index.ts` header — reworded `spec §4 contract` → **`the engine CLI exit-code contract (locked · additive-only)`** and added `· 4 paused`.
- `src/local/types.ts`:
  - `LocalRunOutcome.exitCode` — reworded anchor **+ added `4 paused`** (run is the surface that can pause), cross-referencing ADR-099 / `RunOptions.resume`.
  - `LocalCheckReport.exitCode` — reworded anchor; kept the static `{0, 2, 3}` set (`check` never runs, never pauses).
  - `GoldenVerdict` — reworded `others per §4` → `others per the engine CLI exit-code contract`.
- `TraceVerdict` (exit `0/2/3`, its own contract) left untouched — not the run/check exit space.

Diff: 2 files, 11 insertions / 6 deletions — comments only.

## What was NOT done (and why)

- **No typed `paused` field added.** The SDK surfaces `exitCode` as a raw number and derives `ok = (exitCode === 0)`; there is **no exit-code map/enum/switch** to extend. A `paused` verdict field would be a public-API addition (structurally additive on a return type, but a design decision on a published SDK), so it is flagged here rather than imposed. Today, consumers detect a resumable pause via `outcome.exitCode === 4` (and `outcome.ok === false`). **Gap for a follow-up:** a derived `paused` boolean on `LocalRunOutcome` (mirroring `ok`) would make the ADR-099 resume flow first-class.
- **No test added** — no code arm was implemented, so the fixture (`test/fixtures/fake-nika.mjs`, which already drives exit codes via `process.exit`) gains no `4`/paused scenario.
- One residual `§4` mention remains in a *test title* (`test/local.test.ts:72`) — left untouched to keep this leg scoped to `src/local/`.

## Tests

`npm ci && npm test` → **111 passed / 1 failed (112)**. The unit suite for the touched files (`test/local.test.ts`, 13 tests) is fully green.

The single failure is `test/local.e2e.test.ts` — the **live-engine `skipIf(!BIN)` leg** that only runs when a real `nika` resolves (it skips in CI without a binary). It is **pre-existing and unrelated**: identical failure on pristine `main` with these edits stashed. Root cause is a fixture/engine skew — the installed `nika 0.104.0` reports `clean: false` (`NIKA-PARSE-019`) on the test's inline mock workflow. A comment-only change cannot flip a runtime `clean` value.

```
 ❯ test/local.e2e.test.ts (2 tests | 1 failed)
   × live engine (skip-honest) > version → check clean → ...
     → expected false to be true   // report.clean, NIKA-PARSE-019 on 0.104.0
 ✓ test/local.test.ts (13 tests)
 Test Files  1 failed | 7 passed (8)
      Tests  1 failed | 111 passed (112)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
