### PR TITLE
feat(http): retarget the client to live nika serve routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,15 @@ Vendor-neutral agent entry per the AGENTS.md convention (agents.md).
 
 The TypeScript client SDK for Nika — the open workflow language for AI.
 Its local module drives the released engine (`supernovae-st/nika`, AGPL).
-Its root module types an intended workflow HTTP service that does not ship in
-the reference engine today. The language spec is `supernovae-st/nika-spec`
+Its root module talks to live `nika serve` HTTP (`--bind` + `--workflows` +
+`--token-file`). The language spec is `supernovae-st/nika-spec`
 (Apache-2.0).
 
 ## Editing rules
 
-1. The remote wire types mirror the intended workflow service contract —
+1. The remote wire types mirror live `nika serve` OpenAPI (`openapi.json`) —
    never invent fields; check the owning contract and engine source when in
-   doubt. `nika serve` is the resident cadence firer, not this HTTP service.
+   doubt. Bare `nika serve` is the resident cadence firer; HTTP is the
+   `--bind` door. Cancel and artifacts stay absent.
 2. 4 verbs only: `infer` · `exec` · `invoke` · `agent`.
 3. Commit trailer: `Co-Authored-By: Nika 🦋 <nika@supernovae.studio>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **HTTP client retargets the live `nika serve` door (W09).** Paths are
+  `POST /v1/jobs` (Idempotency-Key required), `GET /v1/jobs/{id}`,
+  `GET /v1/jobs/{id}/status`, `GET /v1/jobs/{id}/events`. Job identity is
+  `{ id, status }` with statuses `queued|running|interrupted|paused|succeeded|failed`.
+  SSE payloads are `{ sequence, kind, status }`. The OpenAPI pin lives at
+  `openapi.json`. Cancel, artifacts, `/v1/run`, workflow source and reload
+  are not claimed — those helpers throw `NikaUnavailableError`. Inputs are
+  refused at submit because the live body is `{ workflow }` only.
 - Leftover teaching: the live-e2e negative fixture no longer writes
   `nika: v1` or a `tasks:` list. It is a nine-key file (`nika: sdk-bad`)
   with an unknown `name:` field, still parse-fatal as NIKA-PARSE-005

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@
 <p align="center"><strong>The TypeScript client for <a href="https://github.com/supernovae-st/nika">Nika</a>, the workflow language for AI.<br>
 One file, 4 verbs, one binary. Typed, zero-dependency, honest about what ships today.</strong></p>
 
-> **Status:** two modules, two horizons. **`@supernovae-st/nika-client/local`
-> works TODAY**: a typed, zero-dependency driver for the shipped binary
-> (`check --json` · `run --json` event stream · the dry-run plan object ·
-> `test` · `trace verify`). The root module targets the **future**
-> workflow HTTP and SSE API. The reference engine does not ship a compatible
-> service today. `nika serve` is the resident cadence firer, not that API.
+> **Status:** two modules. **`@supernovae-st/nika-client/local` works TODAY**:
+> a typed, zero-dependency driver for the shipped binary (`check --json` ·
+> `run --json` event stream · the dry-run plan object · `test` ·
+> `trace verify`). The root module talks to **live `nika serve` HTTP**
+> (`--bind` + `--workflows` + `--token-file`): `POST /v1/jobs`,
+> `GET /v1/jobs/{id}`, `GET /v1/jobs/{id}/events`. Bare `nika serve` remains
+> the resident cadence firer. Cancel and artifacts are **not** on this
+> surface — those helpers throw rather than claim a 404.
 
 Zero keys first — the shipped binary rehearses a canonical workflow
 offline, nothing written, nothing owned (bare `nika try` lists them all):
@@ -66,14 +68,14 @@ exit code. This repo's own CI pins every action by commit SHA and
 checks against the latest released engine tag, never a floating `main`.
 
 - Zero runtime dependencies (uses native `fetch`)
-- Full TypeScript types for the intended workflow HTTP contract
+- Full TypeScript types pinned to live OpenAPI 3.1 (`openapi.json`)
 - Namespace pattern: `nika.jobs.*`, `nika.workflows.*`
 - 6 typed error classes with full hierarchy
 - Automatic retry on 429/5xx with exponential backoff
 - Client-side concurrency limiter (semaphore, default: 24)
 - SSE streaming via `AsyncIterable` with idle timeout + auto-reconnect
-- Binary artifact download (`Uint8Array`) + streaming (`ReadableStream`)
-- Auto-paginating workflow listing
+- Honest refusals for cancel/artifacts (not on the live HTTP surface)
+- Workflow list + metadata (no source bytes over HTTP)
 - AbortSignal support on long-running operations
 - Webhook HMAC-SHA256 verification (async, Web Crypto API)
 - Dual CJS/ESM build
@@ -91,16 +93,13 @@ npm install @supernovae-st/nika-client
 import { Nika } from '@supernovae-st/nika-client';
 
 const nika = new Nika({
-  url: 'http://localhost:3000',
+  url: 'http://127.0.0.1:8787',
   token: process.env.NIKA_TOKEN!,
 });
 
-// Submit + poll until done
-const job = await nika.jobs.run('translate.nika.yaml', {
-  file: 'ui.json',
-  locale: 'fr_FR',
-});
-console.log(job.status); // 'completed'
+// Submit + poll until succeeded. Body is { workflow } only.
+const job = await nika.jobs.run('translate.nika.yaml');
+console.log(job.status); // 'succeeded'
 ```
 
 ## Usage
@@ -108,71 +107,33 @@ console.log(job.status); // 'completed'
 ### Run a workflow and wait for completion
 
 ```typescript
-const job = await nika.jobs.run('pipeline.nika.yaml', { topic: 'AI' });
-console.log(job.status);       // 'completed'
-console.log(job.exit_code);    // 0
-console.log(job.completed_at); // '2026-04-02T10:01:00Z'
+const job = await nika.jobs.run('pipeline.nika.yaml');
+console.log(job.id, job.status); // uuid, 'succeeded'
 ```
 
 ### Stream events in real time (SSE)
 
 ```typescript
-const { job_id } = await nika.jobs.submit('pipeline.nika.yaml', { topic: 'AI' });
+const { id } = await nika.jobs.submit('pipeline.nika.yaml');
 
-for await (const event of nika.jobs.stream(job_id)) {
-  console.log(event.type, event.task_id ?? '', event.duration_ms ?? '');
-  // started
-  // task_start research infer
-  // task_complete research 1200
-  // completed
+for await (const event of nika.jobs.stream(id)) {
+  console.log(event.sequence, event.kind, event.status);
 }
 ```
 
-### Run and collect all artifacts
+### List workflows
 
 ```typescript
-const artifacts = await nika.jobs.runAndCollect('research.nika.yaml', {
-  topic: 'workflow engines',
-});
-
-console.log(artifacts['report.md']);   // markdown string
-console.log(artifacts['data.json']);   // parsed JSON object
-// binary artifacts (audio, images) are skipped
+const names = await nika.workflows.list();
+const meta = await nika.workflows.metadata('pipeline.nika.yaml');
 ```
 
-### Download binary artifacts
+### What is not on the wire yet
 
-```typescript
-const bytes = await nika.jobs.artifactBinary('job-id', 'audio.mp3');
-// bytes is Uint8Array
-```
-
-### Stream large artifacts without loading into memory
-
-```typescript
-import * as fs from 'node:fs';
-
-const stream = await nika.jobs.artifactStream('job-id', 'dataset.csv');
-const writer = fs.createWriteStream('output.csv');
-for await (const chunk of stream) {
-  writer.write(chunk);
-}
-writer.end();
-```
-
-### Paginate workflow listing
-
-```typescript
-// Auto-pagination (default): fetches all pages transparently
-const all = await nika.workflows.list();
-
-// Manual pagination for large lists
-const page1 = await nika.workflows.listPage({ limit: 50 });
-if (page1.has_more) {
-  const last = page1.workflows[page1.workflows.length - 1].name;
-  const page2 = await nika.workflows.listPage({ limit: 50, after: last });
-}
-```
+Cancel and artifacts stay 404 on the server. Those helpers throw
+`NikaUnavailableError` instead of claiming the route. `POST /v1/jobs`
+accepts `{ workflow }` only — inputs live in the workflow file or
+go through `LocalNika`.
 
 ### Cancel a running job with AbortSignal
 
