### PR TITLE
ci: sha-pin actions + grouped weekly dependabot (actions + npm)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot · supply-chain freshness for this repo's own CI + npm deps.
+#
+# github-actions bumps are GROUPED into ONE weekly PR. Lesson proven on
+# nika-spec 2026-07-19 (PR #135): a multi-step action pair such as
+# github/codeql-action's `init` + `analyze`, if bumped in SEPARATE PRs,
+# desyncs mid-merge and the scan breaks (init and analyze must ride the
+# same version). One grouped weekly PR keeps the pair, and every other
+# action, moving together. The npm ecosystem rides the same grouped-weekly
+# discipline (one PR, all deps).
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-all:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -24,13 +24,13 @@ jobs:
   sdk-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       # Checkout nika repo for server source analysis
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: supernovae-st/nika
           path: nika
@@ -56,8 +56,8 @@ jobs:
   type-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check version alignment with nika
         run: |
           SDK_VERSION=$(node -p "require('./package.json').version")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -55,7 +55,7 @@ jobs:
       - run: npm run build
 
       # SDK coverage check against nika source
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: supernovae-st/nika
           path: nika-source


### PR DESCRIPTION
## Supply-chain hardening · SHA-pin actions + grouped Dependabot (actions + npm)

Additive-only estate hardening. Pins this repo's own GitHub Actions to
full-length commit SHAs (tag preserved as a trailing comment, **same
version**) and adds a grouped-weekly Dependabot config for both the
github-actions and npm ecosystems. Nothing outside `.github/` is touched.

### Actions pinned (before → after)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4` |
| `actions/setup-node` | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4` |

Occurrences: `workflows/ci.yml` (checkout ×5, setup-node ×3) ·
`workflows/release.yml` (checkout ×2, setup-node ×1). `workflows/release-heal.yml`
uses no actions (untouched). **11 refs pinned**, zero tag-only `uses:` remain.

### New `.github/dependabot.yml`

- `github-actions` · weekly · **grouped** (`patterns: ["*"]`)
- `npm` · directory `/` · weekly · **grouped** `npm-all` (`patterns: ["*"]`) —
  repo carries `package.json` + `package-lock.json`

### Why grouped

Split-pair lesson (proven on supernovae-st/nika-spec#135, 2026-07-19): a
multi-step action pair such as `github/codeql-action`'s `init` + `analyze`,
if bumped in **separate** PRs, desyncs mid-merge and the scan breaks (init
and analyze must ride the same version). One grouped weekly PR keeps the
pair — and every other action — moving together.

### Validation

- Every workflow + the new config parse (`yaml.safe_load`) ✅
- Re-grep: zero tag-only `uses:` in this repo's workflows ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
