### PR TITLE
fix(release): preserve pinned npm lock order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           NIKA_URL: http://127.0.0.1:3000
           NIKA_TOKEN: ci-test-token-32-chars-minimum!!
         run: |
+          set -euo pipefail
           sdk_version=$(node -p "require('./package.json').version")
           engine_version=$(nika --version | awk '{print $2}')
           if [ "$sdk_version" != "$engine_version" ]; then
@@ -98,8 +99,23 @@ jobs:
           # The fixture speaks the shipped nine-key envelope — this exact file
           # passes `nika check` clean (rc=0) on the released binary
           # (`nika: <id>` names the file).
-          mkdir -p /tmp/wf
-          cat > /tmp/wf/test.nika.yaml <<'EOF'
+          probe_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/nika-client-type-drift.XXXXXX")
+          project_dir="$probe_root/project"
+          workflows_dir="$probe_root/workflows"
+          state_dir="$probe_root/state"
+          token_file="$probe_root/serve.token"
+          server_pid=""
+          cleanup() {
+            if [ -n "$server_pid" ]; then
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            fi
+            find "$probe_root" -depth -delete
+          }
+          trap cleanup EXIT
+          mkdir -p "$project_dir" "$workflows_dir" "$state_dir"
+          printf '%s\n' 'nika: ci-type-drift-probe' > "$project_dir/nika.yaml"
+          cat > "$workflows_dir/test.nika.yaml" <<'EOF'
           nika: test
           permits: {}
           tasks:
@@ -111,11 +127,19 @@ jobs:
           outputs:
             greeting: ${{ '${{ tasks.hello.output }}' }}
           EOF
-          mkdir -p /tmp/nika-ci
           umask 077
-          printf '%s' "$NIKA_SERVE_TOKEN" > /tmp/nika-ci/serve.token
-          chmod 600 /tmp/nika-ci/serve.token
-          nika serve --bind 127.0.0.1:3000 --workflows /tmp/wf --token-file /tmp/nika-ci/serve.token &
+          printf '%s' "$NIKA_SERVE_TOKEN" > "$token_file"
+          chmod 600 "$token_file"
+          (
+            cd "$project_dir"
+            exec nika serve \
+              --bind 127.0.0.1:3000 \
+              --workflows "$workflows_dir" \
+              --token-file "$token_file" \
+              --state-root "$state_dir" \
+              --plain
+          ) >"$probe_root/server.log" 2>&1 &
+          server_pid=$!
           ok=0
           for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
             if curl -sf http://127.0.0.1:3000/health >/dev/null; then
@@ -125,14 +149,15 @@ jobs:
             sleep 1
           done
           if [ "$ok" != 1 ]; then
+            cat "$probe_root/server.log" >&2
             echo "::error::nika serve --bind never answered GET /health"
             exit 1
           fi
           curl -sf -H "Authorization: Bearer $NIKA_TOKEN" \
-            http://127.0.0.1:3000/v1/openapi.json > /tmp/nika-live-openapi.json
-          jq -S . openapi.json > /tmp/nika-pinned-openapi.sorted.json
-          jq -S . /tmp/nika-live-openapi.json > /tmp/nika-live-openapi.sorted.json
-          diff -u /tmp/nika-pinned-openapi.sorted.json /tmp/nika-live-openapi.sorted.json
+            http://127.0.0.1:3000/v1/openapi.json > "$probe_root/live-openapi.json"
+          jq -S . openapi.json > "$probe_root/pinned-openapi.sorted.json"
+          jq -S . "$probe_root/live-openapi.json" > "$probe_root/live-openapi.sorted.json"
+          diff -u "$probe_root/pinned-openapi.sorted.json" "$probe_root/live-openapi.sorted.json"
           npm run generate:types -- http://127.0.0.1:3000
           git diff --exit-code -- src/generated/openapi.d.ts
           echo "Pinned OpenAPI and generated types match the live tagged engine"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,30 +119,56 @@ jobs:
       - name: Prove the pinned contract and generated types against the released binary
         run: |
           set -euo pipefail
-          mkdir -p openapi-probe/{workflows,state}
-          tar -xzf "engine-assets/nika-linux-x64-$VERSION.tar.gz" -C openapi-probe nika
+          probe_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/nika-client-release-openapi.XXXXXX")
+          project_dir="$probe_root/project"
+          workflows_dir="$probe_root/workflows"
+          state_dir="$probe_root/state"
+          token_file="$probe_root/token"
+          server_pid=""
+          cleanup() {
+            if [ -n "$server_pid" ]; then
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            fi
+            find "$probe_root" -depth -delete
+          }
+          trap cleanup EXIT
+          mkdir -p "$project_dir" "$workflows_dir" "$state_dir"
+          printf '%s\n' 'nika: release-openapi-probe' > "$project_dir/nika.yaml"
+          tar -xzf "engine-assets/nika-linux-x64-$VERSION.tar.gz" -C "$probe_root" nika
           token="nika-release-openapi-probe-token-0116"