@@ -180,7 +141,7 @@ if (page1.has_more) {
 const controller = new AbortController();
 setTimeout(() => controller.abort(), 60_000);
 
-const job = await nika.jobs.run('slow.nika.yaml', {}, {
+const job = await nika.jobs.run('slow.nika.yaml', undefined, {
   signal: controller.signal,
 });
 ```
@@ -189,7 +150,7 @@ const job = await nika.jobs.run('slow.nika.yaml', {}, {
 
 ```typescript
 const nika = new Nika({
-  url: 'http://localhost:3000',
+  url: 'http://127.0.0.1:8787',
   token: process.env.NIKA_TOKEN!,
   fetch: async (url, init) => {
     console.log(`>> ${init?.method ?? 'GET'} ${url}`);
@@ -220,7 +181,7 @@ const isValid = await Nika.verifyWebhook(
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `url` | `string` | (required) | Compatible workflow service URL (http/https) |
+| `url` | `string` | (required) | `nika serve --bind` URL (http/https) |
 | `token` | `string` | (required) | Bearer token (`NIKA_TOKEN`) |
 | `timeout` | `number` | `30000` | HTTP request timeout in ms |
 | `retries` | `number` | `2` | Retries on 429/5xx |
@@ -237,26 +198,22 @@ const isValid = await Nika.verifyWebhook(
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `submit(workflow, inputs?, opts?)` | `RunResponse` | Submit workflow, return `{ job_id, status }` |
-| `status(jobId)` | `NikaJob` | Get job status |
-| `cancel(jobId)` | `CancelResponse` | Cancel a running job |
-| `run(workflow, inputs?, opts?)` | `NikaJob` | Submit + poll until terminal state |
-| `stream(jobId, opts?)` | `AsyncIterable<NikaEvent>` | SSE event stream |
-| `artifacts(jobId)` | `NikaArtifact[]` | List job artifacts |
-| `artifact(jobId, name)` | `string` | Download artifact as text |
-| `artifactJson<T>(jobId, name)` | `T` | Download artifact as parsed JSON |
-| `artifactBinary(jobId, name)` | `Uint8Array` | Download artifact as raw bytes |
-| `artifactStream(jobId, name)` | `ReadableStream<Uint8Array>` | Stream artifact (for large files) |
-| `runAndCollect(workflow, inputs?, opts?)` | `Record<string, unknown>` | Run + collect all non-binary artifacts |
+| `submit(workflow, inputs?, opts?)` | `NikaJob` | `POST /v1/jobs` `{ workflow }` + Idempotency-Key. `inputs` throws. |
+| `status(jobId)` | `NikaJob` | `GET /v1/jobs/{id}` |
+| `statusOnly(jobId)` | `JobStatusOnly` | `GET /v1/jobs/{id}/status` |
+| `cancel(jobId)` | never | throws `NikaUnavailableError` (no live route) |
+| `run(workflow, inputs?, opts?)` | `NikaJob` | submit + poll until succeeded/failed/interrupted |
+| `stream(jobId, opts?)` | `AsyncIterable<NikaEvent>` | `GET /v1/jobs/{id}/events` |
+| `artifacts` / `artifact*` / `runAndCollect` | never | throws `NikaUnavailableError` (no live route) |
 
 ### Workflows: `nika.workflows.*`
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `list()` | `WorkflowInfo[]` | List all workflows (auto-paginates) |
-| `listPage(opts?)` | `ListWorkflowsResponse` | List single page (manual pagination) |
-| `reload()` | `WorkflowInfo[]` | Rescan workflows directory |
-| `source(name)` | `string` | Get raw YAML source |
+| `list()` | `string[]` | Contained `.nika.yaml` names |
+| `listPage()` | `ListWorkflowsResponse` | Same payload (no pagination on the live server) |
+| `metadata(name)` | `WorkflowMetadata` | Name only, no source bytes |
+| `reload()` / `source(name)` | never | throws `NikaUnavailableError` |
 
 ### System
 
@@ -271,11 +228,12 @@ All SDK errors extend `NikaError`. Catch it to handle any SDK error:
 
 ```
 NikaError (base)
-├── NikaAPIError        : HTTP errors (status, body, requestId)
-├── NikaConnectionError : Network errors (DNS, TCP, abort)
-├── NikaTimeoutError    : Request or poll timeout
-└── NikaJobError        : Job failed (exitCode, job object)
-    └── NikaJobCancelledError : Job was cancelled
+├── NikaAPIError          : HTTP errors (status, body, requestId)
+├── NikaConnectionError   : Network errors (DNS, TCP, abort)
+├── NikaTimeoutError      : Request or poll timeout
+├── NikaUnavailableError  : helper for a route the live server keeps 404
+└── NikaJobError          : Job failed or interrupted
+    └── NikaJobCancelledError : exported; live HTTP never throws it
 ```
 
 ```typescript
@@ -285,7 +243,7 @@ try {
   await nika.jobs.run('pipeline.nika.yaml');
 } catch (err) {
   if (err instanceof NikaJobError) {
-    console.error('Job failed:', err.job.output, 'exit:', err.exitCode);
+    console.error('Job failed:', err.job.id, err.job.status);
   } else if (err instanceof NikaAPIError) {
     console.error('HTTP error:', err.status, err.body);
   } else if (err instanceof NikaError) {
@@ -294,22 +252,13 @@ try {
 }
 ```
 
-## SSE event types
+## SSE events
 
-| Type | Fields | Terminal |
-|------|--------|----------|
-| `started` | `job_id` | No |
-| `task_start` | `job_id, task_id, verb` | No |
-| `task_complete` | `job_id, task_id, duration_ms` | No |
-| `task_failed` | `job_id, task_id, error, duration_ms` | No |
-| `artifact_written` | `job_id, task_id, path, size` | No |
-| `completed` | `job_id, output?` | Yes |
-| `failed` | `job_id, error?` | Yes |
-| `cancelled` | `job_id` | Yes |
+Each frame is `{ sequence, kind, status }`. Terminal when `status` is
+`succeeded`, `failed`, or `interrupted`. `paused` keeps the stream open.
 
-Terminal events close the SSE stream automatically.
-
-The SDK auto-reconnects on stream drops (up to 3 attempts), using the `Last-Event-Id` header to resume without losing events. Configure via `StreamOptions`:
+The SDK auto-reconnects on stream drops (up to 3 attempts), using the
+`Last-Event-ID` header to resume. Configure via `StreamOptions`:
 
 ```typescript
 for await (const event of nika.jobs.stream(jobId, {

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,221 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "nika serve",
+    "version": "0.113.0",
+    "description": "Authenticated loopback remote execution. Cancel and artifacts are absent."
+  },
+  "servers": [
+    {
+      "url": "http://127.0.0.1"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Exactly one Authorization: Bearer value from the token file"
+      }
+    },
+    "parameters": {
+      "IdempotencyKey": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      },
+      "LastEventId": {
+        "name": "Last-Event-ID",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)$"
+        }
+      }
+    },
+    "schemas": {
+      "JobStatus": {
+        "type": "string",
+        "enum": ["queued", "running", "interrupted", "paused", "succeeded", "failed"]
+      },
+      "Job": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "status"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "status": { "$ref": "#/components/schemas/JobStatus" }
+        }
+      },
+      "JobStatusOnly": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["status"],
+        "properties": {
+          "status": { "$ref": "#/components/schemas/JobStatus" }
+        }
+      },
+      "CreateJob": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["workflow"],
+        "properties": {
+          "workflow": { "type": "string" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["code", "message"],
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "security": [],
+        "summary": "Public process liveness",
+        "responses": {
+          "200": { "description": "Engine identity only" }
+        }
+      }
+    },
+    "/v1/openapi.json": {
+      "get": {
+        "summary": "This document",
+        "responses": {
+          "200": { "description": "OpenAPI 3.1" },
+          "401": { "description": "Bearer required" }
+        }
+      }
+    },
+    "/v1/workflows": {
+      "get": {
+        "summary": "Contained workflow names",
+        "responses": {
+          "200": { "description": "Relative .nika.yaml names" },
+          "401": { "description": "Error envelope" }
+        }
+      }
+    },
+    "/v1/workflows/{name}": {
+      "get": {
+        "summary": "Workflow metadata without source bytes",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Contained name" },
+          "401": { "description": "Error envelope" },
+          "404": { "description": "Error envelope" }
+        }
+      }
+    },
+    "/v1/jobs": {
+      "post": {
+        "summary": "Admit a job",
+        "parameters": [
+          { "$ref": "#/components/parameters/IdempotencyKey" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateJob" }
+            }
+          }
+        },
+        "responses": {
+          "202": { "description": "Created" },
+          "200": { "description": "Idempotent replay" },
+          "401": { "description": "Error envelope" }
+        }
+      }
+    },
+    "/v1/jobs/{id}": {
+      "get": {
+        "summary": "Job identity and status",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Job" },
+          "401": { "description": "Error envelope" },
+          "404": { "description": "Error envelope" }
+        }
+      }
+    },
+    "/v1/jobs/{id}/status": {
+      "get": {
+        "summary": "Status only",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Status" },
+          "401": { "description": "Error envelope" },
+          "404": { "description": "Error envelope" }
+        }
+      }
+    },
+    "/v1/jobs/{id}/events": {
+      "get": {
+        "summary": "Job event SSE",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          { "$ref": "#/components/parameters/LastEventId" }
+        ],
+        "responses": {
+          "200": {
+            "description": "text/event-stream; data is {sequence,kind,status}"
+          },
+          "400": { "description": "Error envelope" },
+          "401": { "description": "Error envelope" },
+          "404": { "description": "Error envelope" }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supernovae-st/nika-client",
   "version": "0.112.0",
-  "description": "TypeScript client for Nika — a live local driver plus the preview workflow HTTP client",
+  "description": "TypeScript client for Nika — a live local driver plus the nika serve HTTP client",
   "repository": {
     "type": "git",
     "url": "https://github.com/supernovae-st/nika-client.git"

--- a/scripts/check-sdk-coverage.js
+++ b/scripts/check-sdk-coverage.js
@@ -2,276 +2,117 @@
 /**
  * SDK Coverage Checker
  *
- * Verifies that the TypeScript SDK covers all nika-serve endpoints.
- * Run from nika-client root: node scripts/check-sdk-coverage.js [path-to-nika]
+ * The live contract is the pinned OpenAPI at repo-root openapi.json
+ * (W09.B). SDK helpers must call every live path and must not call
+ * absent ones (cancel, artifacts, /v1/run).
  *
- * Exit 0 = all covered. Exit 1 = drift detected.
+ * Exit 0 = covered. Exit 1 = drift.
  */
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 
-// ── Config ──────────────────────────────────────────────────
-
-const NIKA_ROOT = process.argv[2] || resolve('..', 'nika');
 const SDK_ROOT = resolve(import.meta.dirname, '..');
+const SPEC = join(SDK_ROOT, 'openapi.json');
+const SDK_FILES = [
+  join(SDK_ROOT, 'src/resources/jobs.ts'),
+  join(SDK_ROOT, 'src/resources/workflows.ts'),
+  join(SDK_ROOT, 'src/index.ts'),
+  join(SDK_ROOT, 'src/lib/api-client.ts'),
+  join(SDK_ROOT, 'src/lib/streaming.ts'),
+];
 
-// `nika serve` left the tree in the Diamond refonte and re-admits during
-// the 0.9x arc (docs reference/cli) — on a modern checkout the serve tree
-// is absent and coverage has NOTHING to judge. Skip honestly (exit 0,
-// loud) instead of failing every release forever. Probe the Diamond home
-// (`crates/`) first — the pre-refonte `tools/` address kept last so the
-// day serve re-admits, coverage wakes without a maintainer flip.
-const SERVE_HOMES = ['crates/nika-serve', 'tools/nika-serve'];
-const SERVE_SRC = SERVE_HOMES.map((home) => join(NIKA_ROOT, home, 'src')).find(
-  (src) => existsSync(join(src, 'routes/mod.rs')),
-);
+const ABSENT = [
+  '/v1/run',
+  '/v1/status',
+  '/v1/cancel',
+  '/v1/events',
+  '/v1/reload',
+  '/v1/jobs/:param/cancel',
+  '/v1/jobs/:param/artifacts',
+];
 
-if (!SERVE_SRC) {
-  console.log(
-    `nika-serve not present at ${NIKA_ROOT} (probed ${SERVE_HOMES.join(' · ')} — re-admits in the 0.9x arc) — coverage SKIPPED`,
-  );
-  process.exit(0);
+function livePaths() {
+  const spec = JSON.parse(readFileSync(SPEC, 'utf-8'));
+  return Object.keys(spec.paths || {});
 }
 
-const SERVE_ROUTES = join(SERVE_SRC, 'routes/mod.rs');
-const SERVE_EVENTS = join(SERVE_SRC, 'events.rs');
-const SERVE_WORKFLOWS = join(SERVE_SRC, 'routes/workflows.rs');
-const SERVE_ARTIFACTS = join(SERVE_SRC, 'routes/artifacts.rs');
-
-const SDK_JOBS = join(SDK_ROOT, 'src/resources/jobs.ts');
-const SDK_WORKFLOWS_FILE = join(SDK_ROOT, 'src/resources/workflows.ts');
-const SDK_INDEX = join(SDK_ROOT, 'src/index.ts');
-const SDK_TYPES = join(SDK_ROOT, 'src/types.ts');
-const SDK_API_CLIENT = join(SDK_ROOT, 'src/lib/api-client.ts');
-const SDK_STREAMING = join(SDK_ROOT, 'src/lib/streaming.ts');
-
-// ── Extract routes from Rust ────────────────────────────────
-
-function extractRustRoutes(routesFile) {
-  const src = readFileSync(routesFile, 'utf-8');
-  const routes = [];
-
-  // Match both .route() and .api_route() with get/post/get_with/post_with
-  const routeRegex = /\.(?:api_)?route\(\s*"([^"]+)"\s*,\s*(get|post|put|delete|patch)(?:_with)?\s*\(/g;
-  let match;
-  while ((match = routeRegex.exec(src)) !== null) {
-    routes.push({ method: match[2].toUpperCase(), path: match[1] });
-  }
-
-  return routes;
-}
-
-// ── Extract SSE event types from Rust ───────────────────────
-
-function extractRustEvents(eventsFile) {
-  const src = readFileSync(eventsFile, 'utf-8');
-  const events = [];
-
-  // Match explicit serde renames: #[serde(rename = "event_name")]
-  const renameRegex = /#\[serde\(rename\s*=\s*"(\w+)"\)\]/g;
-  let match;
-  while ((match = renameRegex.exec(src)) !== null) {
-    events.push(match[1]);
-  }
-
-  return events;
-}
-
-// ── Extract response types from Rust ────────────────────────
-
-function extractRustTypes(files) {
-  const types = [];
-
-  for (const file of files) {
-    if (!existsSync(file)) continue;
-    const src = readFileSync(file, 'utf-8');
-
-    const structRegex = /pub\s+struct\s+(\w+)\s*\{/g;
-    let match;
-    while ((match = structRegex.exec(src)) !== null) {
-      types.push(match[1]);
-    }
-  }
-
-  return types;
-}
-
-// ── Extract SDK coverage ────────────────────────────────────
-
-function extractSdkEndpoints(files) {
+function extractSdkEndpoints() {
   const endpoints = [];
-
-  for (const file of files) {
+  for (const file of SDK_FILES) {
     if (!existsSync(file)) continue;
     const src = readFileSync(file, 'utf-8');
-
-    // Match API calls with string/template literal paths:
-    // this.api.json('/v1/run', ...) or client.connectSSE(`/v1/events/${jobId}`)
     const apiCallRegex = /(?:this\.api|client)\.\w+(?:<[^>]+>)?\(\s*[`'"]([^`'"]*)[`'"]/g;
     let match;
     while ((match = apiCallRegex.exec(src)) !== null) {
-      // Clean template expressions: `/v1/events/${jobId}` → `/v1/events/:param`
       const cleaned = match[1].replace(/\$\{[^}]+\}/g, ':param');
-      if (cleaned.startsWith('/')) {
-        endpoints.push(cleaned);
-      }
+      if (cleaned.startsWith('/')) endpoints.push(cleaned.split('?')[0]);
     }
-
-    if (src.includes('fetchHealth')) {
-      endpoints.push('/health');
-    }
+    if (src.includes('fetchHealth')) endpoints.push('/health');
   }
-
-  return endpoints;
+  return [...new Set(endpoints)];
 }
 
-function extractSdkEventTypes(typesFile) {
-  const src = readFileSync(typesFile, 'utf-8');
-  const events = [];
-
-  const eventRegex = /type:\s*'(\w+)'/g;
-  let match;
-  while ((match = eventRegex.exec(src)) !== null) {
-    events.push(match[1]);
-  }
-
-  return events;
+function normalize(path) {
+  return path
+    .replace(/\{[^}]+\}/g, ':param')
+    .replace(/:param/g, ':param');
 }
 
-function extractSdkTypes(typesFile) {
-  const src = readFileSync(typesFile, 'utf-8');
-  const types = [];
-
-  const typeRegex = /export\s+(?:interface|type)\s+(\w+)/g;
-  let match;
-  while ((match = typeRegex.exec(src)) !== null) {
-    types.push(match[1]);
-  }
-
-  return types;
+if (!existsSync(SPEC)) {
+  console.error(`missing pin: ${SPEC}`);
+  process.exit(1);
 }
 
-// ── Normalize route path for comparison ─────────────────────
+const live = livePaths().map(normalize);
+const sdk = extractSdkEndpoints();
+const sdkNorm = sdk.map(normalize);
 
-function normalizePath(path) {
-  return path.replace(/\{[^}]+\}/g, ':param');
-}
+let failed = false;
 
-function routeKey(method, path) {
-  return `${method} ${normalizePath(path)}`;
-}
-
-// ── Main ────────────────────────────────────────────────────
-
-function main() {
-  console.log('SDK Coverage Check');
-  console.log('==================\n');
-
-  if (!existsSync(SERVE_ROUTES)) {
-    console.error(`ERROR: nika-serve not found at ${NIKA_ROOT}`);
-    console.error(`Usage: node scripts/check-sdk-coverage.js [path-to-nika]`);
-    process.exit(1);
-  }
-
-  let hasIssues = false;
-
-  // ── 1. Route coverage ──────────────────────────────────
-
-  console.log('1. Route Coverage\n');
-
-  const rustRoutes = extractRustRoutes(SERVE_ROUTES);
-  const sdkEndpoints = extractSdkEndpoints([SDK_JOBS, SDK_WORKFLOWS_FILE, SDK_INDEX, SDK_API_CLIENT, SDK_STREAMING]);
-
-  const SKIP_ROUTES = new Set([
-    'GET /metrics',
-    'GET /v1/openapi.json',
-  ]);
-
-  for (const route of rustRoutes) {
-    const key = routeKey(route.method, route.path);
-    const normalized = normalizePath(route.path);
-
-    if (SKIP_ROUTES.has(key)) {
-      console.log(`  SKIP  ${key} (intentionally excluded)`);
+console.log('Live OpenAPI paths:');
+for (const path of live) {
+  const covered = sdkNorm.some(
+    (s) => s === path || s.startsWith(`${path}/`) || path.startsWith(`${s}/`),
+  );
+  // /v1/jobs/{id}/status is extra to /v1/jobs/{id}
+  const hit = sdkNorm.includes(path)
+    || (path === '/v1/jobs/:param' && sdkNorm.includes('/v1/jobs/:param'))
+    || (path === '/v1/jobs/:param/status' && sdkNorm.includes('/v1/jobs/:param/status'))
+    || (path === '/v1/jobs/:param/events' && sdkNorm.includes('/v1/jobs/:param/events'))
+    || (path === '/v1/workflows/:param' && sdkNorm.includes('/v1/workflows/:param'))
+    || (path === '/v1/openapi.json' && sdkNorm.includes('/v1/openapi.json'))
+    || (path === '/v1/jobs' && sdkNorm.includes('/v1/jobs'))
+    || (path === '/v1/workflows' && sdkNorm.includes('/v1/workflows'))
+    || (path === '/health' && sdkNorm.includes('/health'));
+  if (!hit) {
+    // openapi.json is fetched by generate-types, not the runtime client
+    if (path === '/v1/openapi.json') {
+      console.log(`  skip runtime  ${path} (pin/generate only)`);
       continue;
     }
-
-    const covered = sdkEndpoints.some(ep => {
-      const epNorm = ep.replace(/\$\{[^}]+\}/g, ':param');
-      return normalizePath(epNorm) === normalized;
-    });
-
-    if (covered) {
-      console.log(`  OK    ${key}`);
-    } else {
-      console.log(`  MISS  ${key} ← NOT in SDK!`);
-      hasIssues = true;
-    }
-  }
-
-  // ── 2. SSE Event coverage ──────────────────────────────
-
-  console.log('\n2. SSE Event Types\n');
-
-  const rustEvents = extractRustEvents(SERVE_EVENTS);
-  const sdkEvents = new Set(extractSdkEventTypes(SDK_TYPES));
-
-  for (const event of rustEvents) {
-    if (sdkEvents.has(event)) {
-      console.log(`  OK    ${event}`);
-    } else {
-      console.log(`  MISS  ${event} ← NOT in SDK types!`);
-      hasIssues = true;
-    }
-  }
-
-  for (const event of sdkEvents) {
-    if (!rustEvents.includes(event)) {
-      console.log(`  STALE ${event} ← in SDK but NOT in Rust`);
-      hasIssues = true;
-    }
-  }
-
-  // ── 3. Response type coverage ──────────────────────────
-
-  console.log('\n3. Response Types\n');
-
-  const rustTypes = extractRustTypes([SERVE_WORKFLOWS, SERVE_ARTIFACTS]);
-  const sdkTypes = new Set(extractSdkTypes(SDK_TYPES));
-
-  const TYPE_MAP = {
-    'RunRequest': 'RunRequest',
-    'RunResponse': 'RunResponse',
-    'StatusResponse': 'NikaJob',
-    'WorkflowInfo': 'WorkflowInfo',
-    'ListWorkflowsResponse': 'ListWorkflowsResponse',
-  };
-
-  for (const rustType of rustTypes) {
-    const sdkName = TYPE_MAP[rustType];
-    if (!sdkName) {
-      console.log(`  SKIP  ${rustType} (no SDK mapping defined)`);
-      continue;
-    }
-    if (sdkTypes.has(sdkName)) {
-      console.log(`  OK    ${rustType} → ${sdkName}`);
-    } else {
-      console.log(`  MISS  ${rustType} → ${sdkName} ← NOT in SDK types!`);
-      hasIssues = true;
-    }
-  }
-
-  // ── Summary ────────────────────────────────────────────
-
-  console.log('\n==================');
-  if (hasIssues) {
-    console.log('FAIL: SDK drift detected. Update the SDK to match nika-serve.');
-    process.exit(1);
+    console.log(`  MISSING  ${path}`);
+    failed = true;
   } else {
-    console.log('PASS: SDK covers all nika-serve endpoints and types.');
-    process.exit(0);
+    console.log(`  ok       ${path}`);
   }
 }
 
-main();
+console.log('\nSDK must not claim absent routes:');
+for (const path of ABSENT) {
+  const claimed = sdkNorm.some((s) => s === path || s.startsWith(`${path}/`));
+  if (claimed) {
+    console.log(`  CLAIMED  ${path}`);
+    failed = true;
+  } else {
+    console.log(`  absent   ${path}`);
+  }
+}
+
+console.log('\nSDK endpoints:', sdkNorm.join(', ') || '(none)');
+
+if (failed) {
+  console.error('\ncoverage DRIFT');
+  process.exit(1);
+}
+console.log('\ncoverage OK');

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -3,8 +3,8 @@
  * Generate TypeScript types from nika serve OpenAPI spec.
  *
  * Usage:
- *   node scripts/generate-types.js                          # from running server (localhost:3000)
- *   node scripts/generate-types.js http://vps:3000          # from remote server
+ *   node scripts/generate-types.js                          # from ./openapi.json
+ *   node scripts/generate-types.js http://127.0.0.1:8787    # from a live server
  *   node scripts/generate-types.js ./openapi.json           # from local file
  *
  * Requires NIKA_TOKEN env var when fetching from a server.
@@ -19,7 +19,7 @@ const SDK_ROOT = resolve(import.meta.dirname, '..');
 const OUTPUT_DIR = join(SDK_ROOT, 'src', 'generated');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'openapi.d.ts');
 
-const source = process.argv[2] || 'http://localhost:3000';
+const source = process.argv[2] || join(SDK_ROOT, 'openapi.json');
 
 async function main() {
   let specPath;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,7 +8,7 @@ export class NikaError extends Error {
   }
 }
 
-/** HTTP error from the compatible workflow service (non-2xx response). */
+/** HTTP error from nika serve (non-2xx response). */
 export class NikaAPIError extends NikaError {
   public readonly status: number;
   public readonly body: string;
@@ -42,23 +42,40 @@ export class NikaTimeoutError extends NikaError {
   }
 }
 
-/** Job terminated with status 'failed'. */
+/** Job terminated with status 'failed' or 'interrupted'. */
 export class NikaJobError extends NikaError {
   public readonly job: NikaJob;
   public readonly exitCode: number | undefined;
 
   constructor(job: NikaJob) {
-    super(`Job ${job.job_id} ${job.status}: ${job.output ?? 'unknown error'}`);
+    super(`Job ${job.id} ${job.status}`);
     this.name = 'NikaJobError';
     this.job = job;
-    this.exitCode = job.exit_code;
+    this.exitCode = undefined;
   }
 }
 
-/** Job was cancelled. Extends NikaJobError — catch NikaJobError to get both. */
+/**
+ * Kept for the exported hierarchy. Live HTTP has no cancel route and no
+ * `cancelled` status — poll never throws this.
+ */
 export class NikaJobCancelledError extends NikaJobError {
   constructor(job: NikaJob) {
     super(job);
     this.name = 'NikaJobCancelledError';
+  }
+}
+
+/** A helper that would hit a route the live server keeps 404. */
+export class NikaUnavailableError extends NikaError {
+  public readonly surface: string;
+
+  constructor(surface: string) {
+    super(
+      `${surface} is not on the live nika serve HTTP surface. `
+      + 'Cancel and artifacts stay 404 until those authorities exist.',
+    );
+    this.name = 'NikaUnavailableError';
+    this.surface = surface;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import { Workflows } from './resources/workflows.js';
 import { verifyWebhookSignature } from './webhook.js';
 
 export class Nika {
-  /** Job operations: submit, status, cancel, run, stream, artifacts. */
+  /** Job operations: submit, status, run, stream. Cancel/artifacts throw. */
   readonly jobs: Jobs;
-  /** Workflow operations: list, reload. */
+  /** Workflow operations: list, metadata. Reload/source throw. */
   readonly workflows: Workflows;
 
   private readonly api: ApiClient;
@@ -25,7 +25,7 @@ export class Nika {
     if (!url) {
       throw new TypeError(
         'NIKA_URL environment variable is not set. '
-        + 'Set it or pass url explicitly: new Nika({ url: "http://localhost:3000", token: "..." })',
+        + 'Set it or pass url explicitly: new Nika({ url: "http://127.0.0.1:8787", token: "..." })',
       );
     }
     if (!token) {
@@ -41,7 +41,7 @@ export class Nika {
     if (!config.url) {
       throw new TypeError(
         'NikaConfig.url is required — pass a compatible workflow service URL.\n'
-        + '  Example: new Nika({ url: "http://localhost:3000", token: "..." })\n'
+        + '  Example: new Nika({ url: "http://127.0.0.1:8787", token: "..." })\n'
         + '  Or use:  Nika.fromEnv() to read NIKA_URL and NIKA_TOKEN from environment',
       );
     }
@@ -105,7 +105,6 @@ export class Nika {
 
 export { Jobs } from './resources/jobs.js';
 export { Workflows } from './resources/workflows.js';
-export type { ListPageOptions } from './resources/workflows.js';
 export { verifyWebhookSignature } from './webhook.js';
 
 export {
@@ -115,6 +114,7 @@ export {
   NikaTimeoutError,
   NikaJobError,
   NikaJobCancelledError,
+  NikaUnavailableError,
 } from './errors.js';
 
 export type {
@@ -126,12 +126,13 @@ export type {
   NikaEventType,
   NikaHealth,
   JobStatus,
-  RunRequest,
+  JobStatusOnly,
+  CreateJobRequest,
   RunResponse,
   RunOptions,
   CancelResponse,
   ArtifactsResponse,
-  WorkflowInfo,
+  WorkflowMetadata,
   ListWorkflowsResponse,
   StreamOptions,
   PollOptions,

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -1,5 +1,7 @@
 import type { NikaJob, PollOptions } from '../types.js';
-import { NikaTimeoutError, NikaJobError, NikaJobCancelledError, NikaConnectionError } from '../errors.js';
+import { NikaTimeoutError, NikaJobError, NikaConnectionError } from '../errors.js';
+
+const TERMINAL_FAIL = new Set(['failed', 'interrupted']);
 
 export async function pollUntilDone(
   fetchStatus: () => Promise<NikaJob>,
@@ -9,24 +11,21 @@ export async function pollUntilDone(
   let delay = opts.interval;
 
   while (true) {
-    // Check caller abort
     if (opts.signal?.aborted) {
       throw new NikaConnectionError('Poll aborted by caller');
     }
 
     const job = await fetchStatus();
 
-    if (job.status === 'completed') return job;
-    if (job.status === 'failed') throw new NikaJobError(job);
-    if (job.status === 'cancelled') throw new NikaJobCancelledError(job);
+    if (job.status === 'succeeded') return job;
+    if (TERMINAL_FAIL.has(job.status)) throw new NikaJobError(job);
 
-    // Check deadline BEFORE sleeping — prevents overshoot
     if (Date.now() + delay > deadline) {
-      throw new NikaTimeoutError(`Job ${job.job_id} timed out after ${opts.timeout}ms`);
+      throw new NikaTimeoutError(`Job ${job.id} timed out after ${opts.timeout}ms`);
     }
 
     await sleep(delay, opts.signal);
-    delay = Math.min(delay * opts.backoff, 10_000); // cap at 10s
+    delay = Math.min(delay * opts.backoff, 10_000);
   }
 }
 

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -2,22 +2,23 @@ import type { NikaEvent, StreamOptions } from '../types.js';
 import { NikaConnectionError, NikaError, NikaTimeoutError } from '../errors.js';
 import type { ApiClient } from './api-client.js';
 
-const DEFAULT_IDLE_TIMEOUT = 60_000; // 60s without any event = dead connection
+const DEFAULT_IDLE_TIMEOUT = 60_000;
+
+const TERMINAL_STATUS = new Set(['succeeded', 'failed', 'interrupted']);
+
+function isTerminal(event: NikaEvent): boolean {
+  return typeof event.status === 'string' && TERMINAL_STATUS.has(event.status);
+}
 
 /**
- * Parse a compatible workflow service SSE stream into typed events.
+ * Parse nika serve SSE (`GET /v1/jobs/{id}/events`) into typed events.
  *
- * The intended service emits SSE in the format:
- *   event: <type>
- *   id: <incrementing_number>
- *   data: <json>
- *   \n
+ * Wire format:
+ *   id: <sequence>
+ *   data: {"sequence":N,"kind":"...","status":"..."}
  *
- * Terminal events (completed, failed, cancelled) end the generator.
- * An idle timeout detects dead connections (server died without closing TCP).
- *
- * Auto-reconnects on stream drop (up to maxReconnects), using
- * Last-Event-Id header to resume from where it left off.
+ * Terminal when status is succeeded | failed | interrupted.
+ * Last-Event-ID resumes from the last sequence.
  */
 export async function* streamEvents(
   client: ApiClient,
@@ -32,35 +33,23 @@ export async function* streamEvents(
   while (true) {
     try {
       const extraHeaders: Record<string, string> = {};
-      if (lastEventId) extraHeaders['Last-Event-Id'] = lastEventId;
+      if (lastEventId) extraHeaders['Last-Event-ID'] = lastEventId;
 
       yield* streamOnce(client, jobId, options, extraHeaders, (id) => {
         lastEventId = id;
       });
-
-      // If streamOnce returns normally, a terminal event was received — done
       return;
     } catch (err) {
-      // Don't reconnect on user abort
       if (options?.signal?.aborted) throw err;
-
-      // Don't reconnect on non-retryable errors (4xx, timeout by choice)
       if (err instanceof NikaTimeoutError) throw err;
       if (err instanceof NikaError && !(err instanceof NikaConnectionError)) throw err;
-
-      // NikaConnectionError = stream dropped without terminal event
       if (reconnects >= maxReconnects) throw err;
       reconnects++;
       await sleep(reconnectDelay * reconnects, options?.signal);
-      continue; // retry with Last-Event-Id
     }
   }
 }
 
-/**
- * Single SSE connection attempt. Yields events, tracks last event ID.
- * Returns normally on terminal event. Throws on unexpected disconnect.
- */
 async function* streamOnce(
   client: ApiClient,
   jobId: string,
@@ -71,7 +60,7 @@ async function* streamOnce(
   const idleTimeout = options?.idleTimeout ?? DEFAULT_IDLE_TIMEOUT;
 
   const res = await client.connectSSE(
-    `/v1/events/${jobId}`,
+    `/v1/jobs/${jobId}/events`,
     options?.signal,
     extraHeaders,
   );
@@ -86,7 +75,6 @@ async function* streamOnce(
   let receivedTerminal = false;
   let timedOut = false;
 
-  // Idle timeout: reset on every chunk received
   let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
   function resetIdleTimer() {
@@ -111,7 +99,7 @@ async function* streamOnce(
         }
         if (!receivedTerminal) {
           throw new NikaConnectionError(
-            'SSE stream closed without terminal event (completed/failed/cancelled)',
+            'SSE stream closed without terminal event (succeeded/failed/interrupted)',
           );
         }
         break;
@@ -120,9 +108,8 @@ async function* streamOnce(
       resetIdleTimer();
       buffer += decoder.decode(value, { stream: true });
 
-      // SSE blocks are separated by double newlines
       const parts = buffer.split('\n\n');
-      buffer = parts.pop()!; // keep incomplete chunk
+      buffer = parts.pop()!;
 
       for (const part of parts) {
         const lines = part.split('\n');
@@ -130,21 +117,13 @@ async function* streamOnce(
         let eventId: string | undefined;
 
         for (const line of lines) {
-          // Handle both "data: value" and "data:value" (SSE spec). Multiple
-          // data: lines in ONE event are JOINED with '\n' per the spec — the
-          // previous code kept only the last line, silently dropping the head
-          // of any multi-line payload. The fixtures emit single-line JSON, but
-          // a spec-compliant producer (or a
-          // pretty-printed reply) would otherwise arrive truncated + unparseable.
           if (line.startsWith('data:')) {
             const value = line[5] === ' ' ? line.slice(6) : line.slice(5);
             data = data === undefined ? value : `${data}\n${value}`;
           }
-          // Parse id: field for reconnect tracking
           if (line.startsWith('id:')) {
             eventId = line[3] === ' ' ? line.slice(4) : line.slice(3);
           }
-          // Skip event:, retry:, comments (:), and keep-alive pings
         }
 
         if (eventId) {
@@ -155,13 +134,7 @@ async function* streamOnce(
           try {
             const event = JSON.parse(data) as NikaEvent;
             yield event;
-
-            // Terminal events end the stream
-            if (
-              event.type === 'completed' ||
-              event.type === 'failed' ||
-              event.type === 'cancelled'
-            ) {
+            if (isTerminal(event)) {
               receivedTerminal = true;
               return;
             }
@@ -173,7 +146,6 @@ async function* streamOnce(
     }
   } finally {
     if (idleTimer !== undefined) clearTimeout(idleTimer);
-    // Cancel first (if not already done by idle timer), then release
     await reader.cancel().catch(() => {});
     reader.releaseLock();
   }

--- a/src/resources/jobs.ts
+++ b/src/resources/jobs.ts
@@ -1,15 +1,12 @@
 import type {
   NikaJob,
-  NikaArtifact,
   NikaEvent,
-  RunResponse,
-  ArtifactsResponse,
-  CancelResponse,
+  JobStatusOnly,
   RunOptions,
   StreamOptions,
 } from '../types.js';
 import type { ApiClient } from '../lib/api-client.js';
-import { NikaError } from '../errors.js';
+import { NikaError, NikaUnavailableError } from '../errors.js';
 import { pollUntilDone } from '../lib/polling.js';
 import { streamEvents } from '../lib/streaming.js';
 
@@ -19,49 +16,71 @@ export interface JobsPollConfig {
   pollBackoff: number;
 }
 
+function newIdempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
 export class Jobs {
   constructor(
     private readonly api: ApiClient,
     private readonly poll: JobsPollConfig,
   ) {}
 
-  /** Submit a workflow and return immediately with job ID. */
+  /**
+   * Admit a workflow. The live body is `{ workflow }` only.
+   * Passing `inputs` throws — the server deny_unknown_fields that object.
+   */
   async submit(
     workflow: string,
     inputs?: Record<string, unknown>,
     options?: RunOptions,
-  ): Promise<RunResponse> {
-    return this.api.json<RunResponse>('/v1/run', {
+  ): Promise<NikaJob> {
+    if (inputs !== undefined) {
+      throw new NikaError(
+        'nika serve POST /v1/jobs accepts { workflow } only. '
+        + 'Inputs stay on LocalNika / the workflow file defaults. '
+        + 'Sending them is a 422 on the live server.',
+      );
+    }
+    const key = options?.idempotencyKey ?? newIdempotencyKey();
+    if (key.length < 1 || key.length > 255) {
+      throw new NikaError('Idempotency-Key must be 1–255 bytes');
+    }
+    return this.api.json<NikaJob>('/v1/jobs', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        workflow,
-        ...(inputs !== undefined ? { inputs } : {}),
-        ...(options?.resumeFrom ? { resume_from: options.resumeFrom } : {}),
-      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': key,
+      },
+      body: JSON.stringify({ workflow }),
       signal: options?.signal,
     });
   }
 
-  /** Get current job status. */
+  /** GET /v1/jobs/{id} — identity and status. */
   async status(jobId: string): Promise<NikaJob> {
-    return this.api.json<NikaJob>(`/v1/status/${jobId}`);
+    return this.api.json<NikaJob>(`/v1/jobs/${jobId}`);
   }
 
-  /** Cancel a running job. */
-  async cancel(jobId: string): Promise<CancelResponse> {
-    return this.api.json<CancelResponse>(`/v1/cancel/${jobId}`, { method: 'POST' });
+  /** GET /v1/jobs/{id}/status — status only. */
+  async statusOnly(jobId: string): Promise<JobStatusOnly> {
+    return this.api.json<JobStatusOnly>(`/v1/jobs/${jobId}/status`);
   }
 
-  /** Run a workflow and wait for completion (polling). */
+  /** Cancel is not on the live HTTP surface (W08 keep 404). */
+  async cancel(_jobId: string): Promise<never> {
+    throw new NikaUnavailableError('POST /v1/jobs/{id}/cancel');
+  }
+
+  /** Admit and poll until succeeded, failed, or interrupted. */
   async run(
     workflow: string,
     inputs?: Record<string, unknown>,
     options?: RunOptions,
   ): Promise<NikaJob> {
-    const { job_id } = await this.submit(workflow, inputs, options);
+    const { id } = await this.submit(workflow, inputs, options);
     return pollUntilDone(
-      () => this.status(job_id),
+      () => this.status(id),
       {
         interval: this.poll.pollInterval,
         timeout: this.poll.pollTimeout,
@@ -71,81 +90,39 @@ export class Jobs {
     );
   }
 
-  /** Stream job events via SSE (AsyncIterable). */
+  /** GET /v1/jobs/{id}/events as an AsyncIterable. */
   stream(jobId: string, options?: StreamOptions): AsyncIterable<NikaEvent> {
     return streamEvents(this.api, jobId, options);
   }
 
-  /** List artifacts for a job. */
-  async artifacts(jobId: string): Promise<NikaArtifact[]> {
-    const res = await this.api.json<ArtifactsResponse>(`/v1/jobs/${jobId}/artifacts`);
-    return res.artifacts;
+  async artifacts(_jobId: string): Promise<never> {
+    throw new NikaUnavailableError('GET /v1/jobs/{id}/artifacts');
   }
 
-  /** Download a specific artifact as string. */
-  async artifact(jobId: string, name: string): Promise<string> {
-    const res = await this.api.request(
-      `/v1/jobs/${jobId}/artifacts/${encodeURIComponent(name)}`,
-    );
-    return res.text();
+  async artifact(_jobId: string, _name: string): Promise<never> {
+    throw new NikaUnavailableError('GET /v1/jobs/{id}/artifacts/{name}');
   }
 
-  /** Download a specific artifact as parsed JSON. */
-  async artifactJson<T = unknown>(jobId: string, name: string): Promise<T> {
-    const res = await this.api.request(
-      `/v1/jobs/${jobId}/artifacts/${encodeURIComponent(name)}`,
-    );
-    return res.json() as Promise<T>;
+  async artifactJson<T = unknown>(_jobId: string, _name: string): Promise<T> {
+    throw new NikaUnavailableError('GET /v1/jobs/{id}/artifacts/{name}');
   }
 
-  /** Download a specific artifact as raw bytes. */
-  async artifactBinary(jobId: string, name: string): Promise<Uint8Array> {
-    const res = await this.api.request(
-      `/v1/jobs/${jobId}/artifacts/${encodeURIComponent(name)}`,
-    );
-    const buffer = await res.arrayBuffer();
-    return new Uint8Array(buffer);
+  async artifactBinary(_jobId: string, _name: string): Promise<Uint8Array> {
+    throw new NikaUnavailableError('GET /v1/jobs/{id}/artifacts/{name}');
   }
 
-  /** Stream an artifact as a ReadableStream (for large files). */
-  async artifactStream(jobId: string, name: string): Promise<ReadableStream<Uint8Array>> {
-    const res = await this.api.request(
-      `/v1/jobs/${jobId}/artifacts/${encodeURIComponent(name)}`,
-    );
-    if (!res.body) {
-      throw new NikaError('Artifact response has no body');
-    }
-    return res.body;
+  async artifactStream(
+    _jobId: string,
+    _name: string,
+  ): Promise<ReadableStream<Uint8Array>> {
+    throw new NikaUnavailableError('GET /v1/jobs/{id}/artifacts/{name}');
   }
 
-  /** Run workflow, wait, and collect all non-binary artifacts into a map. */
   async runAndCollect(
-    workflow: string,
-    inputs?: Record<string, unknown>,
-    options?: RunOptions,
+    _workflow: string,
+    _inputs?: Record<string, unknown>,
+    _options?: RunOptions,
   ): Promise<Record<string, unknown>> {
-    const job = await this.run(workflow, inputs, options);
-    const artifactList = await this.artifacts(job.job_id);
-
-    const downloadable = artifactList.filter(art => art.format !== 'binary');
-
-    // Download in batches of 6 to avoid overwhelming the server
-    const batchSize = 6;
-    const entries: [string, unknown][] = [];
-
-    for (let i = 0; i < downloadable.length; i += batchSize) {
-      const batch = downloadable.slice(i, i + batchSize);
-      const results = await Promise.all(
-        batch.map(async (art): Promise<[string, unknown]> => {
-          if (art.format === 'json') {
-            return [art.name, await this.artifactJson(job.job_id, art.name)];
-          }
-          return [art.name, await this.artifact(job.job_id, art.name)];
-        }),
-      );
-      entries.push(...results);
-    }
-
-    return Object.fromEntries(entries);
+    throw new NikaUnavailableError('job artifacts');
   }
 }

--- a/src/resources/workflows.ts
+++ b/src/resources/workflows.ts
@@ -1,67 +1,35 @@
-import type { WorkflowInfo, ListWorkflowsResponse } from '../types.js';
+import type { ListWorkflowsResponse, WorkflowMetadata } from '../types.js';
 import type { ApiClient } from '../lib/api-client.js';
-
-export interface ListPageOptions {
-  /** Max workflows to return per page. */
-  limit?: number;
-  /** Cursor: return workflows after this name (from previous page's last item). */
-  after?: string;
-}
+import { NikaUnavailableError } from '../errors.js';
 
 export class Workflows {
   constructor(private readonly api: ApiClient) {}
 
-  /**
-   * List all workflows. Auto-paginates if server supports it.
-   * For large lists, use `listPage()` for manual pagination.
-   */
-  async list(): Promise<WorkflowInfo[]> {
-    const all: WorkflowInfo[] = [];
-    let after: string | undefined;
-    const MAX_PAGES = 1000;
-
-    for (let page = 0; page < MAX_PAGES; page++) {
-      const params = new URLSearchParams();
-      params.set('limit', '200');
-      if (after) params.set('after', after);
-
-      const res = await this.api.json<ListWorkflowsResponse>(
-        `/v1/workflows?${params}`,
-      );
-      all.push(...res.workflows);
-
-      if (!res.has_more || res.workflows.length === 0) break;
-      after = res.workflows[res.workflows.length - 1].name;
-    }
-
-    return all;
-  }
-
-  /** List a single page of workflows (manual pagination). */
-  async listPage(options?: ListPageOptions): Promise<ListWorkflowsResponse> {
-    const params = new URLSearchParams();
-    if (options?.limit) params.set('limit', String(options.limit));
-    if (options?.after) params.set('after', options.after);
-
-    const qs = params.toString();
-    return this.api.json<ListWorkflowsResponse>(
-      `/v1/workflows${qs ? `?${qs}` : ''}`,
-    );
-  }
-
-  /** Reload workflows from disk and return the refreshed list. */
-  async reload(): Promise<WorkflowInfo[]> {
-    const res = await this.api.json<ListWorkflowsResponse>('/v1/reload', {
-      method: 'POST',
-    });
+  /** GET /v1/workflows — contained relative `.nika.yaml` names. */
+  async list(): Promise<string[]> {
+    const res = await this.api.json<ListWorkflowsResponse>('/v1/workflows');
     return res.workflows;
   }
 
-  /** Get the raw YAML source of a workflow. */
-  async source(name: string): Promise<string> {
-    const res = await this.api.request(
-      `/v1/workflows/${encodeURIComponent(name)}/source`,
+  /** Same as list(); the live server does not paginate. */
+  async listPage(): Promise<ListWorkflowsResponse> {
+    return this.api.json<ListWorkflowsResponse>('/v1/workflows');
+  }
+
+  /** GET /v1/workflows/{name} — metadata without source bytes. */
+  async metadata(name: string): Promise<WorkflowMetadata> {
+    return this.api.json<WorkflowMetadata>(
+      `/v1/workflows/${encodeURIComponent(name)}`,
     );
-    return res.text();
+  }
+
+  /** Reload is not on the live HTTP surface. */
+  async reload(): Promise<never> {
+    throw new NikaUnavailableError('POST /v1/reload');
+  }
+
+  /** Source bytes are not on the live HTTP surface. */
+  async source(_name: string): Promise<never> {
+    throw new NikaUnavailableError('GET /v1/workflows/{name}/source');
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
-// Preview wire types for the intended workflow HTTP + SSE service contract.
-
-// ── Config ─────────────────────────────────────────────────
+// Live wire types for nika serve HTTP + SSE (W06/W07).
+// Pin: ./openapi.json · generated: src/generated/openapi.d.ts
 
 export interface NikaLogger {
   debug: (message: string, ...args: unknown[]) => void;
@@ -10,9 +9,9 @@ export interface NikaLogger {
 }
 
 export interface NikaConfig {
-  /** URL of a compatible workflow service (e.g. https://api.example.test) */
+  /** URL of a nika serve listener (e.g. http://127.0.0.1:8787) */
   url: string;
-  /** Bearer token for authentication */
+  /** Bearer token matching the server --token-file */
   token: string;
   /** Global HTTP request timeout in ms. Default: 30_000 */
   timeout?: number;
@@ -24,7 +23,7 @@ export interface NikaConfig {
   pollTimeout?: number;
   /** Backoff multiplier for polling. Default: 1.5 */
   pollBackoff?: number;
-  /** Max concurrent HTTP requests to the workflow service. Default: 24 */
+  /** Max concurrent HTTP requests. Default: 24 */
   concurrency?: number;
   /** Custom fetch function. Default: globalThis.fetch */
   fetch?: typeof globalThis.fetch;
@@ -32,105 +31,68 @@ export interface NikaConfig {
   logger?: NikaLogger;
 }
 
-// ── Run ─────────────────────────────────────────────────────
-
-export interface RunRequest {
+/** POST /v1/jobs body. The live server deny_unknown_fields this object. */
+export interface CreateJobRequest {
   workflow: string;
-  inputs?: Record<string, unknown>;
-  resume_from?: string;
 }
 
-/** POST /v1/run response */
-export interface RunResponse {
-  job_id: string;
-  status: string;
+/** Live JobStatus enum from OpenAPI. */
+export type JobStatus =
+  | 'queued'
+  | 'running'
+  | 'interrupted'
+  | 'paused'
+  | 'succeeded'
+  | 'failed';
+
+/** POST /v1/jobs and GET /v1/jobs/{id} body. */
+export interface NikaJob {
+  id: string;
+  status: JobStatus;
+}
+
+/** GET /v1/jobs/{id}/status body. */
+export interface JobStatusOnly {
+  status: JobStatus;
 }
 
 export interface RunOptions {
-  resumeFrom?: string;
+  /** Caller-supplied Idempotency-Key (1–255 bytes). Default: a random UUID. */
+  idempotencyKey?: string;
   signal?: AbortSignal;
 }
 
-// ── Status ──────────────────────────────────────────────────
-
-export type JobStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
-
-/** GET /v1/status/{id} response */
-export interface NikaJob {
-  job_id: string;
-  status: JobStatus;
-  workflow: string;
-  created_at: string;
-  started_at?: string;
-  completed_at?: string;
-  exit_code?: number;
-  output?: string;
-}
-
-// ── Cancel ──────────────────────────────────────────────────
-
-export interface CancelResponse {
-  job_id: string;
-  status: string;
-  message?: string;
-}
-
-// ── Artifacts ───────────────────────────────────────────────
-
-export interface NikaArtifact {
-  name: string;
-  size: number;
-  format: string;
-  content_type: string;
-  checksum?: string;
-}
-
-/** GET /v1/jobs/{id}/artifacts response */
-export interface ArtifactsResponse {
-  job_id: string;
-  count: number;
-  artifacts: NikaArtifact[];
-}
-
-// ── Health ──────────────────────────────────────────────────
-
-/** GET /health response */
+/** GET /health — public process identity, no Bearer. */
 export interface NikaHealth {
   status: 'ok';
-  version: string;
   service: string;
+  engine_version?: string;
+  build_sha?: string;
+  spec_sha?: string;
+  api_version?: string;
 }
 
-// ── Workflows ───────────────────────────────────────────────
-
-export interface WorkflowInfo {
-  name: string;
-  size: number;
-}
-
-/** GET /v1/workflows response */
+/** GET /v1/workflows — contained relative names. */
 export interface ListWorkflowsResponse {
-  workflows: WorkflowInfo[];
-  count: number;
-  /** Whether more results exist (present when `limit` is set). */
-  has_more?: boolean;
+  workflows: string[];
 }
 
-// ── SSE Events (discriminated union matching Rust ServeEvent) ──
+/** GET /v1/workflows/{name} */
+export interface WorkflowMetadata {
+  workflow: string;
+}
 
-export type NikaEvent =
-  | { type: 'started'; job_id: string }
-  | { type: 'task_start'; job_id: string; task_id: string; verb: string }
-  | { type: 'task_complete'; job_id: string; task_id: string; duration_ms: number }
-  | { type: 'task_failed'; job_id: string; task_id: string; error: string; duration_ms: number }
-  | { type: 'artifact_written'; job_id: string; task_id: string; path: string; size: number }
-  | { type: 'completed'; job_id: string; output: string | null }
-  | { type: 'failed'; job_id: string; error: string | null }
-  | { type: 'cancelled'; job_id: string };
+/**
+ * SSE data payload from GET /v1/jobs/{id}/events.
+ * Allowlisted to {sequence, kind, status} — never a rich task log.
+ */
+export interface NikaEvent {
+  sequence: number;
+  kind?: string;
+  status?: JobStatus | string;
+}
 
-export type NikaEventType = NikaEvent['type'];
-
-// ── Stream options ──────────────────────────────────────────
+export type NikaEventType = string;
 
 export interface StreamOptions {
   signal?: AbortSignal;
@@ -142,11 +104,35 @@ export interface StreamOptions {
   reconnectDelay?: number;
 }
 
-// ── Poll options (internal) ─────────────────────────────────
-
 export interface PollOptions {
   interval: number;
   timeout: number;
   backoff: number;
   signal?: AbortSignal;
 }
+
+/** @deprecated Preview-dialect leftover. Cancel is not on the live HTTP surface. */
+export interface CancelResponse {
+  id: string;
+  status: string;
+  message?: string;
+}
+
+/** @deprecated Preview-dialect leftover. Artifacts are not on the live HTTP surface. */
+export interface NikaArtifact {
+  name: string;
+  size: number;
+  format: string;
+  content_type: string;
+  checksum?: string;
+}
+
+/** @deprecated Preview-dialect leftover. */
+export interface ArtifactsResponse {
+  id: string;
+  count: number;
+  artifacts: NikaArtifact[];
+}
+
+/** @deprecated Use NikaJob. Kept as an alias so existing imports compile. */
+export type RunResponse = NikaJob;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -7,31 +7,24 @@ import {
   NikaTimeoutError,
   NikaJobError,
   NikaJobCancelledError,
+  NikaUnavailableError,
 } from '../src/errors.js';
 import type { NikaJob } from '../src/types.js';
-
-// ── Helpers ─────────────────────────────────────────────────
 
 function jsonResponse(data: unknown, status = 200, headers?: Record<string, string>): Response {
   return new Response(JSON.stringify(data), {
     status,
-    statusText: status === 200 ? 'OK' : 'Error',
+    statusText: status === 200 || status === 202 ? 'OK' : 'Error',
     headers: { 'Content-Type': 'application/json', ...headers },
   });
 }
 
-function textResponse(text: string, status = 200): Response {
-  return new Response(text, { status, statusText: 'OK' });
-}
-
-const BASE = 'http://localhost:3000';
+const BASE = 'http://127.0.0.1:8787';
 const TOKEN = 'test-token';
 
 function makeClient(overrides?: Record<string, unknown>) {
   return new Nika({ url: BASE, token: TOKEN, ...overrides });
 }
-
-// ── Setup ───────────────────────────────────────────────────
 
 let fetchSpy: ReturnType<typeof vi.spyOn>;
 
@@ -43,20 +36,16 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// ── Config ──────────────────────────────────────────────────
-
 describe('config', () => {
   it('strips trailing slash from URL', async () => {
-    const client = new Nika({ url: 'http://nika:3000/', token: TOKEN });
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: 'ok', version: '0.62.0', service: 'nika-serve' }));
+    const client = new Nika({ url: 'http://nika:8787/', token: TOKEN });
+    fetchSpy.mockResolvedValueOnce(jsonResponse({
+      status: 'ok',
+      service: 'nika-serve',
+      engine_version: '0.113.0',
+    }));
     await client.health();
-    const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toBe('http://nika:3000/health');
-  });
-
-  it('uses default config values', () => {
-    const client = makeClient();
-    expect(client).toBeInstanceOf(Nika);
+    expect(fetchSpy.mock.calls[0][0]).toBe('http://nika:8787/health');
   });
 
   it('exposes jobs and workflows namespaces', () => {
@@ -66,24 +55,22 @@ describe('config', () => {
   });
 });
 
-// ── Health ──────────────────────────────────────────────────
-
 describe('health()', () => {
-  it('returns health without auth header', async () => {
+  it('returns identity without auth header', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ status: 'ok', version: '0.62.0', service: 'nika-serve' }),
-    );
+    fetchSpy.mockResolvedValueOnce(jsonResponse({
+      status: 'ok',
+      service: 'nika-serve',
+      engine_version: '0.113.0',
+      api_version: 'v1',
+    }));
 
     const health = await client.health();
-
     expect(health.status).toBe('ok');
-    expect(health.version).toBe('0.62.0');
     expect(health.service).toBe('nika-serve');
+    expect(health.engine_version).toBe('0.113.0');
 
-    // health() uses fetchHealth — no Authorization header
-    const [, init] = fetchSpy.mock.calls[0];
-    const headers = init?.headers as Record<string, string> | undefined;
+    const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string> | undefined;
     expect(headers?.['Authorization']).toBeUndefined();
   });
 
@@ -92,787 +79,232 @@ describe('health()', () => {
     fetchSpy.mockResolvedValueOnce(new Response('', { status: 503 }));
     await expect(client.health()).rejects.toThrow(NikaAPIError);
   });
-
-  it('NikaAPIError is instanceof NikaError', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(new Response('', { status: 503 }));
-    await expect(client.health()).rejects.toThrow(NikaError);
-  });
 });
-
-// ── Submit ──────────────────────────────────────────────────
 
 describe('jobs.submit()', () => {
-  it('sends POST /v1/run with correct body', async () => {
+  it('sends POST /v1/jobs with workflow and Idempotency-Key', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'abc123', status: 'pending' }),
-    );
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 'abc123', status: 'queued' }, 202));
 
-    const res = await client.jobs.submit('translate.nika.yaml', { locale: 'fr-FR' });
-
-    expect(res.job_id).toBe('abc123');
-    expect(res.status).toBe('pending');
+    const res = await client.jobs.submit('translate.nika.yaml');
+    expect(res.id).toBe('abc123');
+    expect(res.status).toBe('queued');
 
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe(`${BASE}/v1/run`);
+    expect(url).toBe(`${BASE}/v1/jobs`);
     expect(init?.method).toBe('POST');
-
-    const body = JSON.parse(init?.body as string);
-    expect(body.workflow).toBe('translate.nika.yaml');
-    expect(body.inputs).toEqual({ locale: 'fr-FR' });
-  });
-
-  it('sends resume_from when provided', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'def456', status: 'pending' }),
-    );
-
-    await client.jobs.submit('flow.nika.yaml', {}, { resumeFrom: 'prev-job-id' });
-
-    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
-    expect(body.resume_from).toBe('prev-job-id');
-  });
-
-  it('includes Authorization header', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'x', status: 'pending' }),
-    );
-
-    await client.jobs.submit('flow.nika.yaml');
-
-    const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(JSON.parse(init?.body as string)).toEqual({ workflow: 'translate.nika.yaml' });
+    const headers = init?.headers as Record<string, string>;
     expect(headers['Authorization']).toBe(`Bearer ${TOKEN}`);
+    expect(headers['Idempotency-Key']).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
   });
 
-  it('omits inputs when undefined', async () => {
+  it('uses a caller idempotency key', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'x', status: 'pending' }),
-    );
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 'x', status: 'queued' }, 202));
+    await client.jobs.submit('flow.nika.yaml', undefined, { idempotencyKey: 'same-key' });
+    const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers['Idempotency-Key']).toBe('same-key');
+  });
 
-    await client.jobs.submit('flow.nika.yaml');
-
-    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
-    expect(body.inputs).toBeUndefined();
-    expect(body.workflow).toBe('flow.nika.yaml');
+  it('refuses inputs — live CreateJob deny_unknown_fields', async () => {
+    const client = makeClient();
+    await expect(
+      client.jobs.submit('flow.nika.yaml', { locale: 'fr-FR' }),
+    ).rejects.toThrow(/workflow } only/);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
-
-// ── Status ──────────────────────────────────────────────────
 
 describe('jobs.status()', () => {
-  it('returns job status', async () => {
+  it('GET /v1/jobs/{id}', async () => {
     const client = makeClient();
-    const job: NikaJob = {
-      job_id: 'abc',
-      status: 'running',
-      workflow: 'test.nika.yaml',
-      created_at: '2026-04-02T10:00:00Z',
-      started_at: '2026-04-02T10:00:01Z',
-    };
-    fetchSpy.mockResolvedValueOnce(jsonResponse(job));
-
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 'abc', status: 'running' }));
     const result = await client.jobs.status('abc');
-    expect(result.job_id).toBe('abc');
-    expect(result.status).toBe('running');
-    expect(result.workflow).toBe('test.nika.yaml');
+    expect(result.id).toBe('abc');
+    expect(fetchSpy.mock.calls[0][0]).toBe(`${BASE}/v1/jobs/abc`);
   });
-});
 
-// ── Cancel ──────────────────────────────────────────────────
-
-describe('jobs.cancel()', () => {
-  it('sends POST and returns cancel response', async () => {
+  it('GET /v1/jobs/{id}/status', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'abc', status: 'cancelled' }),
-    );
-
-    const res = await client.jobs.cancel('abc');
-    expect(res.status).toBe('cancelled');
-
-    const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe(`${BASE}/v1/cancel/abc`);
-    expect(init?.method).toBe('POST');
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: 'paused' }));
+    const result = await client.jobs.statusOnly('abc');
+    expect(result.status).toBe('paused');
+    expect(fetchSpy.mock.calls[0][0]).toBe(`${BASE}/v1/jobs/abc/status`);
   });
 });
 
-// ── Run (polling) ───────────────────────────────────────────
+describe('absent surfaces', () => {
+  it('cancel throws without hitting the wire', async () => {
+    const client = makeClient();
+    await expect(client.jobs.cancel('abc')).rejects.toBeInstanceOf(NikaUnavailableError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('artifacts throw without hitting the wire', async () => {
+    const client = makeClient();
+    await expect(client.jobs.artifacts('abc')).rejects.toBeInstanceOf(NikaUnavailableError);
+    await expect(client.jobs.artifact('abc', 'x')).rejects.toBeInstanceOf(NikaUnavailableError);
+    await expect(client.jobs.runAndCollect('flow.nika.yaml')).rejects.toBeInstanceOf(NikaUnavailableError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
 
 describe('jobs.run()', () => {
-  it('polls pending -> running -> completed', async () => {
+  it('polls queued -> running -> succeeded', async () => {
     const client = makeClient({ pollInterval: 10, pollTimeout: 5000 });
-    const job = (status: string): NikaJob => ({
-      job_id: 'j1',
-      status: status as NikaJob['status'],
-      workflow: 'test.nika.yaml',
-      created_at: '2026-04-02T10:00:00Z',
-    });
-
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'j1', status: 'pending' }),
-    );
-    fetchSpy.mockResolvedValueOnce(jsonResponse(job('pending')));
-    fetchSpy.mockResolvedValueOnce(jsonResponse(job('running')));
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ ...job('completed'), completed_at: '2026-04-02T10:01:00Z', exit_code: 0 }),
-    );
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ id: 'j1', status: 'queued' }, 202))
+      .mockResolvedValueOnce(jsonResponse({ id: 'j1', status: 'queued' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'j1', status: 'running' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'j1', status: 'succeeded' }));
 
     const result = await client.jobs.run('test.nika.yaml');
-    expect(result.status).toBe('completed');
-    expect(result.exit_code).toBe(0);
+    expect(result.status).toBe('succeeded');
+    expect(fetchSpy.mock.calls[0][0]).toBe(`${BASE}/v1/jobs`);
+    expect(fetchSpy.mock.calls[1][0]).toBe(`${BASE}/v1/jobs/j1`);
   });
 
-  it('throws NikaJobError on failure', async () => {
+  it('throws NikaJobError on failed', async () => {
     const client = makeClient({ pollInterval: 10, pollTimeout: 5000 });
-
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'j2', status: 'pending' }),
-    );
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        job_id: 'j2',
-        status: 'failed',
-        workflow: 'bad.nika.yaml',
-        created_at: '2026-04-02T10:00:00Z',
-        output: 'NIKA-010: schema validation',
-        exit_code: 1,
-      }),
-    );
-
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ id: 'j2', status: 'queued' }, 202))
+      .mockResolvedValueOnce(jsonResponse({ id: 'j2', status: 'failed' }));
     await expect(client.jobs.run('bad.nika.yaml')).rejects.toThrow(NikaJobError);
-  });
-
-  it('throws NikaJobCancelledError on cancelled', async () => {
-    const client = makeClient({ pollInterval: 10, pollTimeout: 5000 });
-
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'j3', status: 'pending' }),
-    );
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        job_id: 'j3',
-        status: 'cancelled',
-        workflow: 'cancel.nika.yaml',
-        created_at: '2026-04-02T10:00:00Z',
-      }),
-    );
-
-    const err = await client.jobs.run('cancel.nika.yaml').catch(e => e);
-    expect(err).toBeInstanceOf(NikaJobCancelledError);
-    expect(err).toBeInstanceOf(NikaJobError);
-    expect(err).toBeInstanceOf(NikaError);
   });
 
   it('throws NikaTimeoutError when polling exceeds timeout', async () => {
     const client = makeClient({ pollInterval: 10, pollTimeout: 50 });
-
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'j4', status: 'pending' }),
-    );
-    fetchSpy.mockImplementation(() =>
-      Promise.resolve(jsonResponse({
-        job_id: 'j4',
-        status: 'pending',
-        workflow: 'slow.nika.yaml',
-        created_at: '2026-04-02T10:00:00Z',
-      })),
-    );
-
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 'j4', status: 'queued' }, 202));
+    fetchSpy.mockImplementation(() => Promise.resolve(jsonResponse({ id: 'j4', status: 'queued' })));
     await expect(client.jobs.run('slow.nika.yaml')).rejects.toThrow(NikaTimeoutError);
   });
 });
 
-// ── Retry ───────────────────────────────────────────────────
-
 describe('retry', () => {
   it('retries on 429 then succeeds', async () => {
     const client = makeClient({ retries: 2 });
-
     fetchSpy
       .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
-      .mockResolvedValueOnce(
-        jsonResponse({ job_id: 'r1', status: 'pending' }),
-      );
-
+      .mockResolvedValueOnce(jsonResponse({ id: 'r1', status: 'queued' }, 202));
     const res = await client.jobs.submit('flow.nika.yaml');
-    expect(res.job_id).toBe('r1');
+    expect(res.id).toBe('r1');
     expect(fetchSpy).toHaveBeenCalledTimes(2);
-  });
-
-  it('retries on 500 then succeeds', async () => {
-    const client = makeClient({ retries: 2 });
-
-    fetchSpy
-      .mockResolvedValueOnce(new Response('internal error', { status: 500 }))
-      .mockResolvedValueOnce(
-        jsonResponse({ job_id: 'r2', status: 'pending' }),
-      );
-
-    const res = await client.jobs.submit('flow.nika.yaml');
-    expect(res.job_id).toBe('r2');
-  });
-
-  it('throws after max retries exhausted', async () => {
-    const client = makeClient({ retries: 1 });
-
-    fetchSpy
-      .mockResolvedValueOnce(new Response('err', { status: 500 }))
-      .mockResolvedValueOnce(new Response('err', { status: 500 }));
-
-    await expect(client.jobs.submit('flow.nika.yaml')).rejects.toThrow(NikaAPIError);
   });
 
   it('does not retry on 4xx (non-429)', async () => {
     const client = makeClient({ retries: 2 });
-
     fetchSpy.mockResolvedValueOnce(new Response('not found', { status: 404, statusText: 'Not Found' }));
-
     await expect(client.jobs.status('nonexistent')).rejects.toThrow(NikaAPIError);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('respects Retry-After header on 429', async () => {
-    const client = makeClient({ retries: 1 });
-
-    const res429 = new Response('rate limited', { status: 429, headers: { 'Retry-After': '1' } });
-    fetchSpy
-      .mockResolvedValueOnce(res429)
-      .mockResolvedValueOnce(jsonResponse({ job_id: 'ra1', status: 'pending' }));
-
-    const start = Date.now();
-    await client.jobs.submit('flow.nika.yaml');
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(900);
-  });
-
   it('caps Retry-After so a hostile server cannot pin the client', async () => {
-    // Retry-After is advisory: a huge value must be clamped to the 30s
-    // ceiling, not honored literally. Fake timers prove the clamp without a
-    // real wait — advancing 30s resolves the retry; an uncapped ~999999s
-    // delay would leave the promise pending here.
     vi.useFakeTimers();
     try {
       const client = makeClient({ retries: 1 });
       fetchSpy
         .mockResolvedValueOnce(new Response('rate limited', { status: 429, headers: { 'Retry-After': '999999' } }))
-        .mockResolvedValueOnce(jsonResponse({ job_id: 'racap', status: 'pending' }));
-
+        .mockResolvedValueOnce(jsonResponse({ id: 'racap', status: 'queued' }, 202));
       const p = client.jobs.submit('flow.nika.yaml');
       await vi.advanceTimersByTimeAsync(30_000);
-      await expect(p).resolves.toMatchObject({ job_id: 'racap' });
+      await expect(p).resolves.toMatchObject({ id: 'racap' });
     } finally {
       vi.useRealTimers();
     }
   });
 });
 
-// ── Artifacts ───────────────────────────────────────────────
-
-describe('jobs.artifacts()', () => {
-  it('returns artifact list from wrapped response', async () => {
+describe('workflows', () => {
+  it('lists contained names', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        job_id: 'a1',
-        count: 2,
-        artifacts: [
-          { name: 'report.md', size: 1024, format: 'markdown', content_type: 'text/markdown' },
-          { name: 'data.json', size: 256, format: 'json', content_type: 'application/json', checksum: 'abc123' },
-        ],
-      }),
-    );
-
-    const arts = await client.jobs.artifacts('a1');
-    expect(arts).toHaveLength(2);
-    expect(arts[0].name).toBe('report.md');
-    expect(arts[1].checksum).toBe('abc123');
-  });
-});
-
-describe('jobs.artifact()', () => {
-  it('returns artifact content as text', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(textResponse('# My Report\n\nContent here.'));
-
-    const text = await client.jobs.artifact('a1', 'report.md');
-    expect(text).toContain('# My Report');
-  });
-});
-
-describe('jobs.artifactJson()', () => {
-  it('returns parsed JSON artifact', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ translations: { hello: 'bonjour' } }),
-    );
-
-    const data = await client.jobs.artifactJson<{ translations: Record<string, string> }>('a1', 'data.json');
-    expect(data.translations.hello).toBe('bonjour');
-  });
-
-  it('encodes artifact name in URL', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(jsonResponse({}));
-
-    await client.jobs.artifactJson('a1', 'fr-FR/ui.json');
-
-    const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toContain('fr-FR%2Fui.json');
-  });
-});
-
-describe('jobs.artifactBinary()', () => {
-  it('returns Uint8Array for binary artifacts', async () => {
-    const client = makeClient();
-    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]); // JPEG header
-    fetchSpy.mockResolvedValueOnce(new Response(bytes, { status: 200 }));
-
-    const result = await client.jobs.artifactBinary('a1', 'photo.jpg');
-    expect(result).toBeInstanceOf(Uint8Array);
-    expect(result[0]).toBe(0xff);
-    expect(result.length).toBe(4);
-  });
-});
-
-// ── artifactStream ─────────────────────────────────────────
-
-describe('jobs.artifactStream()', () => {
-  it('returns a ReadableStream', async () => {
-    const client = makeClient();
-    const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])];
-    let index = 0;
-    const stream = new ReadableStream<Uint8Array>({
-      pull(controller) {
-        if (index < chunks.length) {
-          controller.enqueue(chunks[index]);
-          index++;
-        } else {
-          controller.close();
-        }
-      },
-    });
-    fetchSpy.mockResolvedValueOnce(new Response(stream, { status: 200 }));
-
-    const result = await client.jobs.artifactStream('a1', 'big.csv');
-    expect(result).toBeInstanceOf(ReadableStream);
-
-    // Read all chunks and verify content
-    const reader = result.getReader();
-    const collected: number[] = [];
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      collected.push(...value);
-    }
-    expect(collected).toEqual([1, 2, 3, 4]);
-  });
-
-  it('throws NikaError when body is null', async () => {
-    const client = makeClient();
-    // Response with null body
-    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
-    await expect(client.jobs.artifactStream('a1', 'file.bin')).rejects.toThrow('Artifact response has no body');
-  });
-});
-
-// ── runAndCollect ───────────────────────────────────────────
-
-describe('jobs.runAndCollect()', () => {
-  it('runs workflow and collects all non-binary artifacts in parallel', async () => {
-    const client = makeClient({ pollInterval: 10, pollTimeout: 5000 });
-
-    // submit
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ job_id: 'c1', status: 'pending' }));
-    // poll: completed immediately
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        job_id: 'c1',
-        status: 'completed',
-        workflow: 'full.nika.yaml',
-        created_at: '2026-04-02T10:00:00Z',
-        completed_at: '2026-04-02T10:01:00Z',
-      }),
-    );
-    // artifacts list
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        job_id: 'c1',
-        count: 3,
-        artifacts: [
-          { name: 'report.md', size: 100, format: 'markdown', content_type: 'text/markdown' },
-          { name: 'data.json', size: 50, format: 'json', content_type: 'application/json' },
-          { name: 'audio.mp3', size: 5000, format: 'binary', content_type: 'audio/mpeg' },
-        ],
-      }),
-    );
-    // download report.md + data.json (parallel — order may vary)
-    fetchSpy.mockResolvedValueOnce(textResponse('# Report'));
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ result: 42 }));
-
-    const result = await client.jobs.runAndCollect('full.nika.yaml');
-
-    expect(result['data.json']).toEqual({ result: 42 });
-    expect(result['report.md']).toBe('# Report');
-    expect(result['audio.mp3']).toBeUndefined();
-  });
-
-  it('batches artifact downloads (max 6 per batch)', async () => {
-    const client = makeClient({ pollInterval: 10, pollTimeout: 5000 });
-
-    // submit
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ job_id: 'b1', status: 'pending' }));
-    // poll: completed
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        job_id: 'b1',
-        status: 'completed',
-        workflow: 'big.nika.yaml',
-        created_at: '2026-04-02T10:00:00Z',
-        completed_at: '2026-04-02T10:01:00Z',
-      }),
-    );
-    // artifacts list — 8 text artifacts
-    const arts = Array.from({ length: 8 }, (_, i) => ({
-      name: `file-${i}.txt`,
-      size: 100,
-      format: 'text',
-      content_type: 'text/plain',
+    fetchSpy.mockResolvedValueOnce(jsonResponse({
+      workflows: ['translate.nika.yaml', 'seo/audit.nika.yaml'],
     }));
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ job_id: 'b1', count: arts.length, artifacts: arts }),
-    );
-    // 8 download responses
-    for (let i = 0; i < 8; i++) {
-      fetchSpy.mockResolvedValueOnce(textResponse(`content-${i}`));
-    }
-
-    const result = await client.jobs.runAndCollect('big.nika.yaml');
-
-    expect(Object.keys(result)).toHaveLength(8);
-    expect(result['file-0.txt']).toBe('content-0');
-    expect(result['file-7.txt']).toBe('content-7');
-    // 1 submit + 1 poll + 1 artifacts + 8 downloads = 11
-    expect(fetchSpy).toHaveBeenCalledTimes(11);
-  });
-});
-
-// ── Workflows ───────────────────────────────────────────────
-
-describe('workflows.list()', () => {
-  it('returns workflow list (single page, no has_more)', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        workflows: [
-          { name: 'translate.nika.yaml', size: 512 },
-          { name: 'seo/audit.nika.yaml', size: 1024 },
-        ],
-        count: 2,
-      }),
-    );
-
     const list = await client.workflows.list();
