### PR TITLE
fix(e2e): the live leg speaks the nine keys · 0.109.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,12 @@ jobs:
             echo "::warning::type-drift advisory — nika serve is not yet shipped (target-facing SDK). Re-activates automatically when serve lands."
             exit 0
           fi
-          # The fixture speaks the shipped envelope — this exact file passes
-          # `nika check` clean (rc=0) on the released v0.107.0.
+          # The fixture speaks the shipped nine-key envelope — this exact file
+          # passes `nika check` clean (rc=0) on the released v0.109.0
+          # (`nika: <id>` names the file · no `workflow:` block).
           mkdir -p /tmp/wf
           cat > /tmp/wf/test.nika.yaml <<'EOF'
-          nika: v1
-          workflow:
-            id: test
+          nika: test
           tasks:
             hello:
               infer:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             exit 0
           fi
           # The fixture speaks the shipped nine-key envelope — this exact file
-          # passes `nika check` clean (rc=0) on the released v0.109.0
+          # passes `nika check` clean (rc=0) on the released v0.109.1
           # (`nika: <id>` names the file · no `workflow:` block).
           mkdir -p /tmp/wf
           cat > /tmp/wf/test.nika.yaml <<'EOF'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The live leg speaks the nine keys: the e2e workflow, the demo tape's
   staged workflow and the dormant type-drift fixture carry the
-  nine-key envelope of the released 0.109.0 (`nika: <id>` names the
+  nine-key envelope of the released 0.109.1 (`nika: <id>` names the
   file · the `workflow:` block is gone) · every one proven clean by
-  `nika check` on 0.109.0. The negative parse-fatal fixture stays as it
-  was: 0.109.0 refuses it with NIKA-PARSE-005 (unknown field `name`).
-  Package version follows the engine to 0.109.0.
+  `nika check` on 0.109.1. The negative parse-fatal fixture stays as it
+  was: 0.109.1 refuses it with NIKA-PARSE-005 (unknown field `name`).
+  Package version follows the engine to 0.109.1.
 - Voice correction for the 0.107.0 note below: read it as **the SDK
   publishes verified** — the fact stands (npm provenance proves the
   workflow that built the package); the printed section stays as released.
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   freshness probe.
 - CI: the dormant type-drift fixture speaks the shipped envelope
   (proven clean by `nika check` on the released v0.107.0 when written ·
-  re-proven on 0.109.0 in nine-key form, see above) · the day serve
+  re-proven on 0.109.1 in nine-key form, see above) · the day serve
   lands, the gate wakes on a file the engine accepts.
 - Coverage: the serve probe learns the Diamond address — it checks
   `crates/nika-serve` before the pre-refonte `tools/nika-serve`, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The live leg speaks the nine keys: the e2e workflow, the demo tape's
+  staged workflow and the dormant type-drift fixture carry the
+  nine-key envelope of the released 0.109.0 (`nika: <id>` names the
+  file · the `workflow:` block is gone) · every one proven clean by
+  `nika check` on 0.109.0. The negative parse-fatal fixture stays as it
+  was: 0.109.0 refuses it with NIKA-PARSE-005 (unknown field `name`).
+  Package version follows the engine to 0.109.0.
 - Voice correction for the 0.107.0 note below: read it as **the SDK
   publishes verified** — the fact stands (npm provenance proves the
   workflow that built the package); the printed section stays as released.
@@ -16,9 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hero · the engine hero GIF pins to the release tag it demonstrates
   (was floating `main`) · a lockstep section names `nika doctor` as the
   freshness probe.
-- CI: the dormant type-drift fixture speaks the shipped `nika: v1`
-  envelope (proven clean by `nika check` on the released v0.107.0) —
-  the day serve lands, the gate wakes on a file the engine accepts.
+- CI: the dormant type-drift fixture speaks the shipped envelope
+  (proven clean by `nika check` on the released v0.107.0 when written ·
+  re-proven on 0.109.0 in nine-key form, see above) · the day serve
+  lands, the gate wakes on a file the engine accepts.
 - Coverage: the serve probe learns the Diamond address — it checks
   `crates/nika-serve` before the pre-refonte `tools/nika-serve`, so the
   gate wakes without a maintainer flip when serve re-admits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.108.0",
