### PR TITLE
fix(release): the bump rides a PR and coverage skips honestly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     env:
       # Version comes from either dispatch source
       VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
@@ -68,16 +69,30 @@ jobs:
         run: npm run check:coverage -- ./nika-source
         continue-on-error: true
 
-      # Commit version bump
-      - name: Commit version bump
+      # Commit version bump — via PR, never a push at main: the 2026-07-19
+      # protection wave (4 required checks) declines direct pushes, which
+      # silently killed this lane at 0.105 (issue #22). The bump branch
+      # auto-merges once CI is green; npm publishes from the working tree
+      # (already bumped), so the release never waits on the merge.
+      - name: Open the version-bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
-          git diff --cached --quiet || git commit -m "chore: bump version to $VERSION
-
-          Co-Authored-By: Nika Release Bot <nika@supernovae.studio>"
-          git push
+          if git diff --cached --quiet; then
+            echo "version already $VERSION — no bump PR needed"
+            exit 0
+          fi
+          branch="bot/release-v$VERSION"
+          git checkout -b "$branch"
+          git commit -m "chore: bump version to $VERSION" -m "Co-Authored-By: Nika Release Bot <nika@supernovae.studio>"
+          git push -u origin "$branch"
+          gh pr create --head "$branch" \
+            --title "chore: bump version to $VERSION" \
+            --body "Release-lane bump (auto-merges on green · release.yml)."
+          gh pr merge "$branch" --squash --auto
 
       # Publish to npm
       - name: Publish to npm

--- a/scripts/check-sdk-coverage.js
+++ b/scripts/check-sdk-coverage.js
@@ -21,6 +21,15 @@ const SERVE_EVENTS = join(NIKA_ROOT, 'tools/nika-serve/src/events.rs');
 const SERVE_WORKFLOWS = join(NIKA_ROOT, 'tools/nika-serve/src/routes/workflows.rs');
 const SERVE_ARTIFACTS = join(NIKA_ROOT, 'tools/nika-serve/src/routes/artifacts.rs');
 
+// `nika serve` left the tree in the Diamond refonte and re-admits during
+// the 0.9x arc (docs reference/cli) — on a modern checkout the serve tree
+// is absent and coverage has NOTHING to judge. Skip honestly (exit 0,
+// loud) instead of failing every release forever.
+if (!existsSync(SERVE_ROUTES)) {
+  console.log(`nika-serve not present at ${NIKA_ROOT} (re-admits in the 0.9x arc) — coverage SKIPPED`);
+  process.exit(0);
+}
+
 const SDK_JOBS = join(SDK_ROOT, 'src/resources/jobs.ts');
 const SDK_WORKFLOWS_FILE = join(SDK_ROOT, 'src/resources/workflows.ts');
 const SDK_INDEX = join(SDK_ROOT, 'src/index.ts');


### PR DESCRIPTION
Closes #22 — both legs, root-caused from the 0.105 run logs.

**Leg 1 (the killer)**: the 2026-07-19 protection wave (4 required checks) declines the workflow's direct `git push` of the version bump → the whole lane died silently (`npm` stayed 0.104 while brew served 0.105 — the coherence bot's lockstep row). The bump now rides a **bot PR with `--auto` squash-merge**: npm publishes from the already-bumped working tree so the release never waits on the merge, and a failed PR step aborts **before** publish (fail-closed — no orphan npm version).

**Leg 2**: `check-sdk-coverage.js` hunts `tools/nika-serve` — the brouillon-era tree. `nika serve` re-admits during the 0.9x arc, so coverage red-failed every modern checkout forever. It now **skips honestly** (exit 0, loud line) when the serve tree is absent — proven against a nonexistent path.

Post-merge: dispatch `release-heal` (or `Release` with `version: 0.105.0`) and npm catches the train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)