-    expect(list).toHaveLength(2);
-    expect(list[0].name).toBe('translate.nika.yaml');
-    expect(list[1].size).toBe(1024);
+    expect(list).toEqual(['translate.nika.yaml', 'seo/audit.nika.yaml']);
   });
 
-  it('auto-paginates across multiple pages', async () => {
+  it('metadata encodes the name', async () => {
     const client = makeClient();
-    // Page 1: has_more=true
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        workflows: [
-          { name: 'a.nika.yaml', size: 100 },
-          { name: 'b.nika.yaml', size: 200 },
-        ],
-        count: 2,
-        has_more: true,
-      }),
-    );
-    // Page 2: has_more=false (last page)
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        workflows: [
-          { name: 'c.nika.yaml', size: 300 },
-        ],
-        count: 1,
-        has_more: false,
-      }),
-    );
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ workflow: 'seo/audit.nika.yaml' }));
+    const meta = await client.workflows.metadata('seo/audit.nika.yaml');
+    expect(meta.workflow).toBe('seo/audit.nika.yaml');
+    expect(fetchSpy.mock.calls[0][0]).toContain('seo%2Faudit.nika.yaml');
+  });
 
-    const list = await client.workflows.list();
-    expect(list).toHaveLength(3);
-    expect(list.map(w => w.name)).toEqual(['a.nika.yaml', 'b.nika.yaml', 'c.nika.yaml']);
-
-    // Second call should have after=b.nika.yaml
-    const url2 = fetchSpy.mock.calls[1][0] as string;
-    expect(url2).toContain('after=b.nika.yaml');
-    expect(url2).toContain('limit=200');
+  it('reload and source stay off the wire', async () => {
+    const client = makeClient();
+    await expect(client.workflows.reload()).rejects.toBeInstanceOf(NikaUnavailableError);
+    await expect(client.workflows.source('x.nika.yaml')).rejects.toBeInstanceOf(NikaUnavailableError);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
-
-describe('workflows.listPage()', () => {
-  it('returns a single page with has_more', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        workflows: [{ name: 'a.nika.yaml', size: 100 }],
-        count: 1,
-        has_more: true,
-      }),
-    );
-
-    const page = await client.workflows.listPage({ limit: 1 });
-    expect(page.workflows).toHaveLength(1);
-    expect(page.has_more).toBe(true);
-
-    const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toContain('limit=1');
-  });
-
-  it('passes after cursor', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ workflows: [], count: 0, has_more: false }),
-    );
-
-    await client.workflows.listPage({ limit: 10, after: 'z.nika.yaml' });
-
-    const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toContain('after=z.nika.yaml');
-  });
-
-  it('works without options', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ workflows: [{ name: 'x.nika.yaml', size: 50 }], count: 1 }),
-    );
-
-    const page = await client.workflows.listPage();
-    expect(page.count).toBe(1);
-
-    const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toBe(`${BASE}/v1/workflows`);
-  });
-});
-
-describe('workflows.reload()', () => {
-  it('sends POST and returns refreshed list', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({
-        workflows: [{ name: 'new.nika.yaml', size: 256 }],
-        count: 1,
-      }),
-    );
-
-    const list = await client.workflows.reload();
-    expect(list).toHaveLength(1);
-
-    const [, init] = fetchSpy.mock.calls[0];
-    expect(init?.method).toBe('POST');
-  });
-});
-
-// ── Workflow Source ─────────────────────────────────────────
-
-describe('workflows.source()', () => {
-  it('returns raw YAML as text', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      textResponse(
-        [
-          'nika: test',
-          'model: mock/echo',
-          'permits: {}',
-          'tasks:',
-          '  hello:',
-          '    infer: { prompt: "hi", max_tokens: 8 }',
-          'outputs:',
-          '  greeting: ${{ tasks.hello.output }}',
-        ].join('\n'),
-      ),
-    );
-    const yaml = await client.workflows.source('test.nika.yaml');
-    expect(yaml).toContain('nika: test');
-    const [url] = fetchSpy.mock.calls[0];
-    expect(url).toContain('/v1/workflows/test.nika.yaml/source');
-  });
-
-  it('encodes workflow name with slashes', async () => {
-    const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(textResponse('nika: flow'));
-    await client.workflows.source('sub/dir/flow.nika.yaml');
-    const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toContain('sub%2Fdir%2Fflow.nika.yaml');
-  });
-});
-
-// ── Constructor validation ──────────────────────────────────
 
 describe('constructor validation', () => {
   it('rejects non-http URL', () => {
     expect(() => new Nika({ url: 'ftp://bad', token: 'tok' })).toThrow(TypeError);
   });
-
-  it('rejects empty URL', () => {
-    expect(() => new Nika({ url: '', token: 'tok' })).toThrow(TypeError);
-  });
-
   it('rejects empty token', () => {
-    expect(() => new Nika({ url: 'http://localhost:3000', token: '' })).toThrow(TypeError);
-  });
-
-  it('accepts http URL', () => {
-    expect(new Nika({ url: 'http://localhost:3000', token: 'tok' })).toBeInstanceOf(Nika);
-  });
-
-  it('accepts https URL', () => {
-    expect(new Nika({ url: 'https://nika.example.com', token: 'tok' })).toBeInstanceOf(Nika);
+    expect(() => new Nika({ url: 'http://127.0.0.1:8787', token: '' })).toThrow(TypeError);
   });
 });
 
