### PR TITLE
fix(release): auto-merge refusal never kills the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,10 @@ jobs:
           gh pr create --head "$branch" \
             --title "chore: bump version to $VERSION" \
             --body "Release-lane bump (auto-merges on green · release.yml)."
-          gh pr merge "$branch" --squash --auto
+          # belt: a repo with auto-merge off must not kill the release —
+          # the PR stays open (loud) and npm still ships from the tree
+          gh pr merge "$branch" --squash --auto \
+            || echo "::warning::auto-merge unavailable — merge the bump PR by hand; the release continues"
 
       # Publish to npm
       - name: Publish to npm


### PR DESCRIPTION
Follow-up to #24, proven by the 0.105 re-run: **fail-closed worked** (nothing published), and the last snag was `enablePullRequestAutoMerge` off at the repo — `gh pr merge --auto` hard-failed after the bump PR existed (#25, since merged by hand). The repo setting is now ON (API PATCH), and this belt makes any future refusal loud-but-nonfatal: the bump PR stays open for a hand merge while npm still ships from the already-bumped tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)