-          printf '%s\n' "$token" > openapi-probe/token
-          chmod 600 openapi-probe/token
-          ./openapi-probe/nika serve \
-            --bind 127.0.0.1:18787 \
-            --workflows openapi-probe/workflows \
-            --token-file openapi-probe/token \
-            --state-root openapi-probe/state \
-            --plain >openapi-probe/server.log 2>&1 &
+          printf '%s\n' "$token" > "$token_file"
+          chmod 600 "$token_file"
+          (
+            cd "$project_dir"
+            exec "$probe_root/nika" serve \
+              --bind 127.0.0.1:18787 \
+              --workflows "$workflows_dir" \
+              --token-file "$token_file" \
+              --state-root "$state_dir" \
+              --plain
+          ) >"$probe_root/server.log" 2>&1 &
           server_pid=$!
-          trap 'kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true' EXIT
+          ok=0
           for _ in {1..50}; do
-            if curl -fsS http://127.0.0.1:18787/health >/dev/null; then break; fi
+            if curl -fsS http://127.0.0.1:18787/health >/dev/null; then
+              ok=1
+              break
+            fi
             sleep 0.1
           done
+          if [ "$ok" != 1 ]; then
+            cat "$probe_root/server.log" >&2
+            echo "::error::released nika serve never answered GET /health"
+            exit 1
+          fi
           curl -fsS \
             -H "Authorization: Bearer $token" \
             http://127.0.0.1:18787/v1/openapi.json \
-            > openapi-probe/live.json
-          jq -S . openapi.json > openapi-probe/pinned.sorted.json
-          jq -S . openapi-probe/live.json > openapi-probe/live.sorted.json
-          if ! cmp -s openapi-probe/pinned.sorted.json openapi-probe/live.sorted.json; then
+            > "$probe_root/live.json"
+          jq -S . openapi.json > "$probe_root/pinned.sorted.json"
+          jq -S . "$probe_root/live.json" > "$probe_root/live.sorted.json"
+          if ! cmp -s "$probe_root/pinned.sorted.json" "$probe_root/live.sorted.json"; then
             echo "::error::openapi.json differs from the released v$VERSION binary"
             exit 1
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,13 +1260,13 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "AGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ],
       "engines": {
         "node": ">=22"
@@ -1277,13 +1277,13 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "AGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ],
       "engines": {
         "node": ">=22"

--- a/scripts/sync-native-versions.mjs
+++ b/scripts/sync-native-versions.mjs
@@ -39,13 +39,14 @@ lock.version = version;
 lock.packages[''].version = version;
 lock.packages[''].optionalDependencies = rootPackage.optionalDependencies;
 for (const [name, manifest] of lockEntries) {
+  // Match npm@11.19.1's package-lock serialization so release validation is idempotent.
   lock.packages[`node_modules/${name}`] = {
     version,
-    optional: true,
-    license: manifest.license,
-    os: manifest.os,
     cpu: manifest.cpu,
     ...(manifest.libc ? { libc: manifest.libc } : {}),
+    license: manifest.license,
+    optional: true,
+    os: manifest.os,
     engines: manifest.engines,
   };
 }

--- a/test/native-lock.test.ts
+++ b/test/native-lock.test.ts
@@ -8,9 +8,11 @@ interface PackageLock {
   packages: Record<string, {
     version?: string;
     optional?: boolean;
+    license?: string;
     os?: string[];
     cpu?: string[];
     libc?: string[];
+    engines?: Record<string, string>;
   }>;
 }
 
@@ -27,6 +29,13 @@ describe('native package lock coverage', () => {
       expect(entry).toMatchObject({ version, optional: true });
       expect(entry.os).toHaveLength(1);
       expect(entry.cpu).toHaveLength(1);
+
+      const expectedKeys = entry.libc
+        ? ['version', 'cpu', 'libc', 'license', 'optional', 'os', 'engines']
+        : ['version', 'cpu', 'license', 'optional', 'os', 'engines'];
+      expect(Object.keys(entry), `${name} must retain npm 11.19.1 lock order`).toEqual(
+        expectedKeys,
+      );
     }
   });
 });


### PR DESCRIPTION
## What

Make native package-lock generation reproduce npm@11.19.1 serialization exactly, including Linux `libc` placement, and ratchet the key order in tests.

## Failure reproduced

The v0.116.0 five-package release run https://github.com/supernovae-st/nika-client/actions/runs/33369715203 failed before staging because `npm run sync:native-versions` reordered four native lock entries and `git diff --exit-code` correctly rejected the dirty tree.

## Proof

- npm@11.19.1 `npm ci`
- 120/120 tests
- build and `tsc --noEmit`
- two consecutive native-version syncs stay clean
- npm package-lock-only canonicalization stays clean

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
Signed-off-by: Thibaut Melen <20891897+ThibautMelen@users.noreply.github.com>