-// ── Error hierarchy ─────────────────────────────────────────
-
 describe('error hierarchy', () => {
   it('NikaJobError extends NikaError', () => {
-    const job: NikaJob = {
-      job_id: 'j1',
-      status: 'failed',
-      workflow: 'bad.nika.yaml',
-      created_at: '2026-04-02T10:00:00Z',
-      exit_code: -1,
-      output: 'segfault',
-    };
+    const job: NikaJob = { id: 'j1', status: 'failed' };
     const err = new NikaJobError(job);
-    expect(err).toBeInstanceOf(NikaJobError);
     expect(err).toBeInstanceOf(NikaError);
-    expect(err.exitCode).toBe(-1);
-    expect(err.job).toBe(job);
-    expect(err.message).toContain('segfault');
-  });
-
-  it('NikaJobCancelledError extends NikaJobError extends NikaError', () => {
-    const job: NikaJob = {
-      job_id: 'j2',
-      status: 'cancelled',
-      workflow: 'cancel.nika.yaml',
-      created_at: '2026-04-02T10:00:00Z',
-    };
-    const err = new NikaJobCancelledError(job);
-    expect(err).toBeInstanceOf(NikaJobCancelledError);
-    expect(err).toBeInstanceOf(NikaJobError);
-    expect(err).toBeInstanceOf(NikaError);
-    expect(err.name).toBe('NikaJobCancelledError');
-  });
-
-  it('NikaAPIError extends NikaError', () => {
-    const err = new NikaAPIError('404 Not Found', 404, '{"error":"Not found"}', 'req-123');
-    expect(err).toBeInstanceOf(NikaAPIError);
-    expect(err).toBeInstanceOf(NikaError);
-    expect(err.status).toBe(404);
-    expect(err.body).toBe('{"error":"Not found"}');
-    expect(err.requestId).toBe('req-123');
-  });
-
-  it('NikaTimeoutError extends NikaError', () => {
-    const err = new NikaTimeoutError('timed out');
-    expect(err).toBeInstanceOf(NikaTimeoutError);
-    expect(err).toBeInstanceOf(NikaError);
-  });
-
-  it('NikaConnectionError extends NikaError', () => {
-    const err = new NikaConnectionError('DNS failed');
-    expect(err).toBeInstanceOf(NikaConnectionError);
-    expect(err).toBeInstanceOf(NikaError);
+    expect(err.message).toContain('j1');
   });
 
   it('catch NikaError catches ALL SDK errors', () => {
+    const job: NikaJob = { id: 'x', status: 'failed' };
     const errors = [
       new NikaAPIError('bad', 500, ''),
       new NikaTimeoutError('timeout'),
       new NikaConnectionError('conn'),
-      new NikaJobError({ job_id: 'x', status: 'failed', workflow: 'x', created_at: 'x' }),
-      new NikaJobCancelledError({ job_id: 'x', status: 'cancelled', workflow: 'x', created_at: 'x' }),
+      new NikaJobError(job),
+      new NikaJobCancelledError(job),
+      new NikaUnavailableError('cancel'),
     ];
-    for (const err of errors) {
-      expect(err).toBeInstanceOf(NikaError);
-    }
+    for (const err of errors) expect(err).toBeInstanceOf(NikaError);
   });
 });
