### PR TITLE
fix: leftover teaching speaks the nine-key envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
                 prompt: "say hello"
                 max_tokens: 64
           outputs:
-            greeting: ${{ tasks.hello.output }}
+            greeting: ${{ '${{ tasks.hello.output }}' }}
           EOF
           nika serve --bind 127.0.0.1:3000 --workflows /tmp/wf &
           sleep 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,19 @@ jobs:
           fi
           # The fixture speaks the shipped nine-key envelope — this exact file
           # passes `nika check` clean (rc=0) on the released v0.109.2
-          # (`nika: <id>` names the file · no `workflow:` block).
+          # (`nika: <id>` names the file).
           mkdir -p /tmp/wf
           cat > /tmp/wf/test.nika.yaml <<'EOF'
           nika: test
+          permits: {}
           tasks:
             hello:
               infer:
                 model: mock/fast
                 prompt: "say hello"
                 max_tokens: 64
+          outputs:
+            greeting: ${{ tasks.hello.output }}
           EOF
           nika serve --bind 127.0.0.1:3000 --workflows /tmp/wf &
           sleep 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Leftover teaching: the live-e2e negative fixture no longer writes
+  `nika: v1` or a `tasks:` list. It is a nine-key file (`nika: sdk-bad`)
+  with an unknown `name:` field, still parse-fatal as NIKA-PARSE-005
+  on 0.109.2. Mock serve-source YAML in the HTTP tests, and the dormant
+  type-drift fixture, carry a non-empty `tasks:` map plus `permits:`
+  and `outputs:`. Live comments name `nika: <id>`.
 - The live leg speaks the nine keys: the e2e workflow, the demo tape's
   staged workflow and the dormant type-drift fixture carry the
   nine-key envelope of the released 0.109.2 (`nika: <id>` names the
-  file · the `workflow:` block is gone) · every one proven clean by
-  `nika check` on 0.109.2. The negative parse-fatal fixture stays as it
-  was: 0.109.2 refuses it with NIKA-PARSE-005 (unknown field `name`).
-  Package version follows the published engine to 0.109.2.
+  file) · every one proven clean by `nika check` on 0.109.2. Package
+  version follows the published engine to 0.109.2.
 - README: the engine hero GIF and the lockstep sentence pin to the
   published v0.109.2 tag (was v0.107.0 · #38 left them until a nine-key
   engine release existed).

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -684,7 +684,20 @@ describe('workflows.reload()', () => {
 describe('workflows.source()', () => {
   it('returns raw YAML as text', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(textResponse('nika: test\ntasks: {}'));
+    fetchSpy.mockResolvedValueOnce(
+      textResponse(
+        [
+          'nika: test',
+          'model: mock/echo',
+          'permits: {}',
+          'tasks:',
+          '  hello:',
+          '    infer: { prompt: "hi", max_tokens: 8 }',
+          'outputs:',
+          '  greeting: ${{ tasks.hello.output }}',
+        ].join('\n'),
+      ),
+    );
     const yaml = await client.workflows.source('test.nika.yaml');
     expect(yaml).toContain('nika: test');
     const [url] = fetchSpy.mock.calls[0];

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -86,7 +86,19 @@ function createMockServer(state: MockState) {
       const name = decodeURIComponent(sourceMatch[1]);
       if (name === 'translate.nika.yaml') {
         res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end('# Translate files\nnika: translate\nmodel: mock/echo\ntasks: {}');
+        res.end(
+          [
+            '# Translate files',
+            'nika: translate',
+            'model: mock/echo',
+            'permits: {}',
+            'tasks:',
+            '  greet:',
+            '    infer: { prompt: "say hello", max_tokens: 8 }',
+            'outputs:',
+            '  greeting: ${{ tasks.greet.output }}',
+          ].join('\n'),
+        );
         return;
       }
       json(res, { error: `Workflow not found: ${name}` }, 404);

--- a/test/local.e2e.test.ts
+++ b/test/local.e2e.test.ts
@@ -23,8 +23,8 @@ function realNika(): string | null {
 
 const BIN = realNika();
 
-// The nine-key envelope of the released engine (0.109.2 · `nika: <id>` is
-// the file's name · no `workflow:` block) · `nika check` clean on it.
+// The nine-key envelope of the released engine (0.109.2 · `nika: <id>`
+// names the file) · `nika check` clean on it.
 const WF = `nika: sdk-live
 model: mock/echo
 permits:
@@ -36,6 +36,8 @@ tasks:
     with:
       data: \${{ tasks.fetch.output }}
     infer: { prompt: "sum \${{ with.data }}", max_tokens: 30 }
+outputs:
+  summary: \${{ tasks.think.output }}
 `;
 
 describe.skipIf(!BIN)('LocalNika · live engine (skip-honest)', () => {
@@ -66,10 +68,21 @@ describe.skipIf(!BIN)('LocalNika · live engine (skip-honest)', () => {
 
   it('parse-fatal file → typed result, BOTH engine voices accepted', async () => {
     const bad = path.join(dir, 'bad.nika.yaml');
-    // A NEGATIVE fixture: it must stay parse-fatal. On 0.109.2 the engine
-    // dies on it with NIKA-PARSE-005 (unknown field `name` in the strict
-    // nine-key envelope) — verified against the 0.109 oracle 2026-08-19.
-    writeFileSync(bad, 'nika: v1\nname: nope\ntasks: []\n');
+    // A NEGATIVE fixture: it must stay parse-fatal. Identity is a kebab
+    // id and `tasks:` is a map; the unknown `name:` field is what
+    // 0.109.2 refuses (NIKA-PARSE-005) — `nika check --json` on the
+    // published 0.109.2 (`1da35b685`).
+    writeFileSync(
+      bad,
+      [
+        'nika: sdk-bad',
+        'name: nope',
+        'tasks:',
+        '  hello:',
+        '    infer: { prompt: "x", max_tokens: 8 }',
+        '',
+      ].join('\n'),
+    );
     const r = await nika.check(bad);
     expect(r.clean).toBe(false);
     expect(r.exitCode).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Leftover teaching of the dead envelope on **nika-client**, after #38/#39 already migrated the live workflows onto the nine-key form of 0.109.2.

`nika: v1` as a identity is a valid kebab-id on 0.109.2 (it checks clean). The negative fixture still wrote that mark plus a `tasks:` list, so it never refused the dead dialect — it refused unknown field `name`. Mock serve-source YAML used `tasks: {}` (PARSE-002, empty tasks). Live comments named the retired block.

## Changes

- Negative live-e2e fixture is `nika: sdk-bad` with unknown `name:` and a tasks **map** — still parse-fatal (`NIKA-PARSE-005`) on 0.109.2
- Mock `/source` YAML in the HTTP tests is a complete nine-key snippet
- Dormant type-drift CI fixture declares `permits:` + `outputs:`
- Live comments name `nika: <id>`
- SDK wire types that name `workflow` as a **job field** are unchanged (serve API, not the YAML envelope)

## Proofs

Against brew **nika 0.109.2** (`1da35b685`):

- `nika check` on sdk-live · brief · translate · test · ci-test → rc=0
- `nika check --json` on sdk-bad → `parse_fatal: true` · `NIKA-PARSE-005`
- `npm test` → Test Files 8 passed (8) · Tests 112 passed (112)
- `npm run build` → green

Column-0 census: `nika: v1` remains only in CHANGELOG as the record of this NUKE. No `declassify` / `on_finally` / `fail_workflow` / `depends_on:` / `succeeded` / `` `workflow:` `` teaching.

## Not done · deliberately

- No merge
- No SDK npm publish
- No GIF rewrite
- No ARM worktree
- No rename of published TS APIs (`RunRequest.workflow`, `NikaJob.workflow`, `LocalPlan.workflow`)