### PR TITLE
fix: deliver terminal cancellation event before observer close

### DIFF
--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -395,7 +395,6 @@ export class HttpTransport implements Transport {
           throw new NikaProtocolError(this.kind, 'Cancellation did not return a terminal job');
         }
         settle(durable);
-        controller.abort();
         const accepted = durable.status === 'cancelled';
         return {
           runId: id,

--- a/src/lib/run-session.ts
+++ b/src/lib/run-session.ts
@@ -72,7 +72,10 @@ export class RunSession {
   private async cancelAndSettle(): Promise<NikaCancelResult> {
     const cancellation = await this.source.cancel();
     const result = await this.source.done;
-    if (!this.terminal) {
+    // An active observer owns the terminal event boundary. Let the transport
+    // pump deliver that persisted frame before it closes the subscription.
+    // With no observer, cancellation can still clean up immediately.
+    if (!this.terminal && this.subscribers.size === 0) {
       this.terminal = true;
       this.resolveDone(result);
       for (const subscriber of [...this.subscribers]) subscriber.close();

--- a/test/http-depth-lifecycle.test.ts
+++ b/test/http-depth-lifecycle.test.ts
@@ -268,6 +268,80 @@ describe('SSE replay, reconnect, and terminal authority', () => {
 });
 
 describe('cancellation and terminal identity', () => {
+  it('delivers one terminal cancellation event before closing active observers', async () => {
+    const stream = controlledByteStream();
+    const terminal = {
+      sequence: 2,
+      kind: 'execution.cancelled',
+      status: 'cancelled',
+      receipt: RECEIPT,
+    } as const;
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const path = new URL(String(input)).pathname;
+      if (path === '/health') return healthResponse();
+      if (path === '/v1/jobs') {
+        return jsonResponse({ id: 'job-1', status: 'queued' }, 202);
+      }
+      if (path === '/v1/jobs/job-1/events') return stream.response;
+      if (path === '/v1/jobs/job-1/cancel') {
+        return jsonResponse({
+          id: 'job-1',
+          status: 'cancelled',
+          execution_id: 'execution-1',
+          trace_id: 'trace-1',
+          receipt: RECEIPT,
+        });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const nika = client(fetch as typeof globalThis.fetch);
+    const run = await nika.run('flow.nika.yaml');
+    const observer = nika.events(run)[Symbol.asyncIterator]();
+    stream.enqueue(sseFrame({
+      sequence: 1,
+      kind: 'execution.started',
+      status: 'running',
+    }));
+    await expect(observer.next()).resolves.toMatchObject({
+      done: false,
+      value: { sequence: 1, status: 'running' },
+    });
+    const terminalObservation = observer.next();
+
+    const cancellation = nika.cancel(run);
+    expect(nika.cancel(run)).toBe(cancellation);
+    await expect(cancellation).resolves.toMatchObject({
+      accepted: true,
+      status: 'cancelled',
+    });
+    await expect(run.done).resolves.toMatchObject({
+      id: 'job-1',
+      status: 'cancelled',
+      receipt: RECEIPT,
+    });
+
+    try {
+      stream.enqueue(sseFrame(terminal));
+      stream.close();
+    } catch {
+      // The regression closes the stream before the persisted terminal event
+      // can reach the already-waiting observer. The assertion below owns the
+      // failure so the user-visible contract stays explicit.
+    }
+    await expect(terminalObservation).resolves.toEqual({
+      done: false,
+      value: terminal,
+    });
+    await expect(observer.next()).resolves.toEqual({ done: true, value: undefined });
+
+    const replay = await collect(nika.events(run));
+    expect(replay).toEqual([
+      { sequence: 1, kind: 'execution.started', status: 'running' },
+      terminal,
+    ]);
+    expect(replay.filter((event) => event.status === 'cancelled')).toHaveLength(1);
+  });
+
   it('settles a terminal 200 admission immediately while replaying persisted SSE', async () => {
     const terminal = {
       sequence: 1,


### PR DESCRIPTION
## Outcome

Keeps the HTTP event pump alive long enough for an already-active observer to receive the persisted `execution.cancelled` frame. Sessions without observers retain immediate cancellation cleanup.

The bug was found by a fresh packed consumer against the published 0.116 engine: `run.done` settled cancelled, but the live iterator closed after `execution.started`; replay later showed the missing terminal frame.

## Proof

- regression red before fix, green after
- exact terminal once, before iterator `done: true`
- cancel idempotency, `run.done`, replay and no-duplicate assertions
- HTTP lifecycle: 30/30
- complete suite: 123/123
- TypeScript, ESM/CJS build and pack: green
- real packed-client E2E against `nika 0.116.0 (2574d23c6)`: `[started, cancelled]`

No npm publication is claimed; trusted publishing remains the separate issue #55.