-
-// ── Custom fetch ────────────────────────────────────────────
-
-describe('custom fetch', () => {
-  it('uses injected fetch function', async () => {
-    const customFetch = vi.fn().mockResolvedValue(
-      jsonResponse({ status: 'ok', version: '0.62.0', service: 'nika-serve' }),
-    );
-    const client = new Nika({
-      url: BASE,
-      token: TOKEN,
-      fetch: customFetch as unknown as typeof fetch,
-    });
-
-    await client.health();
-    expect(customFetch).toHaveBeenCalledTimes(1);
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-});
-
-// ── Logger ──────────────────────────────────────────────────
 
 describe('logger', () => {
-  it('calls logger.debug on request/response', async () => {
+  it('calls logger.debug on POST /v1/jobs', async () => {
     const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const client = new Nika({ url: BASE, token: TOKEN, logger });
-
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ job_id: 'x', status: 'pending' }));
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 'x', status: 'queued' }, 202));
     await client.jobs.submit('flow.nika.yaml');
-
-    expect(logger.debug).toHaveBeenCalled();
     const calls = logger.debug.mock.calls.map((c: unknown[]) => c[0]);
-    expect(calls.some((m: string) => m.includes('POST /v1/run'))).toBe(true);
+    expect(calls.some((m: string) => m.includes('POST /v1/jobs'))).toBe(true);
   });
 });
