### PR TITLE
chore(release): main catches up with npm — 0.106.0 + 0.106.1 enter the ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.106.1] — 2026-07-28
+
+Lockstep on the engine's v0.106.1 (the browser release — the engine's check
+half now ships as a wasm artifact on every release, headed for npm as
+`@supernovae-st/nika-check-wasm`: a different seat from this SDK — the
+client talks to a serve daemon, the wasm package is the checker in-page).
+No SDK-side changes: a pure same-day version alignment.
+
+## [0.106.0] — 2026-07-28
+
+Lockstep on the engine's 0.106 line (the authority release).
+
+### Changed
+
+- E2E: the live workflow grants the exec it spends.
+- Deps: TypeScript majors held for a deliberate migration ·
+  actions/checkout group bumped.
+
 ## [0.105.0] — 2026-07-20
 
 Lockstep on the engine's 0.105 line. What rode the 0.100 → 0.105 alignments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.105.0",
+  "version": "0.106.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supernovae-st/nika-client",
-      "version": "0.105.0",
+      "version": "0.106.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.105.0",
+  "version": "0.106.1",
   "description": "TypeScript client for Nika — the local driver for the shipped binary today, the nika serve HTTP client at serve-time",
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm is two releases ahead of this tree (0.106.0 published this morning,
0.106.1 tonight — both verified on the registry), and the bot bump-back PRs
(#30, #31) can never land: a PR opened with GITHUB_TOKEN triggers no
workflows, so the required checks never report and their armed auto-merge
waits forever. This PR supersedes both — the version npm already carries, its
lockfile, and the two changelog sections the ledger owes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