+  "version": "0.109.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supernovae-st/nika-client",
-      "version": "0.108.0",
+      "version": "0.109.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.109.0",
+  "version": "0.109.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supernovae-st/nika-client",
-      "version": "0.109.0",
+      "version": "0.109.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.109.0",
+  "version": "0.109.1",
   "description": "TypeScript client for Nika — the local driver for the shipped binary today, the nika serve HTTP client at serve-time",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.108.0",
+  "version": "0.109.0",
   "description": "TypeScript client for Nika — the local driver for the shipped binary today, the nika serve HTTP client at serve-time",
   "repository": {
     "type": "git",

--- a/scripts/media/render.sh
+++ b/scripts/media/render.sh
@@ -17,9 +17,8 @@ command -v nika >/dev/null || { echo "nika not on PATH" >&2; exit 1; }
 rm -rf /tmp/sdk-demo
 mkdir -p /tmp/sdk-demo
 cat > /tmp/sdk-demo/flow.nika.yaml <<'EOF'
-nika: v1
-workflow:
-  id: brief
+# a two-step launch brief · outline first, then the brief written from it
+nika: brief
 model: mock/echo
 permits: {}
 tasks:

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -684,16 +684,16 @@ describe('workflows.reload()', () => {
 describe('workflows.source()', () => {
   it('returns raw YAML as text', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(textResponse('nika: v1\nworkflow: test'));
+    fetchSpy.mockResolvedValueOnce(textResponse('nika: test\ntasks: {}'));
     const yaml = await client.workflows.source('test.nika.yaml');
-    expect(yaml).toContain('nika: v1');
+    expect(yaml).toContain('nika: test');
     const [url] = fetchSpy.mock.calls[0];
     expect(url).toContain('/v1/workflows/test.nika.yaml/source');
   });
 
   it('encodes workflow name with slashes', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(textResponse('nika: v1'));
+    fetchSpy.mockResolvedValueOnce(textResponse('nika: flow'));
     await client.workflows.source('sub/dir/flow.nika.yaml');
     const url = fetchSpy.mock.calls[0][0] as string;
     expect(url).toContain('sub%2Fdir%2Fflow.nika.yaml');

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -86,7 +86,7 @@ function createMockServer(state: MockState) {
       const name = decodeURIComponent(sourceMatch[1]);
       if (name === 'translate.nika.yaml') {
         res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end('nika: v1\nworkflow:\n  id: translate\n  description: "Translate files"');
+        res.end('# Translate files\nnika: translate\nmodel: mock/echo\ntasks: {}');
         return;
       }
       json(res, { error: `Workflow not found: ${name}` }, 404);
@@ -591,8 +591,8 @@ describe('E2E: nika-client v2 against mock server', () => {
       const client = makeClient();
 
       const yaml = await client.workflows.source('translate.nika.yaml');
-      expect(yaml).toContain('nika: v1');
-      expect(yaml).toContain('  id: translate');
+      expect(yaml).toContain('nika: translate');
+      expect(yaml).toContain('# Translate files');
     });
   });
 

--- a/test/local.e2e.test.ts
+++ b/test/local.e2e.test.ts
@@ -23,9 +23,9 @@ function realNika(): string | null {
 
 const BIN = realNika();
 
-const WF = `nika: v1
-workflow:
-  id: sdk-live
+// The nine-key envelope of the released engine (0.109.0 · `nika: <id>` is
+// the file's name · no `workflow:` block) · `nika check` clean on it.
+const WF = `nika: sdk-live
 model: mock/echo
 permits:
   exec: ["echo"]
@@ -66,6 +66,9 @@ describe.skipIf(!BIN)('LocalNika · live engine (skip-honest)', () => {
 
   it('parse-fatal file → typed result, BOTH engine voices accepted', async () => {
     const bad = path.join(dir, 'bad.nika.yaml');
+    // A NEGATIVE fixture: it must stay parse-fatal. On 0.109.0 the engine
+    // dies on it with NIKA-PARSE-005 (unknown field `name` in the strict
+    // nine-key envelope) — verified against the 0.109 oracle 2026-08-19.
     writeFileSync(bad, 'nika: v1\nname: nope\ntasks: []\n');
     const r = await nika.check(bad);
     expect(r.clean).toBe(false);

--- a/test/local.e2e.test.ts
+++ b/test/local.e2e.test.ts
@@ -23,7 +23,7 @@ function realNika(): string | null {
 
 const BIN = realNika();
 
-// The nine-key envelope of the released engine (0.109.0 · `nika: <id>` is
+// The nine-key envelope of the released engine (0.109.1 · `nika: <id>` is
 // the file's name · no `workflow:` block) · `nika check` clean on it.
 const WF = `nika: sdk-live
 model: mock/echo
@@ -66,7 +66,7 @@ describe.skipIf(!BIN)('LocalNika · live engine (skip-honest)', () => {
 
   it('parse-fatal file → typed result, BOTH engine voices accepted', async () => {
     const bad = path.join(dir, 'bad.nika.yaml');
-    // A NEGATIVE fixture: it must stay parse-fatal. On 0.109.0 the engine
+    // A NEGATIVE fixture: it must stay parse-fatal. On 0.109.1 the engine
     // dies on it with NIKA-PARSE-005 (unknown field `name` in the strict
     // nine-key envelope) — verified against the 0.109 oracle 2026-08-19.
     writeFileSync(bad, 'nika: v1\nname: nope\ntasks: []\n');


### PR DESCRIPTION
Lot L7 SDK of the plan **SURFACES · NUKE LEGACY** (nika 0.109.1 · the nine-key envelope on every teaching surface).

## What changed

- `test/local.e2e.test.ts` · the live workflow `WF` speaks the nine keys (`nika: sdk-live` · no `workflow:` block). The negative parse-fatal fixture at the bottom stays as it was — the 0.109 engine still refuses it (`NIKA-PARSE-005` · unknown field `name`) and its comment now names that code.
- `scripts/media/render.sh` · the demo tape's staged workflow becomes `nika: brief` (a `#` line above it says what the demo does).
- `.github/workflows/ci.yml` · the dormant type-drift fixture becomes `nika: test`; the comment that claimed « clean on the released v0.107.0 » now claims v0.109.1 (proven on the 0.109 build, see below).
- `test/e2e.test.ts` · `test/client.test.ts` · the opaque mock payloads served for `workflows.source()` stop teaching the dead head (`nika: translate` · `nika: test` · `nika: flow`). Beyond the plan's line list · found by the lot-opening grep · pure test strings.
- `package.json` + lockfile · `0.109.1` (the advisory `version-check` job compares against `releases/latest`).
- `CHANGELOG.md` · one Unreleased bullet for the migration · the earlier Unreleased bullet about the type-drift fixture corrected (it still said the fixture speaks the fourteen-key form).

## Proofs (all against a 0.109 build of the engine · a 0.109.0-dev binary carrying the nine-key language the 0.109.1 tag publishes · `NIKA_BIN=<nika 0.109>`)

- before · `npm test` → `1 failed | 111 passed` · the intended red at `test/local.e2e.test.ts:51` (`report.clean` false · the engine refuses `workflow:` with `NIKA-PARSE-005`).
- after · `npm test` → `Test Files 8 passed (8) · Tests 112 passed (112)` (the live leg RUNS · not skipped).
- `npm run build` → green (tsup · DTS build success).
- `nika check` on each migrated workflow (sdk-live · brief · test) → rc=0 (hints only).
- `nika check --json` on the negative fixture → `parse_fatal: true` · `NIKA-PARSE-005` unknown field `name` (so the fixture keeps its job).

## Not done · deliberately

- No merge. On the machine that runs it, `npm test` with an **0.108.0** binary on PATH now fails the live leg (the old binary refuses the nine keys) — that is the intended state until 0.109.1 is the published release. CI's `test` job installs no engine (skip-honest) and stays green either way.
- The README's hero GIF pin (`v0.107.0`) and the lockstep example sentence were left alone: no engine release newer than 0.108.0 is published at the time of writing (the v0.109.0 release run failed before upload · v0.109.1 is in flight), so there is nothing newer to pin to.

## Note for the maintainer

The v0.109.0 release run died at its own pre-upload gate and nothing was published under that number; the engine re-tagged **v0.109.1** (release in flight at the time of writing). The package and every comment naming the released engine say 0.109.1. Until it publishes, `releases/latest` is v0.108.0: the `version-check` job warns, the type-drift job stays advisory. The proofs above ran on a 0.109 build of the engine (the same nine-key language the 0.109.1 tag publishes).