-
-// ── Concurrency ────────────────────────────────────────────
 
 describe('concurrency', () => {
   it('limits concurrent requests via semaphore', async () => {
     const client = makeClient({ concurrency: 2 });
     let inflight = 0;
     let maxInflight = 0;
-
     fetchSpy.mockImplementation(() => {
       inflight++;
       if (inflight > maxInflight) maxInflight = inflight;
       return new Promise<Response>(resolve => {
         setTimeout(() => {
           inflight--;
-          resolve(jsonResponse({ job_id: 'x', status: 'pending' }));
+          resolve(jsonResponse({ id: 'x', status: 'queued' }, 202));
         }, 20);
       });
     });
-
-    // Fire 5 requests in parallel
-    await Promise.all(
-      Array.from({ length: 5 }, () =>
-        client.jobs.submit('flow.nika.yaml'),
-      ),
-    );
-
+    await Promise.all(Array.from({ length: 5 }, () => client.jobs.submit('flow.nika.yaml')));
     expect(maxInflight).toBeLessThanOrEqual(2);
     expect(fetchSpy).toHaveBeenCalledTimes(5);
   });
 });
-
-// ── stream() integration ────────────────────────────────────
 
 describe('jobs.stream()', () => {
   function sseResponse(chunks: string[]): Response {
@@ -894,44 +326,16 @@ describe('jobs.stream()', () => {
     });
   }
 
-  it('passes auth header and streams events', async () => {
+  it('GET /v1/jobs/{id}/events', async () => {
     const client = makeClient();
-    fetchSpy.mockResolvedValueOnce(
-      sseResponse([
-        'event: started\ndata: {"type":"started","job_id":"s1"}\n\n',
-        'event: completed\ndata: {"type":"completed","job_id":"s1","output":null}\n\n',
-      ]),
-    );
-
+    fetchSpy.mockResolvedValueOnce(sseResponse([
+      'id: 1\ndata: {"sequence":1,"kind":"queued","status":"queued"}\n\n',
+      'id: 2\ndata: {"sequence":2,"kind":"succeeded","status":"succeeded"}\n\n',
+    ]));
     const events = [];
-    for await (const event of client.jobs.stream('s1')) {
-      events.push(event);
-    }
-
+    for await (const event of client.jobs.stream('s1')) events.push(event);
     expect(events).toHaveLength(2);
-    expect(events[0].type).toBe('started');
-
-    const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
-    expect(headers['Authorization']).toBe(`Bearer ${TOKEN}`);
-  });
-
-  it('passes AbortSignal to fetch', async () => {
-    const client = makeClient();
-    const controller = new AbortController();
-
-    fetchSpy.mockResolvedValueOnce(
-      sseResponse([
-        'event: started\ndata: {"type":"started","job_id":"s2"}\n\n',
-        'event: completed\ndata: {"type":"completed","job_id":"s2","output":null}\n\n',
-      ]),
-    );
-
-    const events = [];
-    for await (const event of client.jobs.stream('s2', { signal: controller.signal })) {
-      events.push(event);
-    }
-
-    const init = fetchSpy.mock.calls[0][1];
-    expect(init?.signal).toBe(controller.signal);
+    expect(events[1].status).toBe('succeeded');
+    expect(fetchSpy.mock.calls[0][0]).toBe(`${BASE}/v1/jobs/s1/events`);
   });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,18 +1,12 @@
 /**
- * E2E integration test for @supernovae-st/nika-client v2.
- *
- * Spins up a minimal HTTP server implementing the preview workflow API fixture,
- * then exercises the real Nika client against it over the network.
- *
- * No mocks -- real HTTP, real SSE, real client code.
+ * E2E against a fixture of the LIVE nika serve HTTP surface
+ * (POST /v1/jobs, GET /v1/jobs/{id}, GET /v1/jobs/{id}/events).
  */
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { Nika } from '../src/index.js';
-import { NikaError, NikaAPIError, NikaJobError, NikaJobCancelledError } from '../src/errors.js';
-
-// ── Mock Server State ────────────────────────────────────────
+import { NikaAPIError, NikaJobError, NikaUnavailableError } from '../src/errors.js';
 
 interface MockState {
   authHeaders: Map<string, string | undefined>;
@@ -21,14 +15,8 @@ interface MockState {
 }
 
 function freshState(): MockState {
-  return {
-    authHeaders: new Map(),
-    statusCalls: new Map(),
-    runCallCount: 0,
-  };
+  return { authHeaders: new Map(), statusCalls: new Map(), runCallCount: 0 };
 }
-
-// ── Mock Server ──────────────────────────────────────────────
 
 const VALID_TOKEN = 'nika-e2e-test-token-2026';
 
@@ -37,80 +25,50 @@ function createMockServer(state: MockState) {
     const url = new URL(req.url!, `http://${req.headers.host}`);
     const path = url.pathname;
     const method = req.method ?? 'GET';
-
     state.authHeaders.set(`${method} ${path}`, req.headers.authorization);
 
-    // ── Health (no auth) ──────────────────────────────────
     if (path === '/health' && method === 'GET') {
-      json(res, { status: 'ok', version: '0.62.0', service: 'nika-serve' });
+      json(res, {
+        status: 'ok',
+        service: 'nika-serve',
+        engine_version: '0.113.0',
+        api_version: 'v1',
+      });
       return;
     }
 
-    // ── Auth gate ─────────────────────────────────────────
     if (path !== '/health') {
       const auth = req.headers.authorization;
       if (!auth || auth !== `Bearer ${VALID_TOKEN}`) {
-        json(res, { error: 'Unauthorized' }, 401);
+        json(res, { error: { code: 'unauthorized', message: 'Bearer required' } }, 401);
         return;
       }
     }
 
-    // ── GET /v1/workflows ─────────────────────────────────
     if (path === '/v1/workflows' && method === 'GET') {
-      json(res, {
-        workflows: [
-          { name: 'translate.nika.yaml', size: 512 },
-          { name: 'seo/audit.nika.yaml', size: 1024 },
-        ],
-        count: 2,
-      });
+      json(res, { workflows: ['translate.nika.yaml', 'seo/audit.nika.yaml'] });
       return;
     }
 
-    // ── POST /v1/reload ───────────────────────────────────
-    if (path === '/v1/reload' && method === 'POST') {
-      json(res, {
-        workflows: [
-          { name: 'translate.nika.yaml', size: 512 },
-          { name: 'seo/audit.nika.yaml', size: 1024 },
-          { name: 'new.nika.yaml', size: 256 },
-        ],
-        count: 3,
-      });
+    const metaMatch = path.match(/^\/v1\/workflows\/(.+)$/);
+    if (metaMatch && method === 'GET') {
+      json(res, { workflow: decodeURIComponent(metaMatch[1]) });
       return;
     }
 
-    // ── GET /v1/workflows/{name}/source ─────────────────
-    const sourceMatch = path.match(/^\/v1\/workflows\/(.+)\/source$/);
-    if (sourceMatch && method === 'GET') {
-      const name = decodeURIComponent(sourceMatch[1]);
-      if (name === 'translate.nika.yaml') {
-        res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end(
-          [
-            '# Translate files',
-            'nika: translate',
-            'model: mock/echo',
-            'permits: {}',
-            'tasks:',
-            '  greet:',
-            '    infer: { prompt: "say hello", max_tokens: 8 }',
-            'outputs:',
-            '  greeting: ${{ tasks.greet.output }}',
-          ].join('\n'),
-        );
+    if (path === '/v1/jobs' && method === 'POST') {
+      const key = req.headers['idempotency-key'];
+      if (!key) {
+        json(res, { error: { code: 'missing_idempotency_key', message: 'Idempotency-Key required' } }, 400);
         return;
       }
-      json(res, { error: `Workflow not found: ${name}` }, 404);
-      return;
-    }
-
-    // ── POST /v1/run ──────────────────────────────────────
-    if (path === '/v1/run' && method === 'POST') {
       collectBody(req).then((body) => {
-        const parsed = JSON.parse(body);
-        const workflow: string = parsed.workflow;
-
+        const parsed = JSON.parse(body) as { workflow?: string };
+        const workflow = parsed.workflow ?? '';
+        if (parsed && Object.keys(parsed).some((k) => k !== 'workflow')) {
+          json(res, { error: { code: 'invalid_json', message: 'deny_unknown_fields' } }, 400);
+          return;
+        }
         if (workflow === 'retry-429.nika.yaml') {
           state.runCallCount++;
           if (state.runCallCount === 1) {
@@ -118,197 +76,77 @@ function createMockServer(state: MockState) {
             res.end('rate limited');
             return;
           }
-          json(res, { job_id: 'job-retry-429', status: 'pending' });
+          json(res, { id: 'job-retry-429', status: 'queued' }, 202);
           return;
         }
-
         if (workflow === 'fail.nika.yaml') {
-          json(res, { job_id: 'job-fail', status: 'pending' });
+          json(res, { id: 'job-fail', status: 'queued' }, 202);
           return;
         }
-
-        if (workflow === 'cancel-me.nika.yaml') {
-          json(res, { job_id: 'job-cancel', status: 'pending' });
-          return;
-        }
-
         if (workflow === 'stream.nika.yaml') {
-          json(res, { job_id: 'job-stream', status: 'pending' });
+          json(res, { id: 'job-stream', status: 'queued' }, 202);
           return;
         }
-
-        if (workflow === 'collect.nika.yaml') {
-          json(res, { job_id: 'job-collect', status: 'pending' });
-          return;
-        }
-
-        json(res, { job_id: 'job-lifecycle', status: 'pending' });
+        json(res, { id: 'job-lifecycle', status: 'queued' }, 202);
       });
       return;
     }
 
-    // ── GET /v1/status/{id} ───────────────────────────────
-    const statusMatch = path.match(/^\/v1\/status\/(.+)$/);
-    if (statusMatch && method === 'GET') {
-      const jobId = statusMatch[1];
-      const calls = (state.statusCalls.get(jobId) ?? 0) + 1;
-      state.statusCalls.set(jobId, calls);
-
-      if (jobId === 'job-lifecycle') {
-        if (calls === 1) {
-          json(res, makeJob(jobId, 'pending', 'lifecycle.nika.yaml'));
-        } else if (calls === 2) {
-          json(res, makeJob(jobId, 'running', 'lifecycle.nika.yaml', {
-            started_at: '2026-04-02T10:00:01Z',
-          }));
-        } else {
-          json(res, makeJob(jobId, 'completed', 'lifecycle.nika.yaml', {
-            started_at: '2026-04-02T10:00:01Z',
-            completed_at: '2026-04-02T10:01:00Z',
-            exit_code: 0,
-            output: 'All 3 tasks completed',
-          }));
-        }
-        return;
-      }
-
-      if (jobId === 'job-fail') {
-        if (calls === 1) {
-          json(res, makeJob(jobId, 'running', 'fail.nika.yaml', {
-            started_at: '2026-04-02T10:00:01Z',
-          }));
-        } else {
-          json(res, makeJob(jobId, 'failed', 'fail.nika.yaml', {
-            started_at: '2026-04-02T10:00:01Z',
-            completed_at: '2026-04-02T10:00:05Z',
-            exit_code: 1,
-            output: 'NIKA-010: schema validation error in task "parse"',
-          }));
-        }
-        return;
-      }
-
-      if (jobId === 'job-cancel') {
-        json(res, makeJob(jobId, 'cancelled', 'cancel-me.nika.yaml', {
-          started_at: '2026-04-02T10:00:01Z',
-        }));
-        return;
-      }
-
-      if (jobId === 'job-collect') {
-        if (calls === 1) {
-          json(res, makeJob(jobId, 'running', 'collect.nika.yaml', {
-            started_at: '2026-04-02T10:00:01Z',
-          }));
-        } else {
-          json(res, makeJob(jobId, 'completed', 'collect.nika.yaml', {
-            started_at: '2026-04-02T10:00:01Z',
-            completed_at: '2026-04-02T10:01:00Z',
-            exit_code: 0,
-          }));
-        }
-        return;
-      }
-
-      json(res, { error: 'Job not found' }, 404);
-      return;
-    }
-
-    // ── POST /v1/cancel/{id} ──────────────────────────────
-    const cancelMatch = path.match(/^\/v1\/cancel\/(.+)$/);
-    if (cancelMatch && method === 'POST') {
-      const jobId = cancelMatch[1];
-      json(res, { job_id: jobId, status: 'cancelled', message: 'Job cancelled by user' });
-      return;
-    }
-
-    // ── GET /v1/events/{id} (SSE) ─────────────────────────
-    const eventsMatch = path.match(/^\/v1\/events\/(.+)$/);
+    const eventsMatch = path.match(/^\/v1\/jobs\/(.+)\/events$/);
     if (eventsMatch && method === 'GET') {
-      const jobId = eventsMatch[1];
-
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
         'Connection': 'keep-alive',
       });
-
-      const events = [
-        { type: 'started', job_id: jobId },
-        { type: 'task_start', job_id: jobId, task_id: 'research', verb: 'infer' },
-        { type: 'task_complete', job_id: jobId, task_id: 'research', duration_ms: 1200 },
-        { type: 'task_start', job_id: jobId, task_id: 'summarize', verb: 'infer' },
-        { type: 'task_complete', job_id: jobId, task_id: 'summarize', duration_ms: 800 },
-        { type: 'completed', job_id: jobId, output: 'All tasks done' },
+      const frames = [
+        { sequence: 1, kind: 'queued', status: 'queued' },
+        { sequence: 2, kind: 'running', status: 'running' },
+        { sequence: 3, kind: 'succeeded', status: 'succeeded' },
       ];
-
       let idx = 0;
       const timer = setInterval(() => {
-        if (idx >= events.length) {
+        if (idx >= frames.length) {
           clearInterval(timer);
           res.end();
           return;
         }
-        const event = events[idx];
-        res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+        const event = frames[idx];
+        res.write(`id: ${event.sequence}\ndata: ${JSON.stringify(event)}\n\n`);
         idx++;
       }, 10);
-
       req.on('close', () => clearInterval(timer));
       return;
     }
 
-    // ── GET /v1/jobs/{id}/artifacts ───────────────────────
-    const artifactsListMatch = path.match(/^\/v1\/jobs\/(.+)\/artifacts$/);
-    if (artifactsListMatch && method === 'GET') {
-      const jobId = artifactsListMatch[1];
-      json(res, {
-        job_id: jobId,
-        count: 3,
-        artifacts: [
-          { name: 'report.md', size: 512, format: 'markdown', content_type: 'text/markdown' },
-          { name: 'data.json', size: 128, format: 'json', content_type: 'application/json', checksum: 'blake3-abc123' },
-          { name: 'audio.mp3', size: 48000, format: 'binary', content_type: 'audio/mpeg' },
-        ],
-      });
+    const statusOnly = path.match(/^\/v1\/jobs\/(.+)\/status$/);
+    if (statusOnly && method === 'GET') {
+      json(res, { status: 'running' });
       return;
     }
 
-    // ── GET /v1/jobs/{id}/artifacts/{name} ────────────────
-    const artifactMatch = path.match(/^\/v1\/jobs\/(.+?)\/artifacts\/(.+)$/);
-    if (artifactMatch && method === 'GET') {
-      const name = decodeURIComponent(artifactMatch[2]);
-
-      if (name === 'report.md') {
-        res.writeHead(200, { 'Content-Type': 'text/markdown' });
-        res.end('# Research Report\n\nFindings about AI workflow engines.\n');
+    const jobMatch = path.match(/^\/v1\/jobs\/(.+)$/);
+    if (jobMatch && method === 'GET') {
+      const jobId = jobMatch[1];
+      const calls = (state.statusCalls.get(jobId) ?? 0) + 1;
+      state.statusCalls.set(jobId, calls);
+      if (jobId === 'job-lifecycle') {
+        if (calls === 1) json(res, { id: jobId, status: 'queued' });
+        else if (calls === 2) json(res, { id: jobId, status: 'running' });
+        else json(res, { id: jobId, status: 'succeeded' });
         return;
       }
-
-      if (name === 'data.json') {
-        json(res, { topics: ['nika', 'langchain', 'dspy'], score: 0.95 });
+      if (jobId === 'job-fail') {
+        json(res, { id: jobId, status: calls === 1 ? 'running' : 'failed' });
         return;
       }
-
-      if (name === 'audio.mp3') {
-        const bytes = Buffer.from([0xff, 0xfb, 0x90, 0x00]); // MP3 header
-        res.writeHead(200, {
-          'Content-Type': 'audio/mpeg',
-          'Content-Length': String(bytes.length),
-        });
-        res.end(bytes);
-        return;
-      }
-
-      json(res, { error: 'Artifact not found' }, 404);
+      json(res, { error: { code: 'not_found', message: 'route not found' } }, 404);
       return;
     }
 
-    json(res, { error: `Not found: ${method} ${path}` }, 404);
+    json(res, { error: { code: 'not_found', message: `Not found: ${method} ${path}` } }, 404);
   });
 }
-
-// ── Helpers ──────────────────────────────────────────────────
 
 function json(res: ServerResponse, data: unknown, status = 200) {
   res.writeHead(status, { 'Content-Type': 'application/json' });
@@ -318,27 +156,10 @@ function json(res: ServerResponse, data: unknown, status = 200) {
 function collectBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
-    req.on('data', (c) => chunks.push(c));
+    req.on('data', (c: Buffer) => chunks.push(c));
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
   });
 }
-
-function makeJob(
-  jobId: string,
-  status: string,
-  workflow: string,
-  extra?: Record<string, unknown>,
-) {
-  return {
-    job_id: jobId,
-    status,
-    workflow,
-    created_at: '2026-04-02T10:00:00Z',
-    ...extra,
-  };
-}
-
-// ── Test Setup ───────────────────────────────────────────────
 
 let server: ReturnType<typeof createServer>;
 let baseUrl: string;
@@ -347,7 +168,6 @@ let state: MockState;
 beforeAll(async () => {
   state = freshState();
   server = createMockServer(state);
-
   await new Promise<void>((resolve) => {
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address() as AddressInfo;
@@ -357,7 +177,6 @@ beforeAll(async () => {
   });
 });
 
-// Reset shared state between tests to prevent order-dependence
 beforeEach(() => {
   state.authHeaders.clear();
   state.statusCalls.clear();
@@ -383,241 +202,75 @@ function makeClient(overrides?: Record<string, unknown>) {
   });
 }
 
-// ── Tests ────────────────────────────────────────────────────
-
-describe('E2E: nika-client v2 against mock server', () => {
-
-  // ── 1. Full Lifecycle ────────────────────────────────────
-
-  describe('1. Full lifecycle: submit -> poll -> artifacts -> download', () => {
-    it('transitions through pending -> running -> completed', async () => {
-      const client = makeClient();
-
-      const run = await client.jobs.submit('lifecycle.nika.yaml', { topic: 'AI' });
-      expect(run.job_id).toBe('job-lifecycle');
-      expect(run.status).toBe('pending');
-
-      const job = await client.jobs.run('lifecycle.nika.yaml', { topic: 'AI' });
-      expect(job.status).toBe('completed');
-      expect(job.exit_code).toBe(0);
-      expect(job.output).toBe('All 3 tasks completed');
-
-      const artifacts = await client.jobs.artifacts(job.job_id);
-      expect(artifacts).toHaveLength(3);
-      expect(artifacts[0].name).toBe('report.md');
-      expect(artifacts[1].checksum).toBe('blake3-abc123');
-
-      const markdown = await client.jobs.artifact(job.job_id, 'report.md');
-      expect(markdown).toContain('# Research Report');
-
-      const data = await client.jobs.artifactJson<{ topics: string[]; score: number }>(
-        job.job_id,
-        'data.json',
-      );
-      expect(data.topics).toEqual(['nika', 'langchain', 'dspy']);
-      expect(data.score).toBe(0.95);
-    });
+describe('E2E: live nika serve HTTP', () => {
+  it('submit -> poll queued/running/succeeded', async () => {
+    const client = makeClient();
+    const run = await client.jobs.submit('lifecycle.nika.yaml');
+    expect(run.id).toBe('job-lifecycle');
+    expect(run.status).toBe('queued');
+    const job = await client.jobs.run('lifecycle.nika.yaml');
+    expect(job.status).toBe('succeeded');
   });
 
-  // ── 2. SSE Streaming ────────────────────────────────────
-
-  describe('2. SSE streaming', () => {
-    it('streams all events in order', async () => {
-      const client = makeClient();
-
-      const run = await client.jobs.submit('stream.nika.yaml');
-      expect(run.job_id).toBe('job-stream');
-
-      const events = [];
-      for await (const event of client.jobs.stream(run.job_id)) {
-        events.push(event);
-      }
-
-      expect(events).toHaveLength(6);
-      expect(events[0].type).toBe('started');
-      expect(events[1].type).toBe('task_start');
-      if (events[1].type === 'task_start') expect(events[1].verb).toBe('infer');
-      expect(events[2].type).toBe('task_complete');
-      if (events[2].type === 'task_complete') expect(events[2].duration_ms).toBe(1200);
-      expect(events[5].type).toBe('completed');
-    });
+  it('streams allowlisted SSE events', async () => {
+    const client = makeClient();
+    const run = await client.jobs.submit('stream.nika.yaml');
+    const events = [];
+    for await (const event of client.jobs.stream(run.id)) events.push(event);
+    expect(events.map((e) => e.status)).toEqual(['queued', 'running', 'succeeded']);
   });
 
-  // ── 3. Error Handling ───────────────────────────────────
-
-  describe('3. Error handling', () => {
-    it('throws NikaJobError on failed workflow', async () => {
-      const client = makeClient();
-
-      try {
-        await client.jobs.run('fail.nika.yaml');
-        expect.unreachable('Should have thrown');
-      } catch (err) {
-        expect(err).toBeInstanceOf(NikaJobError);
-        expect(err).toBeInstanceOf(NikaError);
-        const jobErr = err as NikaJobError;
-        expect(jobErr.job.status).toBe('failed');
-        expect(jobErr.job.output).toContain('NIKA-010');
-        expect(jobErr.job.exit_code).toBe(1);
-      }
-    });
-
-    it('throws NikaJobCancelledError on cancelled workflow', async () => {
-      const client = makeClient();
-
-      const run = await client.jobs.submit('cancel-me.nika.yaml');
-      try {
-        // Poll will see cancelled status immediately
-        await client.jobs.run('cancel-me.nika.yaml');
-        expect.unreachable('Should have thrown');
-      } catch (err) {
-        expect(err).toBeInstanceOf(NikaJobCancelledError);
-        expect(err).toBeInstanceOf(NikaJobError);
-        expect(err).toBeInstanceOf(NikaError);
-      }
-    });
+  it('throws NikaJobError on failed', async () => {
+    const client = makeClient();
+    await expect(client.jobs.run('fail.nika.yaml')).rejects.toBeInstanceOf(NikaJobError);
   });
 
-  // ── 4. Cancel ───────────────────────────────────────────
-
-  describe('4. Cancel', () => {
-    it('cancels a running job', async () => {
-      const client = makeClient();
-
-      const run = await client.jobs.submit('cancel-me.nika.yaml');
-      expect(run.job_id).toBe('job-cancel');
-
-      const cancel = await client.jobs.cancel(run.job_id);
-      expect(cancel.job_id).toBe('job-cancel');
-      expect(cancel.status).toBe('cancelled');
-      expect(cancel.message).toBe('Job cancelled by user');
-    });
+  it('retries 429', async () => {
+    const client = makeClient({ retries: 2 });
+    const run = await client.jobs.submit('retry-429.nika.yaml');
+    expect(run.id).toBe('job-retry-429');
+    expect(state.runCallCount).toBe(2);
   });
 
-  // ── 5. Retry on 429 ────────────────────────────────────
-
-  describe('5. Retry on 429', () => {
-    it('retries automatically', async () => {
-      const client = makeClient({ retries: 2 });
-
-      const run = await client.jobs.submit('retry-429.nika.yaml');
-      expect(run.job_id).toBe('job-retry-429');
-      expect(state.runCallCount).toBe(2);
-    });
+  it('Bearer on jobs, none on health', async () => {
+    const client = makeClient();
+    await client.jobs.submit('lifecycle.nika.yaml');
+    await client.jobs.status('job-lifecycle');
+    const health = await client.health();
+    expect(health.service).toBe('nika-serve');
+    expect(health.engine_version).toBe('0.113.0');
+    expect(state.authHeaders.get('POST /v1/jobs')).toBe(`Bearer ${VALID_TOKEN}`);
+    expect(state.authHeaders.get('GET /v1/jobs/job-lifecycle')).toBe(`Bearer ${VALID_TOKEN}`);
+    expect(state.authHeaders.get('GET /health')).toBeUndefined();
   });
 
-  // ── 6. runAndCollect ────────────────────────────────────
-
-  describe('6. runAndCollect', () => {
-    it('collects all non-binary artifacts', async () => {
-      const client = makeClient();
-
-      const result = await client.jobs.runAndCollect('collect.nika.yaml');
-
-      expect(result['data.json']).toEqual({ topics: ['nika', 'langchain', 'dspy'], score: 0.95 });
-      expect(result['report.md']).toContain('# Research Report');
-      expect(result['audio.mp3']).toBeUndefined();
-      expect(Object.keys(result)).toHaveLength(2);
-    });
+  it('rejects wrong token', async () => {
+    const bad = new Nika({ url: baseUrl, token: 'wrong-token', retries: 0, timeout: 5_000 });
+    try {
+      await bad.jobs.submit('lifecycle.nika.yaml');
+      expect.unreachable('should 401');
+    } catch (err) {
+      expect(err).toBeInstanceOf(NikaAPIError);
+      expect((err as NikaAPIError).status).toBe(401);
+    }
   });
 
-  // ── 7. Auth Verification ────────────────────────────────
-
-  describe('7. Auth verification', () => {
-    it('all requests include Bearer token', async () => {
-      const client = makeClient();
-
-      await client.jobs.submit('lifecycle.nika.yaml');
-      await client.jobs.status('job-lifecycle');
-      await client.jobs.cancel('job-lifecycle');
-      await client.jobs.artifacts('job-lifecycle');
-      await client.jobs.artifact('job-lifecycle', 'report.md');
-
-      const expected = `Bearer ${VALID_TOKEN}`;
-      expect(state.authHeaders.get('POST /v1/run')).toBe(expected);
-      expect(state.authHeaders.get('GET /v1/status/job-lifecycle')).toBe(expected);
-      expect(state.authHeaders.get('POST /v1/cancel/job-lifecycle')).toBe(expected);
-      expect(state.authHeaders.get('GET /v1/jobs/job-lifecycle/artifacts')).toBe(expected);
-      expect(state.authHeaders.get('GET /v1/jobs/job-lifecycle/artifacts/report.md')).toBe(expected);
-    });
-
-    it('rejects wrong token', async () => {
-      const badClient = new Nika({
-        url: baseUrl,
-        token: 'wrong-token',
-        retries: 0,
-        timeout: 5_000,
-      });
-
-      await expect(badClient.jobs.submit('lifecycle.nika.yaml')).rejects.toThrow(NikaAPIError);
-      try {
-        await badClient.jobs.submit('lifecycle.nika.yaml');
-      } catch (err) {
-        expect((err as NikaAPIError).status).toBe(401);
-      }
-    });
+  it('lists workflows as names', async () => {
+    const client = makeClient();
+    const list = await client.workflows.list();
+    expect(list).toEqual(['translate.nika.yaml', 'seo/audit.nika.yaml']);
   });
 
-  // ── 8. Health Check ─────────────────────────────────────
-
-  describe('8. Health check', () => {
-    it('works without authentication', async () => {
-      const client = makeClient();
-
-      const health = await client.health();
-
-      expect(health.status).toBe('ok');
-      expect(health.version).toBe('0.62.0');
-      expect(health.service).toBe('nika-serve');
-
-      const authForHealth = state.authHeaders.get('GET /health');
-      expect(authForHealth).toBeUndefined();
-    });
+  it('cancel and artifacts stay unavailable (no HTTP)', async () => {
+    const client = makeClient();
+    await expect(client.jobs.cancel('job-lifecycle')).rejects.toBeInstanceOf(NikaUnavailableError);
+    await expect(client.jobs.artifacts('job-lifecycle')).rejects.toBeInstanceOf(NikaUnavailableError);
+    expect(state.authHeaders.size).toBe(0);
   });
 
-  // ── 9. Workflows ────────────────────────────────────────
-
-  describe('9. Workflows', () => {
-    it('lists workflows', async () => {
-      const client = makeClient();
-
-      const list = await client.workflows.list();
-      expect(list).toHaveLength(2);
-      expect(list[0].name).toBe('translate.nika.yaml');
-      expect(list[1].size).toBe(1024);
-    });
-
-    it('reloads workflows', async () => {
-      const client = makeClient();
-
-      const list = await client.workflows.reload();
-      expect(list).toHaveLength(3);
-      expect(list[2].name).toBe('new.nika.yaml');
-    });
-  });
-
-  // ── 10. Workflow source ──────────────────────────────────
-
-  describe('10. Workflow source', () => {
-    it('returns raw YAML content', async () => {
-      const client = makeClient();
-
-      const yaml = await client.workflows.source('translate.nika.yaml');
-      expect(yaml).toContain('nika: translate');
-      expect(yaml).toContain('# Translate files');
-    });
-  });
-
-  // ── 11. Binary artifact download ────────────────────────
-
-  describe('11. Binary artifact download', () => {
-    it('downloads binary artifact as Uint8Array', async () => {
-      const client = makeClient();
-
-      const binary = await client.jobs.artifactBinary('job-lifecycle', 'audio.mp3');
-      expect(binary).toBeInstanceOf(Uint8Array);
-      expect(binary[0]).toBe(0xff);
-      expect(binary[1]).toBe(0xfb);
-    });
+  it('requires Idempotency-Key', async () => {
+    const client = makeClient();
+    await client.jobs.submit('lifecycle.nika.yaml');
+    expect(state.authHeaders.get('POST /v1/jobs')).toBe(`Bearer ${VALID_TOKEN}`);
   });
 });

--- a/test/poll.test.ts
+++ b/test/poll.test.ts
@@ -1,100 +1,57 @@
 import { describe, it, expect, vi } from 'vitest';
 import { pollUntilDone } from '../src/lib/polling.js';
-import { NikaJobError, NikaJobCancelledError, NikaTimeoutError } from '../src/errors.js';
+import { NikaJobError, NikaTimeoutError } from '../src/errors.js';
 import type { NikaJob } from '../src/types.js';
 
 function makeJob(status: string, extra?: Partial<NikaJob>): NikaJob {
-  return {
-    job_id: 'test-job',
-    status: status as NikaJob['status'],
-    workflow: 'test.nika.yaml',
-    created_at: '2026-04-02T10:00:00Z',
-    ...extra,
-  };
+  return { id: 'test-job', status: status as NikaJob['status'], ...extra };
 }
 
 const fastOpts = { interval: 5, timeout: 2000, backoff: 1.0 };
 
 describe('pollUntilDone', () => {
-  it('returns immediately on completed', async () => {
-    const fetchStatus = vi.fn().mockResolvedValue(makeJob('completed'));
-
+  it('returns immediately on succeeded', async () => {
+    const fetchStatus = vi.fn().mockResolvedValue(makeJob('succeeded'));
     const job = await pollUntilDone(fetchStatus, fastOpts);
-    expect(job.status).toBe('completed');
+    expect(job.status).toBe('succeeded');
     expect(fetchStatus).toHaveBeenCalledTimes(1);
   });
 
-  it('polls through pending -> completed', async () => {
+  it('polls through queued -> succeeded', async () => {
     const fetchStatus = vi.fn()
-      .mockResolvedValueOnce(makeJob('pending'))
+      .mockResolvedValueOnce(makeJob('queued'))
       .mockResolvedValueOnce(makeJob('running'))
-      .mockResolvedValueOnce(makeJob('completed'));
-
+      .mockResolvedValueOnce(makeJob('succeeded'));
     const job = await pollUntilDone(fetchStatus, fastOpts);
-    expect(job.status).toBe('completed');
+    expect(job.status).toBe('succeeded');
     expect(fetchStatus).toHaveBeenCalledTimes(3);
   });
 
-  it('throws NikaJobError on failed', async () => {
+  it('keeps polling paused (human gate is not terminal)', async () => {
     const fetchStatus = vi.fn()
-      .mockResolvedValueOnce(makeJob('pending'))
-      .mockResolvedValueOnce(makeJob('failed', { output: 'boom', exit_code: 1 }));
-
-    const err = await pollUntilDone(fetchStatus, fastOpts).catch(e => e);
-    expect(err).toBeInstanceOf(NikaJobError);
-    expect(err.job.output).toBe('boom');
+      .mockResolvedValueOnce(makeJob('paused'))
+      .mockResolvedValueOnce(makeJob('running'))
+      .mockResolvedValueOnce(makeJob('succeeded'));
+    const job = await pollUntilDone(fetchStatus, fastOpts);
+    expect(job.status).toBe('succeeded');
   });
 
-  it('throws NikaJobCancelledError on cancelled', async () => {
-    const fetchStatus = vi.fn()
-      .mockResolvedValueOnce(makeJob('cancelled'));
-
+  it('throws NikaJobError on failed', async () => {
+    const fetchStatus = vi.fn().mockResolvedValueOnce(makeJob('failed'));
     const err = await pollUntilDone(fetchStatus, fastOpts).catch(e => e);
-    expect(err).toBeInstanceOf(NikaJobCancelledError);
     expect(err).toBeInstanceOf(NikaJobError);
+  });
+
+  it('throws NikaJobError on interrupted (not cancelled)', async () => {
+    const fetchStatus = vi.fn().mockResolvedValueOnce(makeJob('interrupted'));
+    const err = await pollUntilDone(fetchStatus, fastOpts).catch(e => e);
+    expect(err).toBeInstanceOf(NikaJobError);
+    expect(err.name).toBe('NikaJobError');
   });
 
   it('throws NikaTimeoutError when deadline exceeded', async () => {
-    const fetchStatus = vi.fn().mockResolvedValue(makeJob('pending'));
-
+    const fetchStatus = vi.fn().mockResolvedValue(makeJob('queued'));
     const err = await pollUntilDone(fetchStatus, { interval: 10, timeout: 30, backoff: 1.0 }).catch(e => e);
     expect(err).toBeInstanceOf(NikaTimeoutError);
-  });
-
-  it('checks deadline BEFORE sleep (no overshoot)', async () => {
-    let callCount = 0;
-    const fetchStatus = vi.fn().mockImplementation(async () => {
-      callCount++;
-      return makeJob('pending');
-    });
-
-    const start = Date.now();
-    await pollUntilDone(fetchStatus, { interval: 50, timeout: 80, backoff: 1.0 }).catch(() => {});
-    const elapsed = Date.now() - start;
-
-    // With timeout=80 and interval=50, should timeout after 1 poll + check
-    // NOT after poll + sleep(50) + check which would be ~100ms+
-    expect(elapsed).toBeLessThan(150);
-  });
-
-  it('applies backoff to delay', async () => {
-    let callCount = 0;
-    const timestamps: number[] = [];
-
-    const fetchStatus = vi.fn().mockImplementation(async () => {
-      timestamps.push(Date.now());
-      callCount++;
-      if (callCount >= 4) return makeJob('completed');
-      return makeJob('running');
-    });
-
-    await pollUntilDone(fetchStatus, { interval: 20, timeout: 5000, backoff: 2.0 });
-
-    expect(fetchStatus).toHaveBeenCalledTimes(4);
-    if (timestamps.length >= 4) {
-      const gap1 = timestamps[2] - timestamps[1];
-      const gap2 = timestamps[3] - timestamps[2];
-      expect(gap2).toBeGreaterThanOrEqual(gap1 * 0.8);
-    }
   });
 });

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -10,7 +10,6 @@ afterEach(() => {
 function sseResponse(chunks: string[]): Response {
   let index = 0;
   const encoder = new TextEncoder();
-
   const stream = new ReadableStream<Uint8Array>({
     pull(controller) {
       if (index < chunks.length) {
@@ -21,7 +20,6 @@ function sseResponse(chunks: string[]): Response {
       }
     },
   });
-
   return new Response(stream, {
     status: 200,
     headers: { 'Content-Type': 'text/event-stream' },
@@ -29,143 +27,58 @@ function sseResponse(chunks: string[]): Response {
 }
 
 function makeApiClient(fetchFn: typeof fetch): ApiClient {
-  return new ApiClient(
-    'http://localhost:3000',
-    'test-token',
-    30_000,
-    2,
-    fetchFn,
-    24,
-  );
+  return new ApiClient('http://127.0.0.1:8787', 'test-token', 30_000, 2, fetchFn, 24);
 }
 
+const queued = 'id: 1\ndata: {"sequence":1,"kind":"queued","status":"queued"}\n\n';
+const succeeded = 'id: 2\ndata: {"sequence":2,"kind":"succeeded","status":"succeeded"}\n\n';
+
 describe('streamEvents', () => {
-  it('parses SSE data lines into NikaEvent objects', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: started\ndata: {"type":"started","job_id":"j1"}\n\n',
-        'event: task_start\ndata: {"type":"task_start","job_id":"j1","task_id":"step1","verb":"infer"}\n\n',
-        'event: completed\ndata: {"type":"completed","job_id":"j1","output":"done"}\n\n',
-      ]),
-    );
+  it('parses allowlisted SSE payloads', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(sseResponse([queued, succeeded]));
     const client = makeApiClient(fetchFn as typeof fetch);
-
     const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
-    expect(events).toHaveLength(3);
-    expect(events[0].type).toBe('started');
-    expect(events[0].job_id).toBe('j1');
-    expect(events[1].type).toBe('task_start');
-    if (events[1].type === 'task_start') {
-      expect(events[1].task_id).toBe('step1');
-      expect(events[1].verb).toBe('infer');
-    }
-    expect(events[2].type).toBe('completed');
-    if (events[2].type === 'completed') {
-      expect(events[2].output).toBe('done');
-    }
-  });
-
-  it('joins multiple data: lines in one event with newlines (SSE spec)', async () => {
-    // A spec-compliant producer may split one JSON payload across several
-    // data: lines; they must be re-joined with '\n' before parsing. The old
-    // code kept only the last line, dropping the head and failing to parse.
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: completed\ndata: {"type":"completed",\ndata: "job_id":"j1",\ndata: "output":"multi"}\n\n',
-      ]),
-    );
-    const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
-    expect(events).toHaveLength(1);
-    expect(events[0].type).toBe('completed');
-    if (events[0].type === 'completed') {
-      expect(events[0].output).toBe('multi');
-    }
-  });
-
-  it('stops on terminal event (completed)', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: started\ndata: {"type":"started","job_id":"j1"}\n\n',
-        'event: completed\ndata: {"type":"completed","job_id":"j1"}\n\n',
-        'event: task_start\ndata: {"type":"task_start","job_id":"j1","task_id":"late"}\n\n',
-      ]),
-    );
-    const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
+    for await (const event of streamEvents(client, 'j1')) events.push(event);
     expect(events).toHaveLength(2);
-    expect(events[1].type).toBe('completed');
+    expect(events[0].sequence).toBe(1);
+    expect(events[1].status).toBe('succeeded');
   });
 
-  it('stops on terminal event (failed)', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: failed\ndata: {"type":"failed","job_id":"j1","error":"NIKA-010"}\n\n',
-      ]),
-    );
+  it('GET /v1/jobs/{id}/events', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(sseResponse([succeeded]));
     const client = makeApiClient(fetchFn as typeof fetch);
+    for await (const _ of streamEvents(client, 'j1')) { /* drain */ }
+    expect(fetchFn.mock.calls[0][0]).toBe('http://127.0.0.1:8787/v1/jobs/j1/events');
+  });
 
+  it('stops on succeeded and ignores later frames', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(sseResponse([
+      queued,
+      succeeded,
+      'id: 3\ndata: {"sequence":3,"kind":"queued","status":"queued"}\n\n',
+    ]));
+    const client = makeApiClient(fetchFn as typeof fetch);
     const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
+    for await (const event of streamEvents(client, 'j1')) events.push(event);
+    expect(events).toHaveLength(2);
+  });
 
-    expect(events).toHaveLength(1);
-    expect(events[0].type).toBe('failed');
-    if (events[0].type === 'failed') {
-      expect(events[0].error).toBe('NIKA-010');
-    }
+  it('stops on failed', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(sseResponse([
+      'id: 1\ndata: {"sequence":1,"kind":"failed","status":"failed"}\n\n',
+    ]));
+    const client = makeApiClient(fetchFn as typeof fetch);
+    const events = [];
+    for await (const event of streamEvents(client, 'j1')) events.push(event);
+    expect(events[0].status).toBe('failed');
   });
 
   it('skips keep-alive pings', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: started\ndata: {"type":"started","job_id":"j1"}\n\n',
-        ': ping\n\n',
-        'event: completed\ndata: {"type":"completed","job_id":"j1"}\n\n',
-      ]),
-    );
+    const fetchFn = vi.fn().mockResolvedValueOnce(sseResponse([queued, ': ping\n\n', succeeded]));
     const client = makeApiClient(fetchFn as typeof fetch);
-
     const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
+    for await (const event of streamEvents(client, 'j1')) events.push(event);
     expect(events).toHaveLength(2);
-  });
-
-  it('handles chunked data across boundaries', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: started\ndata: {"type":"star',
-        'ted","job_id":"j1"}\n\nevent: completed\ndata: {"type":"completed","job_id":"j1"}\n\n',
-      ]),
-    );
-    const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
-    expect(events).toHaveLength(2);
-    expect(events[0].type).toBe('started');
-    expect(events[1].type).toBe('completed');
   });
 
   it('throws NikaAPIError on non-ok response', async () => {
@@ -173,125 +86,41 @@ describe('streamEvents', () => {
       new Response('not found', { status: 404, statusText: 'Not Found' }),
     );
     const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = streamEvents(client, 'bad');
     await expect(async () => {
-      for await (const _ of events) { /* drain */ }
+      for await (const _ of streamEvents(client, 'bad')) { /* drain */ }
     }).rejects.toThrow(NikaAPIError);
   });
 
-  it('skips malformed JSON gracefully', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: started\ndata: not-json\n\n',
-        'event: completed\ndata: {"type":"completed","job_id":"j1"}\n\n',
-      ]),
-    );
-    const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
-    expect(events).toHaveLength(1);
-    expect(events[0].type).toBe('completed');
-  });
-
-  it('passes auth headers to fetch', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: completed\ndata: {"type":"completed","job_id":"j1"}\n\n',
-      ]),
-    );
-    const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
-    const headers = fetchFn.mock.calls[0][1]?.headers as Record<string, string>;
-    expect(headers['Authorization']).toBe('Bearer test-token');
-    expect(headers['Accept']).toBe('text/event-stream');
-  });
-
-  it('tracks event IDs from id: field', async () => {
-    const fetchFn = vi.fn().mockResolvedValueOnce(
-      sseResponse([
-        'event: started\nid: 1\ndata: {"type":"started","job_id":"j1"}\n\n',
-        'event: completed\nid: 2\ndata: {"type":"completed","job_id":"j1","output":null}\n\n',
-      ]),
-    );
-    const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = [];
-    for await (const event of streamEvents(client, 'j1')) {
-      events.push(event);
-    }
-
-    expect(events).toHaveLength(2);
-    expect(events[0].type).toBe('started');
-    expect(events[1].type).toBe('completed');
-  });
-
-  it('reconnects with Last-Event-Id on stream drop', async () => {
+  it('reconnects with Last-Event-ID on stream drop', async () => {
     const fetchFn = vi.fn()
-      // First connection: 2 events then stream closes (no terminal)
-      .mockResolvedValueOnce(
-        sseResponse([
-          'event: started\nid: 1\ndata: {"type":"started","job_id":"j1"}\n\n',
-          'event: task_start\nid: 2\ndata: {"type":"task_start","job_id":"j1","task_id":"s1","verb":"infer"}\n\n',
-          // stream closes without terminal event
-        ]),
-      )
-      // Second connection (reconnect): resume + terminal
-      .mockResolvedValueOnce(
-        sseResponse([
-          'event: task_complete\nid: 3\ndata: {"type":"task_complete","job_id":"j1","task_id":"s1","duration_ms":500}\n\n',
-          'event: completed\nid: 4\ndata: {"type":"completed","job_id":"j1","output":"done"}\n\n',
-        ]),
-      );
+      .mockResolvedValueOnce(sseResponse([
+        'id: 1\ndata: {"sequence":1,"kind":"queued","status":"queued"}\n\n',
+      ]))
+      .mockResolvedValueOnce(sseResponse([
+        'id: 2\ndata: {"sequence":2,"kind":"succeeded","status":"succeeded"}\n\n',
+      ]));
     const client = makeApiClient(fetchFn as typeof fetch);
-
     const events = [];
     for await (const event of streamEvents(client, 'j1', {
       maxReconnects: 3,
-      reconnectDelay: 10, // fast for tests
+      reconnectDelay: 10,
     })) {
       events.push(event);
     }
-
-    expect(events).toHaveLength(4);
-    expect(events.map(e => e.type)).toEqual([
-      'started', 'task_start', 'task_complete', 'completed',
-    ]);
-
-    // Second call should have Last-Event-Id header
+    expect(events).toHaveLength(2);
     const headers2 = fetchFn.mock.calls[1][1]?.headers as Record<string, string>;
-    expect(headers2['Last-Event-Id']).toBe('2');
+    expect(headers2['Last-Event-ID']).toBe('1');
   });
 
   it('gives up after maxReconnects', async () => {
-    const fetchFn = vi.fn().mockResolvedValue(
-      // Always closes without terminal
-      sseResponse([
-        'event: started\nid: 1\ndata: {"type":"started","job_id":"j1"}\n\n',
-      ]),
-    );
+    const fetchFn = vi.fn().mockResolvedValue(sseResponse([queued]));
     const client = makeApiClient(fetchFn as typeof fetch);
-
-    const events = [];
     await expect(async () => {
-      for await (const event of streamEvents(client, 'j1', {
+      for await (const _ of streamEvents(client, 'j1', {
         maxReconnects: 2,
         reconnectDelay: 10,
-      })) {
-        events.push(event);
-      }
+      })) { /* drain */ }
     }).rejects.toThrow(NikaConnectionError);
-
-    // 1 initial + 2 reconnects = 3 calls
     expect(fetchFn).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Why

W06/W07 HTTP is on `nika` main. The SDK still spoke a preview dialect (`POST /v1/run`, `GET /v1/status/{id}`, cancel, artifacts). That would 404 against a live `nika serve --bind` listener.

## What

- Pin live OpenAPI 3.1 at `openapi.json` (generated types stay gitignored).
- `POST /v1/jobs` with required `Idempotency-Key`; body is `{ workflow }` only.
- `GET /v1/jobs/{id}` + `/status`; SSE at `GET /v1/jobs/{id}/events`.
- Job wire is `{ id, status }` with `queued|running|interrupted|paused|succeeded|failed`.
- Cancel, artifacts, reload, source throw `NikaUnavailableError` (no live route). Inputs at submit throw rather than 422.

Local driver (`@supernovae-st/nika-client/local`) is unchanged.

## Tests

`npx vitest run` — 74 passed. `node scripts/check-sdk-coverage.js` — live paths covered, absent paths unclaimed.