### PR TITLE
chore: lockstep 0.109.2 · the teaching residue is gone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             exit 0
           fi
           # The fixture speaks the shipped nine-key envelope — this exact file
-          # passes `nika check` clean (rc=0) on the released v0.109.1
+          # passes `nika check` clean (rc=0) on the released v0.109.2
           # (`nika: <id>` names the file · no `workflow:` block).
           mkdir -p /tmp/wf
           cat > /tmp/wf/test.nika.yaml <<'EOF'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The live leg speaks the nine keys: the e2e workflow, the demo tape's
   staged workflow and the dormant type-drift fixture carry the
-  nine-key envelope of the released 0.109.1 (`nika: <id>` names the
+  nine-key envelope of the released 0.109.2 (`nika: <id>` names the
   file · the `workflow:` block is gone) · every one proven clean by
-  `nika check` on 0.109.1. The negative parse-fatal fixture stays as it
-  was: 0.109.1 refuses it with NIKA-PARSE-005 (unknown field `name`).
-  Package version follows the engine to 0.109.1.
+  `nika check` on 0.109.2. The negative parse-fatal fixture stays as it
+  was: 0.109.2 refuses it with NIKA-PARSE-005 (unknown field `name`).
+  Package version follows the published engine to 0.109.2.
+- README: the engine hero GIF and the lockstep sentence pin to the
+  published v0.109.2 tag (was v0.107.0 · #38 left them until a nine-key
+  engine release existed).
 - Voice correction for the 0.107.0 note below: read it as **the SDK
   publishes verified** — the fact stands (npm provenance proves the
   workflow that built the package); the printed section stays as released.
@@ -25,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   freshness probe.
 - CI: the dormant type-drift fixture speaks the shipped envelope
   (proven clean by `nika check` on the released v0.107.0 when written ·
-  re-proven on 0.109.1 in nine-key form, see above) · the day serve
+  re-proven on 0.109.2 in nine-key form, see above) · the day serve
   lands, the gate wakes on a file the engine accepts.
 - Coverage: the serve probe learns the Diamond address — it checks
   `crates/nika-serve` before the pre-refonte `tools/nika-serve`, so the

--- a/README.md
+++ b/README.md
@@ -322,12 +322,12 @@ for await (const event of nika.jobs.stream(jobId, {
 ```
 
 <!-- engine hero pinned to the release tag it demonstrates · re-pin on lockstep bumps -->
-![nika check audits the workflow (plan, permits, cost, secrets, types, the lethal-trifecta gate), then nika run executes it locally and seals the hash-chained trace — the audit-then-run story](https://raw.githubusercontent.com/supernovae-st/nika/v0.107.0/media/nika-hero.gif)
+![nika check audits the workflow (plan, permits, cost, secrets, types, the lethal-trifecta gate), then nika run executes it locally and seals the hash-chained trace — the audit-then-run story](https://raw.githubusercontent.com/supernovae-st/nika/v0.109.2/media/nika-hero.gif)
 
 ## Keeping it fresh · the lockstep
 
 This package versions in lockstep with the engine's release train —
-SDK 0.107.0 speaks about engine 0.107.0, and CI warns on a gap. When
+SDK 0.109.2 speaks about engine 0.109.2, and CI warns on a gap. When
 the binary moves and a seat stays behind, one command names it:
 
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.109.1",
+  "version": "0.109.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supernovae-st/nika-client",
-      "version": "0.109.1",
+      "version": "0.109.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.109.1",
+  "version": "0.109.2",
   "description": "TypeScript client for Nika — the local driver for the shipped binary today, the nika serve HTTP client at serve-time",
   "repository": {
     "type": "git",

--- a/test/local.e2e.test.ts
+++ b/test/local.e2e.test.ts
@@ -23,7 +23,7 @@ function realNika(): string | null {
 
 const BIN = realNika();
 
-// The nine-key envelope of the released engine (0.109.1 · `nika: <id>` is
+// The nine-key envelope of the released engine (0.109.2 · `nika: <id>` is
 // the file's name · no `workflow:` block) · `nika check` clean on it.
 const WF = `nika: sdk-live
 model: mock/echo
@@ -66,7 +66,7 @@ describe.skipIf(!BIN)('LocalNika · live engine (skip-honest)', () => {
 
   it('parse-fatal file → typed result, BOTH engine voices accepted', async () => {
     const bad = path.join(dir, 'bad.nika.yaml');
-    // A NEGATIVE fixture: it must stay parse-fatal. On 0.109.1 the engine
+    // A NEGATIVE fixture: it must stay parse-fatal. On 0.109.2 the engine
     // dies on it with NIKA-PARSE-005 (unknown field `name` in the strict
     // nine-key envelope) — verified against the 0.109 oracle 2026-08-19.
     writeFileSync(bad, 'nika: v1\nname: nope\ntasks: []\n');


### PR DESCRIPTION
## Summary

Lot L7 residue of **SURFACES · NUKE LEGACY** (nika 0.109.2 · the nine-key envelope on every teaching surface).

#38 already migrated the live e2e (`nika: sdk-live`), the demo tape (`nika: brief`), and the dormant type-drift fixture (`nika: test`). A column-0 census on `origin/main` is **zero**. The monorepo checkout still counted `nika: v1` 1 and `workflow:` 2 because its submodule pointer sat at `4e360b7` (pre-#38) — not because those files still taught the dead envelope on the remote.

This PR is the leftover lockstep now that **v0.109.2 is the published engine**:

- `package.json` + lockfile → `0.109.2` (advisory `version-check` job compares against `releases/latest`)
- README hero GIF pin `v0.107.0` → `v0.109.2` (asset 200 on the tag · #38 left it because no nine-key release existed yet)
- README lockstep sentence now reads `SDK 0.109.2 speaks about engine 0.109.2`
- CI + live-e2e comments name the same published tag
- CHANGELOG Unreleased records the pin

The three live workflows and the negative parse-fatal fixture are unchanged from #38.

## Proofs

Against `/private/tmp/nika-oracle-0109/nika` (0.109.0-dev `9f7042827` · same nine-key language the 0.109.2 tag publishes):

- `NIKA_BIN=<oracle> npm test` → `Test Files 8 passed (8) · Tests 112 passed (112)`
- `npm run build` → green (tsup · DTS)
- `nika check` on the three live workflows (sdk-live · brief · test) → rc=0
- `nika check --json` on the negative fixture (`nika: v1` + `name: nope`) → `parse_fatal: true` · `NIKA-PARSE-005` unknown field `name` (so the fixture keeps its job)
- column-0 census on this tree: `nika: v1` 0 · `workflow:` 0 (the only remaining `nika: v1` is the negative fixture, inside a string)

`npm test` without `NIKA_BIN` on a machine whose PATH still has 0.108.0 fails the live leg. That is PATH lag, not this diff. CI's `test` job installs no engine (skip-honest) and stays green either way.

## Not done · deliberately

- No merge.
- The monorepo submodule pointer is out of this repo's scope. After merge, L9 should move `ventures/nika/02-engineering/repos/client-sdk/repo` from `4e360b7` onto this SHA so the language census stops counting a stale checkout.
- No SDK npm publish (release lane stays `workflow_dispatch`).
- No ARM worktree.

