### PR TITLE
chore(release): lockstep 0.114.0 with nika serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.114.0] - 2026-08-23
+
+Lockstep with engine **v0.114.0**. GET job identity may include
+`execution_id` and `trace_id` after snapshot readmit. Cancel, artifacts
+and `/v1/run` stay unclaimed.
+
 ### Changed
 
 - **HTTP client retargets the live `nika serve` door (W09).** Paths are

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ for await (const event of nika.jobs.stream(jobId, {
 ```
 
 <!-- engine hero pinned to the release tag it demonstrates · re-pin on lockstep bumps -->
-![nika check audits the workflow (plan, permits, cost, secrets, types, the lethal-trifecta gate), then nika run executes it locally and seals the hash-chained trace — the audit-then-run story](https://raw.githubusercontent.com/supernovae-st/nika/v0.112.0/media/nika-hero.gif)
+![nika check audits the workflow (plan, permits, cost, secrets, types, the lethal-trifecta gate), then nika run executes it locally and seals the hash-chained trace — the audit-then-run story](https://raw.githubusercontent.com/supernovae-st/nika/v0.114.0/media/nika-hero.gif)
 
 ## Keeping it fresh · the lockstep
 

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "nika serve",
-    "version": "0.113.0",
+    "version": "0.114.0",
     "description": "Authenticated loopback remote execution. Cancel and artifacts are absent."
   },
   "servers": [
@@ -55,7 +55,9 @@
         "required": ["id", "status"],
         "properties": {
           "id": { "type": "string", "format": "uuid" },
-          "status": { "$ref": "#/components/schemas/JobStatus" }
+          "status": { "$ref": "#/components/schemas/JobStatus" },
+          "execution_id": { "type": "string" },
+          "trace_id": { "type": "string" }
         }
       },
       "JobStatusOnly": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.112.0",
+  "version": "0.114.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supernovae-st/nika-client",
-      "version": "0.112.0",
+      "version": "0.114.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supernovae-st/nika-client",
-  "version": "0.112.0",
+  "version": "0.114.0",
   "description": "TypeScript client for Nika — a live local driver plus the nika serve HTTP client",
   "repository": {
     "type": "git",

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,10 @@ export type JobStatus =
 export interface NikaJob {
   id: string;
   status: JobStatus;
+  /** Present after the worker readmits the POST-time snapshot. */
+  execution_id?: string;
+  /** Present after the worker readmits the POST-time snapshot. */
+  trace_id?: string;
 }
 
 /** GET /v1/jobs/{id}/status body. */

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -42,7 +42,7 @@ describe('config', () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({
       status: 'ok',
       service: 'nika-serve',
-      engine_version: '0.113.0',
+      engine_version: '0.114.0',
     }));
     await client.health();
     expect(fetchSpy.mock.calls[0][0]).toBe('http://nika:8787/health');
@@ -61,14 +61,14 @@ describe('health()', () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({
       status: 'ok',
       service: 'nika-serve',
-      engine_version: '0.113.0',
+      engine_version: '0.114.0',
       api_version: 'v1',
     }));
 
     const health = await client.health();
     expect(health.status).toBe('ok');
     expect(health.service).toBe('nika-serve');
-    expect(health.engine_version).toBe('0.113.0');
+    expect(health.engine_version).toBe('0.114.0');
 
     const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string> | undefined;
     expect(headers?.['Authorization']).toBeUndefined();

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -31,7 +31,7 @@ function createMockServer(state: MockState) {
       json(res, {
         status: 'ok',
         service: 'nika-serve',
-        engine_version: '0.113.0',
+        engine_version: '0.114.0',
         api_version: 'v1',
       });
       return;
@@ -238,7 +238,7 @@ describe('E2E: live nika serve HTTP', () => {
     await client.jobs.status('job-lifecycle');
     const health = await client.health();
     expect(health.service).toBe('nika-serve');
-    expect(health.engine_version).toBe('0.113.0');
+    expect(health.engine_version).toBe('0.114.0');
     expect(state.authHeaders.get('POST /v1/jobs')).toBe(`Bearer ${VALID_TOKEN}`);
     expect(state.authHeaders.get('GET /v1/jobs/job-lifecycle')).toBe(`Bearer ${VALID_TOKEN}`);
     expect(state.authHeaders.get('GET /health')).toBeUndefined();


### PR DESCRIPTION
Lockstep with engine v0.114.0. Additive `execution_id` / `trace_id` on GET job. Cancel, artifacts and `/v1/run` stay unclaimed.