### PR TITLE
fix(release): verify native artifacts end to end

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      attestations: read
     outputs:
       prepared_sha: ${{ steps.release-metadata.outputs.prepared_sha }}
     env:
@@ -94,7 +95,12 @@ jobs:
           ref: "v${{ env.VERSION }}"
           token: ${{ secrets.NIKA_REPO_TOKEN || github.token }}
 
-      - name: Enforce SDK coverage against tagged engine source
+      - name: Test the tagged engine OpenAPI source
+        run: |
+          cargo test --manifest-path nika-source/Cargo.toml \
+            -p nika-serve --lib server::openapi::tests
+
+      - name: Enforce SDK coverage against the pinned contract
         run: npm run check:coverage
 
       - name: Download and verify engine release assets
@@ -113,6 +119,7 @@ jobs:
             --pattern SHA256SUMS
           cd engine-assets
           for asset in nika-*"$VERSION".tar.gz; do
+            gh attestation verify "$asset" --repo supernovae-st/nika
             grep -E "[[:space:]]${asset}$" SHA256SUMS | sha256sum --check --strict
           done
 
@@ -263,11 +270,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-tarballs pack-reports
+          engine_commit=$(git -C nika-source rev-parse HEAD)
           for package_dir in packages/native/*; do
             report="pack-reports/$(basename "$package_dir").json"
             npm pack "$package_dir" --json --pack-destination release-tarballs > "$report"
             node scripts/verify-native-pack.mjs \
-              "$report" release-tarballs "$PREPARED_SHA" "$VERSION"
+              "$report" release-tarballs "$PREPARED_SHA" "$VERSION" \
+              "$engine_commit" engine-assets/SHA256SUMS
           done
           npm pack --ignore-scripts --json --pack-destination release-tarballs \
             > pack-reports/nika-client.json
@@ -312,9 +321,66 @@ jobs:
             echo "- npm staging: skipped by dry run"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  verify-native-runtime:
+    name: packed runtime (${{ matrix.target }})
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      PREPARED_SHA: ${{ needs.prepare.outputs.prepared_sha }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            runner: ubuntu-24.04
+            tarball: supernovae-st-nika-linux-x64
+            package: '@supernovae-st/nika-linux-x64'
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            tarball: supernovae-st-nika-linux-arm64
+            package: '@supernovae-st/nika-linux-arm64'
+          - target: darwin-x64
+            runner: macos-15-intel
+            tarball: supernovae-st-nika-darwin-x64
+            package: '@supernovae-st/nika-darwin-x64'
+          - target: darwin-arm64
+            runner: macos-15
+            tarball: supernovae-st-nika-darwin-arm64
+            package: '@supernovae-st/nika-darwin-arm64'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.prepared_sha }}
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nika-client-release-${{ env.VERSION }}
+          path: release-candidate
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Execute the freshly packed SDK and native payload
+        env:
+          NATIVE_PACKAGE: ${{ matrix.package }}
+          NATIVE_TARBALL: ${{ matrix.tarball }}
+        run: |
+          npm install --global npm@11.19.1
+          node scripts/verify-packed-install.mjs \
+            "release-candidate/release-tarballs/supernovae-st-nika-client-$VERSION.tgz" \
+            "release-candidate/release-tarballs/$NATIVE_TARBALL-$VERSION.tgz" \
+            "$VERSION" "$PREPARED_SHA" "$NATIVE_PACKAGE"
+
   stage:
     if: github.ref == 'refs/heads/main' && github.event.inputs.dry_run != 'true'
-    needs: prepare
+    needs: [prepare, verify-native-runtime]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: npm-staging

--- a/scripts/build-native-package.mjs
+++ b/scripts/build-native-package.mjs
@@ -1,6 +1,13 @@
-import { createHash } from 'node:crypto';
 import { chmod, copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import {
+  assertExecutableIdentity,
+  assertExecutableTarget,
+  assertNativeManifest,
+  isCommit,
+  isSha256,
+  sha256File,
+} from './native-release-contract.mjs';
 
 const args = parseArgs(process.argv.slice(2));
 for (const required of ['package', 'binary', 'license', 'asset', 'asset-sha256', 'source-commit']) {
@@ -10,14 +17,23 @@ for (const required of ['package', 'binary', 'license', 'asset', 'asset-sha256',
 const packageDir = path.resolve(args.package);
 const manifest = JSON.parse(await readFile(path.join(packageDir, 'package.json'), 'utf8'));
 const rootManifest = JSON.parse(await readFile(path.resolve('package.json'), 'utf8'));
-if (manifest.version !== rootManifest.version) {
-  throw new Error(`${manifest.name} version ${manifest.version} != root ${rootManifest.version}`);
+const target = assertNativeManifest(manifest, rootManifest.version);
+if (args.asset !== target.asset) {
+  throw new Error(`${manifest.name} must be built from ${target.asset}, got ${args.asset}`);
 }
+if (!isSha256(args['asset-sha256'])) {
+  throw new Error('--asset-sha256 must be exactly 64 lowercase hexadecimal characters');
+}
+if (!isCommit(args['source-commit'])) {
+  throw new Error('--source-commit must be exactly 40 lowercase hexadecimal characters');
+}
+await assertExecutableTarget(path.resolve(args.binary), target);
+await assertExecutableIdentity(path.resolve(args.binary), rootManifest.version, args['source-commit']);
 
 const metadata = {
-  os: one(manifest.os, 'os'),
-  cpu: one(manifest.cpu, 'cpu'),
-  libc: manifest.libc ? one(manifest.libc, 'libc') : null,
+  os: target.os,
+  cpu: target.cpu,
+  libc: target.libc,
 };
 const binDir = path.join(packageDir, 'bin');
 const outputBin = path.join(binDir, 'nika');
@@ -38,7 +54,7 @@ const integrity = {
   algorithm: 'sha256',
   ...metadata,
   archive: { file: args.asset, sha256: args['asset-sha256'] },
-  executable: { file: 'bin/nika', sha256: await sha256(outputBin) },
+  executable: { file: 'bin/nika', sha256: await sha256File(outputBin) },
 };
 await writeJson(path.join(packageDir, 'SOURCE.json'), source);
 await writeJson(path.join(packageDir, 'INTEGRITY.json'), integrity);
@@ -54,17 +70,6 @@ function parseArgs(values) {
     result[flag.slice(2)] = values[index + 1];
   }
   return result;
-}
-
-function one(value, field) {
-  if (!Array.isArray(value) || value.length !== 1 || typeof value[0] !== 'string') {
-    throw new Error(`${manifest.name} must declare one ${field} value`);
-  }
-  return value[0];
-}
-
-async function sha256(file) {
-  return createHash('sha256').update(await readFile(file)).digest('hex');
 }
 
 async function writeJson(file, value) {

--- a/scripts/native-release-contract.mjs
+++ b/scripts/native-release-contract.mjs
@@ -1,0 +1,270 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { open, readFile } from 'node:fs/promises';
+
+const TARGETS = new Map([
+  ['@supernovae-st/nika-darwin-arm64', {
+    os: 'darwin', cpu: 'arm64', libc: null, assetPlatform: 'macos', assetArch: 'arm64',
+  }],
+  ['@supernovae-st/nika-darwin-x64', {
+    os: 'darwin', cpu: 'x64', libc: null, assetPlatform: 'macos', assetArch: 'x64',
+  }],
+  ['@supernovae-st/nika-linux-arm64', {
+    os: 'linux', cpu: 'arm64', libc: 'glibc', assetPlatform: 'linux', assetArch: 'arm64',
+  }],
+  ['@supernovae-st/nika-linux-x64', {
+    os: 'linux', cpu: 'x64', libc: 'glibc', assetPlatform: 'linux', assetArch: 'x64',
+  }],
+]);
+
+export function nativeTarget(packageName, version) {
+  const target = TARGETS.get(packageName);
+  if (!target) throw new Error(`Unknown native package ${String(packageName)}`);
+  return {
+    ...target,
+    asset: `nika-${target.assetPlatform}-${target.assetArch}-${version}.tar.gz`,
+  };
+}
+
+export function assertNativeManifest(manifest, version) {
+  const target = nativeTarget(manifest.name, version);
+  if (manifest.version !== version) {
+    throw new Error(`${manifest.name} version ${String(manifest.version)} != ${version}`);
+  }
+  assertSingle(manifest.os, target.os, `${manifest.name} os`);
+  assertSingle(manifest.cpu, target.cpu, `${manifest.name} cpu`);
+  if (target.libc === null) {
+    if (manifest.libc !== undefined) {
+      throw new Error(`${manifest.name} must not declare libc`);
+    }
+  } else {
+    assertSingle(manifest.libc, target.libc, `${manifest.name} libc`);
+  }
+  return target;
+}
+
+export async function inspectExecutable(file) {
+  const handle = await open(file, 'r');
+  try {
+    const metadata = await handle.stat();
+    const header = Buffer.alloc(64);
+    const { bytesRead } = await handle.read(header, 0, header.length, 0);
+    if (bytesRead < 32) throw new Error(`${file} is too short to be a native executable`);
+    const detected = inspectExecutableHeader(header);
+    if (detected.format === 'elf64') {
+      await assertElfStructure(handle, header, metadata.size);
+    } else {
+      await assertMachOStructure(handle, header, metadata.size, detected.littleEndian);
+    }
+    return { os: detected.os, cpu: detected.cpu, format: detected.format };
+  } finally {
+    await handle.close();
+  }
+}
+
+export function inspectExecutableHeader(header) {
+  if (
+    header[0] === 0x7f
+    && header[1] === 0x45
+    && header[2] === 0x4c
+    && header[3] === 0x46
+  ) {
+    if (header[4] !== 2) throw new Error('Nika release executable must be 64-bit ELF');
+    const littleEndian = header[5] === 1;
+    const bigEndian = header[5] === 2;
+    if (!littleEndian && !bigEndian) throw new Error('ELF executable has an unknown byte order');
+    const machine = littleEndian ? header.readUInt16LE(18) : header.readUInt16BE(18);
+    const cpu = machine === 62 ? 'x64' : machine === 183 ? 'arm64' : undefined;
+    if (!cpu) throw new Error(`Unsupported ELF machine ${machine}`);
+    return { os: 'linux', cpu, format: 'elf64', littleEndian };
+  }
+
+  const magic = header.readUInt32LE(0);
+  if (magic === 0xfeedfacf || magic === 0xcffaedfe) {
+    const littleEndian = magic === 0xfeedfacf;
+    const cpuType = littleEndian ? header.readUInt32LE(4) : header.readUInt32BE(4);
+    const cpu = cpuType === 0x01000007 ? 'x64' : cpuType === 0x0100000c ? 'arm64' : undefined;
+    if (!cpu) throw new Error(`Unsupported Mach-O CPU type 0x${cpuType.toString(16)}`);
+    return { os: 'darwin', cpu, format: 'mach-o64', littleEndian };
+  }
+
+  throw new Error('Nika release executable is neither ELF64 nor Mach-O 64-bit');
+}
+
+export async function assertExecutableTarget(file, target) {
+  const actual = await inspectExecutable(file);
+  if (actual.os !== target.os || actual.cpu !== target.cpu) {
+    throw new Error(
+      `${file} is ${actual.os}-${actual.cpu} (${actual.format}), expected ${target.os}-${target.cpu}`,
+    );
+  }
+  return actual;
+}
+
+export async function assertExecutableIdentity(file, version, commit) {
+  if (!isCommit(commit)) throw new Error('engine commit must be 40 lowercase hex');
+  const expected = `${version} (${commit.slice(0, 9)})`;
+  const matches = (await readFile(file)).toString('latin1')
+    .match(/\b\d+\.\d+\.\d+ \([0-9a-f]{9}\)/g) ?? [];
+  if (matches.length !== 1 || matches[0] !== expected) {
+    throw new Error(
+      `${file} embeds engine identities [${matches.join(', ')}], expected exactly ${expected}`,
+    );
+  }
+}
+
+export function sha256File(file) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(file);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.once('error', reject);
+    stream.once('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+export function checksumForAsset(contents, asset) {
+  const matches = [];
+  for (const line of contents.split(/\r?\n/)) {
+    const match = line.match(/^([0-9a-f]{64})\s+\*?(.+)$/);
+    if (match?.[2] === asset) matches.push(match[1]);
+  }
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one SHA256SUMS entry for ${asset}, found ${matches.length}`);
+  }
+  return matches[0];
+}
+
+export function isSha256(value) {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+}
+
+export function isCommit(value) {
+  return typeof value === 'string' && /^[0-9a-f]{40}$/.test(value);
+}
+
+function assertSingle(value, expected, label) {
+  if (!Array.isArray(value) || value.length !== 1 || value[0] !== expected) {
+    throw new Error(`${label} must be exactly [${JSON.stringify(expected)}]`);
+  }
+}
+
+async function assertElfStructure(handle, header, fileSize) {
+  const littleEndian = header[5] === 1;
+  const u16 = (offset) => littleEndian ? header.readUInt16LE(offset) : header.readUInt16BE(offset);
+  const u32 = (offset) => littleEndian ? header.readUInt32LE(offset) : header.readUInt32BE(offset);
+  const u64 = (buffer, offset) => safeUInt64(
+    littleEndian ? buffer.readBigUInt64LE(offset) : buffer.readBigUInt64BE(offset),
+    'ELF offset',
+  );
+  const type = u16(16);
+  const version = u32(20);
+  const entry = u64(header, 24);
+  const programOffset = u64(header, 32);
+  const headerSize = u16(52);
+  const programEntrySize = u16(54);
+  const programCount = u16(56);
+  if (
+    ![2, 3].includes(type)
+    || version !== 1
+    || entry === 0
+    || headerSize !== 64
+    || programEntrySize !== 56
+    || programCount < 1
+    || programCount > 4096
+  ) {
+    throw new Error('ELF64 header does not describe a bounded executable image');
+  }
+  const tableSize = programEntrySize * programCount;
+  if (programOffset < headerSize || programOffset + tableSize > fileSize) {
+    throw new Error('ELF64 program header table lies outside the executable');
+  }
+  const table = Buffer.alloc(tableSize);
+  const { bytesRead } = await handle.read(table, 0, table.length, programOffset);
+  if (bytesRead !== table.length) throw new Error('Cannot read the complete ELF64 program table');
+
+  let executableLoad = false;
+  for (let index = 0; index < programCount; index += 1) {
+    const offset = index * programEntrySize;
+    const segmentType = littleEndian ? table.readUInt32LE(offset) : table.readUInt32BE(offset);
+    if (segmentType !== 1) continue;
+    const flags = littleEndian ? table.readUInt32LE(offset + 4) : table.readUInt32BE(offset + 4);
+    const fileOffset = u64(table, offset + 8);
+    const virtualAddress = u64(table, offset + 16);
+    const fileBytes = u64(table, offset + 32);
+    const memoryBytes = u64(table, offset + 40);
+    if (fileBytes > memoryBytes || fileOffset + fileBytes > fileSize) {
+      throw new Error('ELF64 load segment lies outside the executable');
+    }
+    if (
+      (flags & 1) !== 0
+      && entry >= virtualAddress
+      && entry < virtualAddress + memoryBytes
+    ) {
+      executableLoad = true;
+    }
+  }
+  if (!executableLoad) throw new Error('ELF64 entry point is not in an executable load segment');
+}
+
+async function assertMachOStructure(handle, header, fileSize, littleEndian) {
+  const u32 = (buffer, offset) => littleEndian
+    ? buffer.readUInt32LE(offset)
+    : buffer.readUInt32BE(offset);
+  const u64 = (buffer, offset) => safeUInt64(
+    littleEndian ? buffer.readBigUInt64LE(offset) : buffer.readBigUInt64BE(offset),
+    'Mach-O offset',
+  );
+  const fileType = u32(header, 12);
+  const commandCount = u32(header, 16);
+  const commandBytes = u32(header, 20);
+  if (
+    fileType !== 2
+    || commandCount < 1
+    || commandCount > 4096
+    || commandBytes < 8
+    || 32 + commandBytes > fileSize
+  ) {
+    throw new Error('Mach-O header does not describe a bounded executable image');
+  }
+  const commands = Buffer.alloc(commandBytes);
+  const { bytesRead } = await handle.read(commands, 0, commands.length, 32);
+  if (bytesRead !== commands.length) throw new Error('Cannot read the complete Mach-O commands');
+
+  let cursor = 0;
+  let executableSegment = false;
+  let entryPoint = false;
+  for (let index = 0; index < commandCount; index += 1) {
+    if (cursor + 8 > commands.length) throw new Error('Mach-O command header is truncated');
+    const command = u32(commands, cursor);
+    const commandSize = u32(commands, cursor + 4);
+    if (commandSize < 8 || cursor + commandSize > commands.length) {
+      throw new Error('Mach-O load command lies outside the command table');
+    }
+    if (command === 0x19) {
+      if (commandSize < 72) throw new Error('Mach-O segment command is truncated');
+      const fileOffset = u64(commands, cursor + 40);
+      const segmentBytes = u64(commands, cursor + 48);
+      const initialProtection = u32(commands, cursor + 60);
+      if (fileOffset + segmentBytes > fileSize) {
+        throw new Error('Mach-O segment lies outside the executable');
+      }
+      if ((initialProtection & 4) !== 0 && segmentBytes > 0) executableSegment = true;
+    }
+    if (command === 0x80000028) {
+      if (commandSize < 24) throw new Error('Mach-O entry-point command is truncated');
+      const entryOffset = u64(commands, cursor + 8);
+      if (entryOffset >= fileSize) throw new Error('Mach-O entry point lies outside the executable');
+      entryPoint = true;
+    }
+    cursor += commandSize;
+  }
+  if (cursor !== commands.length || !executableSegment || !entryPoint) {
+    throw new Error('Mach-O image lacks a complete executable segment or entry point');
+  }
+}
+
+function safeUInt64(value, label) {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error(`${label} exceeds safe range`);
+  return Number(value);
+}

--- a/scripts/verify-native-pack.mjs
+++ b/scripts/verify-native-pack.mjs
@@ -1,34 +1,160 @@
-import { readFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
+import {
+  assertExecutableIdentity,
+  assertExecutableTarget,
+  assertNativeManifest,
+  checksumForAsset,
+  isCommit,
+  isSha256,
+  sha256File,
+} from './native-release-contract.mjs';
 
-const [packJsonPath, tarballDirectory, preparedCommit, expectedVersion] = process.argv.slice(2);
-if (!packJsonPath || !tarballDirectory || !preparedCommit || !expectedVersion) {
+const [
+  packJsonPath,
+  tarballDirectory,
+  preparedCommit,
+  expectedVersion,
+  engineCommit,
+  checksumsPath,
+] = process.argv.slice(2);
+if (
+  !packJsonPath
+  || !tarballDirectory
+  || !preparedCommit
+  || !expectedVersion
+  || !engineCommit
+  || !checksumsPath
+) {
   throw new Error(
-    'Usage: verify-native-pack.mjs <npm-pack-json> <tarball-directory> <prepared-commit> <version>',
+    'Usage: verify-native-pack.mjs <npm-pack-json> <tarball-directory> '
+      + '<prepared-commit> <version> <engine-commit> <SHA256SUMS>',
   );
 }
+if (!isCommit(preparedCommit)) throw new Error('prepared commit must be 40 lowercase hex');
+if (!isCommit(engineCommit)) throw new Error('engine commit must be 40 lowercase hex');
+
 const result = JSON.parse(await readFile(packJsonPath, 'utf8'))[0];
 if (!result) throw new Error(`No npm pack result in ${packJsonPath}`);
+const tarball = path.join(tarballDirectory, result.filename);
+const extractionRoot = await mkdtemp(path.join(tmpdir(), 'nika-native-pack-proof-'));
 
-const required = ['package.json', 'bin/nika', 'LICENSE', 'SOURCE.json', 'INTEGRITY.json'];
-const files = new Map(result.files.map((entry) => [entry.path, entry]));
-for (const file of required) {
-  if (!files.has(file)) throw new Error(`${result.name} pack is missing ${file}`);
+try {
+  execFileSync('tar', ['-xzf', tarball, '-C', extractionRoot]);
+  const packageRoot = path.join(extractionRoot, 'package');
+  const required = ['package.json', 'bin/nika', 'LICENSE', 'SOURCE.json', 'INTEGRITY.json'];
+  const reportedFiles = new Map(result.files.map((entry) => [entry.path, entry]));
+  for (const file of required) {
+    if (!reportedFiles.has(file)) throw new Error(`${result.name} pack report is missing ${file}`);
+    const metadata = await stat(path.join(packageRoot, file)).catch(() => undefined);
+    if (!metadata?.isFile()) throw new Error(`${result.name} tarball is missing ${file}`);
+  }
+  if ((reportedFiles.get('bin/nika').mode & 0o111) === 0) {
+    throw new Error(`${result.name} bin/nika is not executable in the pack report`);
+  }
+  const executable = path.join(packageRoot, 'bin', 'nika');
+  if (((await stat(executable)).mode & 0o111) === 0) {
+    throw new Error(`${result.name} bin/nika is not executable in the tarball`);
+  }
+
+  const manifest = await readJson(path.join(packageRoot, 'package.json'), 'package.json');
+  const target = assertNativeManifest(manifest, expectedVersion);
+  if (result.name !== manifest.name || result.version !== expectedVersion) {
+    throw new Error(`npm pack report does not describe ${manifest.name}@${expectedVersion}`);
+  }
+  if (
+    manifest.nikaRelease?.version !== expectedVersion
+    || manifest.nikaRelease?.preparedCommit !== preparedCommit
+  ) {
+    throw new Error(`${result.name} packed release metadata does not bind ${preparedCommit}`);
+  }
+
+  const source = await readJson(path.join(packageRoot, 'SOURCE.json'), 'SOURCE.json');
+  assertExactKeys(source, ['repository', 'tag', 'commit', 'releaseAsset', 'sourceArchive'], 'SOURCE.json');
+  const expectedSource = {
+    repository: 'https://github.com/supernovae-st/nika',
+    tag: `v${expectedVersion}`,
+    commit: engineCommit,
+    releaseAsset: target.asset,
+    sourceArchive: `https://github.com/supernovae-st/nika/archive/refs/tags/v${expectedVersion}.tar.gz`,
+  };
+  for (const [key, expected] of Object.entries(expectedSource)) {
+    if (source[key] !== expected) {
+      throw new Error(`SOURCE.json ${key} is ${String(source[key])}, expected ${expected}`);
+    }
+  }
+
+  const integrity = await readJson(path.join(packageRoot, 'INTEGRITY.json'), 'INTEGRITY.json');
+  assertExactKeys(
+    integrity,
+    ['algorithm', 'os', 'cpu', 'libc', 'archive', 'executable'],
+    'INTEGRITY.json',
+  );
+  if (
+    integrity.algorithm !== 'sha256'
+    || integrity.os !== target.os
+    || integrity.cpu !== target.cpu
+    || integrity.libc !== target.libc
+  ) {
+    throw new Error(`INTEGRITY.json target does not bind ${target.os}-${target.cpu}`);
+  }
+  const archive = record(integrity.archive, 'INTEGRITY.json archive');
+  assertExactKeys(archive, ['file', 'sha256'], 'INTEGRITY.json archive');
+  const expectedArchiveSha = checksumForAsset(
+    await readFile(checksumsPath, 'utf8'),
+    target.asset,
+  );
+  if (
+    archive.file !== target.asset
+    || archive.sha256 !== expectedArchiveSha
+    || !isSha256(archive.sha256)
+  ) {
+    throw new Error(`INTEGRITY.json archive does not match SHA256SUMS for ${target.asset}`);
+  }
+
+  const executableIntegrity = record(integrity.executable, 'INTEGRITY.json executable');
+  assertExactKeys(executableIntegrity, ['file', 'sha256'], 'INTEGRITY.json executable');
+  const executableSha = await sha256File(executable);
+  if (
+    executableIntegrity.file !== 'bin/nika'
+    || executableIntegrity.sha256 !== executableSha
+    || !isSha256(executableIntegrity.sha256)
+  ) {
+    throw new Error('INTEGRITY.json executable checksum does not match packed bin/nika');
+  }
+  const detected = await assertExecutableTarget(executable, target);
+  await assertExecutableIdentity(executable, expectedVersion, engineCommit);
+  console.log(
+    `Verified ${result.name}@${result.version}: ${detected.format} ${target.os}-${target.cpu}, `
+      + 'source and checksums bound',
+  );
+} finally {
+  await rm(extractionRoot, { recursive: true, force: true });
 }
-if ((files.get('bin/nika').mode & 0o111) === 0) {
-  throw new Error(`${result.name} bin/nika is not executable`);
+
+async function readJson(file, label) {
+  let value;
+  try {
+    value = JSON.parse(await readFile(file, 'utf8'));
+  } catch (cause) {
+    throw new Error(`Cannot parse ${label}: ${cause instanceof Error ? cause.message : String(cause)}`);
+  }
+  return record(value, label);
 }
-const manifest = JSON.parse(execFileSync(
-  'tar',
-  ['-xOf', path.join(tarballDirectory, result.filename), 'package/package.json'],
-  { encoding: 'utf8' },
-));
-if (
-  manifest.version !== expectedVersion
-  || manifest.nikaRelease?.version !== expectedVersion
-  || manifest.nikaRelease?.preparedCommit !== preparedCommit
-) {
-  throw new Error(`${result.name} packed release metadata does not bind ${preparedCommit}`);
+
+function record(value, label) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
 }
-console.log(`Verified ${result.name}@${result.version}: ${required.join(', ')}`);
+
+function assertExactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  const canonical = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(canonical)) {
+    throw new Error(`${label} keys are ${actual.join(', ')}, expected ${canonical.join(', ')}`);
+  }
+}

--- a/scripts/verify-packed-install.mjs
+++ b/scripts/verify-packed-install.mjs
@@ -1,0 +1,142 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { isCommit, nativeTarget } from './native-release-contract.mjs';
+
+const [
+  clientTarballArg,
+  nativeTarballArg,
+  expectedVersion,
+  preparedCommit,
+  nativePackageName,
+] = process.argv.slice(2);
+if (
+  !clientTarballArg
+  || !nativeTarballArg
+  || !expectedVersion
+  || !preparedCommit
+  || !nativePackageName
+) {
+  throw new Error(
+    'Usage: verify-packed-install.mjs <client.tgz> <host-native.tgz> '
+      + '<version> <prepared-commit> <native-package>',
+  );
+}
+if (!/^0\.\d+\.\d+$/.test(expectedVersion)) throw new Error('version must be 0.x.y');
+if (!isCommit(preparedCommit)) throw new Error('prepared commit must be 40 lowercase hex');
+const nativeTargetContract = nativeTarget(nativePackageName, expectedVersion);
+if (
+  nativeTargetContract.os !== process.platform
+  || nativeTargetContract.cpu !== process.arch
+) {
+  throw new Error(
+    `${nativePackageName} targets ${nativeTargetContract.os}-${nativeTargetContract.cpu}, `
+      + `but this runner is ${process.platform}-${process.arch}`,
+  );
+}
+
+const clientTarball = path.resolve(clientTarballArg);
+const nativeTarball = path.resolve(nativeTarballArg);
+const project = await mkdtemp(path.join(tmpdir(), 'nika-packed-consumer-'));
+
+try {
+  await writeFile(path.join(project, 'package.json'), '{"private":true,"type":"module"}\n');
+  run('npm', [
+    'install',
+    '--ignore-scripts',
+    '--omit=optional',
+    '--no-audit',
+    '--no-fund',
+    '--package-lock=false',
+    clientTarball,
+    nativeTarball,
+  ]);
+
+  const clientManifest = await readJson(
+    path.join(project, 'node_modules/@supernovae-st/nika-client/package.json'),
+  );
+  const nativeManifest = await readJson(
+    path.join(project, 'node_modules', ...nativePackageName.split('/'), 'package.json'),
+  );
+  for (const manifest of [clientManifest, nativeManifest]) {
+    if (
+      manifest.version !== expectedVersion
+      || manifest.nikaRelease?.version !== expectedVersion
+      || manifest.nikaRelease?.preparedCommit !== preparedCommit
+    ) {
+      throw new Error(`${String(manifest.name)} install is not bound to ${preparedCommit}`);
+    }
+  }
+
+  await writeFile(path.join(project, 'packed-release-smoke.nika.yaml'), [
+    'nika: packed-release-smoke',
+    'model: mock/echo',
+    'tasks:',
+    '  prove:',
+    '    infer:',
+    '      prompt: "verify the freshly packed native engine"',
+    '',
+  ].join('\n'));
+  run(process.execPath, ['--input-type=module', '--eval', [
+    "import { Nika } from '@supernovae-st/nika-client';",
+    'const nika = new Nika({ cwd: process.cwd() });',
+    "if (nika.transportKind !== 'native-process') process.exit(1);",
+    "const report = await nika.check('packed-release-smoke.nika.yaml');",
+    'if (report.clean !== true || report.exitCode !== 0) process.exit(2);',
+  ].join(' ')], { cwd: project });
+
+  const cli = path.join(project, 'node_modules/.bin/nika');
+  const identityResult = run(cli, ['--sdk-identity'], { cwd: project });
+  let identity;
+  try {
+    identity = JSON.parse(identityResult.stdout.trim());
+  } catch (cause) {
+    throw new Error(`packed CLI identity is not JSON: ${cause instanceof Error ? cause.message : cause}`);
+  }
+  if (identity.engineVersion !== expectedVersion) {
+    throw new Error(
+      `packed engine identity is ${String(identity.engineVersion)}, expected ${expectedVersion}`,
+    );
+  }
+
+  const versionResult = run(cli, ['--version'], { cwd: project });
+  if (!new RegExp(`^nika\\s+${escapeRegex(expectedVersion)}(?:\\s|$)`).test(versionResult.stdout)) {
+    throw new Error(`packed CLI --version did not identify nika ${expectedVersion}`);
+  }
+  console.log(
+    `Installed and executed packed SDK + ${nativePackageName} ${expectedVersion} at ${preparedCommit}`,
+  );
+} finally {
+  await rm(project, { recursive: true, force: true });
+}
+
+function run(command, args, options = {}) {
+  const env = { ...process.env };
+  delete env.NIKA_BIN;
+  const result = spawnSync(command, args, {
+    cwd: project,
+    env,
+    encoding: 'utf8',
+    timeout: 120_000,
+    ...options,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed: ${result.error?.message ?? result.stderr.trim()}`,
+    );
+  }
+  return result;
+}
+
+async function readJson(file) {
+  const value = JSON.parse(await readFile(file, 'utf8'));
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${file} does not contain an object`);
+  }
+  return value;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/test/native-package-build.test.ts
+++ b/test/native-package-build.test.ts
@@ -1,0 +1,123 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const SCRIPT = path.join(ROOT, 'scripts/build-native-package.mjs');
+const VERSION = '0.116.0';
+const SOURCE_COMMIT = 'e'.repeat(40);
+const ARCHIVE_SHA = 'c'.repeat(64);
+const scratch: string[] = [];
+
+afterEach(() => {
+  for (const directory of scratch.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('native payload construction', () => {
+  it('writes source and integrity metadata for the canonical target', () => {
+    const fixture = createFixture(62);
+    const result = build(fixture, `nika-linux-x64-${VERSION}.tar.gz`);
+
+    expect(result.status).toBe(0);
+    expect(readJson(path.join(fixture.packageDir, 'SOURCE.json'))).toMatchObject({
+      commit: SOURCE_COMMIT,
+      releaseAsset: `nika-linux-x64-${VERSION}.tar.gz`,
+    });
+    expect(readJson(path.join(fixture.packageDir, 'INTEGRITY.json'))).toMatchObject({
+      algorithm: 'sha256',
+      os: 'linux',
+      cpu: 'x64',
+      libc: 'glibc',
+      archive: { sha256: ARCHIVE_SHA },
+    });
+  });
+
+  it('refuses a release asset that does not belong to the package target', () => {
+    const fixture = createFixture(62);
+    const result = build(fixture, `nika-linux-arm64-${VERSION}.tar.gz`);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('must be built from nika-linux-x64');
+  });
+
+  it('refuses a binary architecture that does not match the package target', () => {
+    const fixture = createFixture(183);
+    const result = build(fixture, `nika-linux-x64-${VERSION}.tar.gz`);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('expected linux-x64');
+  });
+
+  it('refuses a matching 64-byte header that is not an executable image', () => {
+    const fixture = createFixture(62);
+    const header = Buffer.alloc(64);
+    header.set([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1]);
+    header.writeUInt16LE(62, 18);
+    writeFileSync(fixture.binary, header);
+    const result = build(fixture, `nika-linux-x64-${VERSION}.tar.gz`);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('does not describe a bounded executable image');
+  });
+});
+
+function createFixture(machine: number) {
+  const root = mkdtempSync(path.join(tmpdir(), 'nika-native-build-proof-'));
+  scratch.push(root);
+  const packageDir = path.join(root, 'packages/native/linux-x64-gnu');
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(path.join(root, 'package.json'), JSON.stringify({ version: VERSION }));
+  writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({
+    name: '@supernovae-st/nika-linux-x64',
+    version: VERSION,
+    os: ['linux'],
+    cpu: ['x64'],
+    libc: ['glibc'],
+  }));
+  const binary = path.join(root, 'nika');
+  const header = Buffer.alloc(256);
+  header.set([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1]);
+  header.writeUInt16LE(2, 16);
+  header.writeUInt16LE(machine, 18);
+  header.writeUInt32LE(1, 20);
+  header.writeBigUInt64LE(128n, 24);
+  header.writeBigUInt64LE(64n, 32);
+  header.writeUInt16LE(64, 52);
+  header.writeUInt16LE(56, 54);
+  header.writeUInt16LE(1, 56);
+  header.writeUInt32LE(1, 64);
+  header.writeUInt32LE(5, 68);
+  header.writeBigUInt64LE(0n, 72);
+  header.writeBigUInt64LE(0n, 80);
+  header.writeBigUInt64LE(BigInt(header.length), 96);
+  header.writeBigUInt64LE(BigInt(header.length), 104);
+  header.writeBigUInt64LE(4096n, 112);
+  header.write(`${VERSION} (${SOURCE_COMMIT.slice(0, 9)})`, 128, 'ascii');
+  writeFileSync(binary, header);
+  const license = path.join(root, 'LICENSE');
+  writeFileSync(license, 'AGPL fixture\n');
+  return { root, packageDir, binary, license };
+}
+
+function build(
+  fixture: ReturnType<typeof createFixture>,
+  asset: string,
+) {
+  return spawnSync(process.execPath, [
+    SCRIPT,
+    '--package', fixture.packageDir,
+    '--binary', fixture.binary,
+    '--license', fixture.license,
+    '--asset', asset,
+    '--asset-sha256', ARCHIVE_SHA,
+    '--source-commit', SOURCE_COMMIT,
+  ], { cwd: fixture.root, encoding: 'utf8' });
+}
+
+function readJson(file: string): unknown {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}

--- a/test/packed-release-install.test.ts
+++ b/test/packed-release-install.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const SCRIPT = path.join(ROOT, 'scripts/verify-packed-install.mjs');
+const VERSION = '0.116.0';
+const PREPARED_COMMIT = 'a'.repeat(40);
+const NATIVE_PACKAGE = nativePackageForHost();
+const scratch: string[] = [];
+
+afterEach(() => {
+  for (const directory of scratch.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('fresh packed release install', () => {
+  it('installs the two tarballs, imports the SDK, and executes the native CLI', () => {
+    const fixture = packedFixture(VERSION);
+    const result = verify(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`Installed and executed packed SDK + ${NATIVE_PACKAGE}`);
+  }, 30_000);
+
+  it('refuses a packed payload whose executable reports another engine version', () => {
+    const fixture = packedFixture('0.115.0');
+    const result = verify(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('packed engine identity is 0.115.0, expected 0.116.0');
+  }, 30_000);
+});
+
+function verify(fixture: { client: string; native: string }) {
+  return spawnSync(process.execPath, [
+    SCRIPT,
+    fixture.client,
+    fixture.native,
+    VERSION,
+    PREPARED_COMMIT,
+    NATIVE_PACKAGE,
+  ], { encoding: 'utf8', timeout: 30_000 });
+}
+
+function packedFixture(engineVersion: string): { client: string; native: string } {
+  const root = mkdtempSync(path.join(tmpdir(), 'nika-packed-install-proof-'));
+  scratch.push(root);
+  const clientRoot = path.join(root, 'client');
+  const nativeRoot = path.join(root, 'native');
+  const tarballs = path.join(root, 'tarballs');
+  mkdirSync(path.join(clientRoot, 'dist/bin'), { recursive: true });
+  mkdirSync(path.join(nativeRoot, 'bin'), { recursive: true });
+  mkdirSync(tarballs);
+
+  writeFileSync(path.join(clientRoot, 'package.json'), JSON.stringify({
+    name: '@supernovae-st/nika-client',
+    version: VERSION,
+    type: 'module',
+    exports: './dist/index.js',
+    bin: { nika: './dist/bin/nika.js' },
+    optionalDependencies: { [NATIVE_PACKAGE]: VERSION },
+    nikaRelease: { preparedCommit: PREPARED_COMMIT, version: VERSION },
+  }));
+  writeFileSync(path.join(clientRoot, 'dist/index.js'), [
+    'export class Nika {',
+    "  constructor() { this.transportKind = 'native-process'; }",
+    '  async check() { return { clean: true, exitCode: 0 }; }',
+    '}',
+    '',
+  ].join('\n'));
+  const shim = path.join(clientRoot, 'dist/bin/nika.js');
+  writeFileSync(shim, [
+    '#!/usr/bin/env node',
+    "import { spawnSync } from 'node:child_process';",
+    "import { createRequire } from 'node:module';",
+    "import path from 'node:path';",
+    'const require = createRequire(import.meta.url);',
+    `const manifest = require.resolve('${NATIVE_PACKAGE}/package.json');`,
+    "const result = spawnSync(path.join(path.dirname(manifest), 'bin/nika'), process.argv.slice(2),",
+    "  { stdio: 'inherit' });",
+    'process.exit(result.status ?? 1);',
+    '',
+  ].join('\n'));
+  chmodSync(shim, 0o755);
+
+  writeFileSync(path.join(nativeRoot, 'package.json'), JSON.stringify({
+    name: NATIVE_PACKAGE,
+    version: VERSION,
+    nikaRelease: { preparedCommit: PREPARED_COMMIT, version: VERSION },
+  }));
+  const binary = path.join(nativeRoot, 'bin/nika');
+  writeFileSync(binary, [
+    '#!/usr/bin/env node',
+    "if (process.argv[2] === '--sdk-identity') {",
+    `  console.log(JSON.stringify({ engineVersion: '${engineVersion}' }));`,
+    "} else if (process.argv[2] === '--version') {",
+    `  console.log('nika ${engineVersion} (fixture)');`,
+    '} else {',
+    '  process.exitCode = 2;',
+    '}',
+    '',
+  ].join('\n'));
+  chmodSync(binary, 0o755);
+
+  return {
+    client: pack(clientRoot, tarballs),
+    native: pack(nativeRoot, tarballs),
+  };
+}
+
+function pack(packageRoot: string, tarballs: string): string {
+  const output = execFileSync(
+    'npm',
+    ['pack', '--ignore-scripts', '--json', '--pack-destination', tarballs],
+    { cwd: packageRoot, encoding: 'utf8' },
+  );
+  const [{ filename }] = JSON.parse(output);
+  return path.join(tarballs, filename);
+}
+
+function nativePackageForHost(): string {
+  const name = ({
+    'darwin-arm64': '@supernovae-st/nika-darwin-arm64',
+    'darwin-x64': '@supernovae-st/nika-darwin-x64',
+    'linux-arm64': '@supernovae-st/nika-linux-arm64',
+    'linux-x64': '@supernovae-st/nika-linux-x64',
+  } as Record<string, string>)[`${process.platform}-${process.arch}`];
+  if (!name) throw new Error(`unsupported test host ${process.platform}-${process.arch}`);
+  return name;
+}

--- a/test/release-pack-verification.test.ts
+++ b/test/release-pack-verification.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -8,6 +9,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const roots: string[] = [];
 const sha = 'a'.repeat(40);
+const engineSha = 'e'.repeat(40);
 const version = '0.116.0';
 
 afterEach(() => {
@@ -71,3 +73,177 @@ describe('packed release commit proof', () => {
     expect(result.stderr.toString()).toContain('packed release metadata');
   });
 });
+
+describe('packed native release proof', () => {
+  it('binds the package, source, release checksum, executable checksum, and architecture', () => {
+    const packed = nativeFixture();
+    expect(() => verifyNative(packed)).not.toThrow();
+  });
+
+  it('refuses executable bytes changed after INTEGRITY.json was written', () => {
+    const packed = nativeFixture({ executableSha: 'f'.repeat(64) });
+    const result = verifyNativeResult(packed);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('executable checksum does not match');
+  });
+
+  it('refuses SOURCE.json bound to another engine commit', () => {
+    const packed = nativeFixture({ sourceCommit: 'b'.repeat(40) });
+    const result = verifyNativeResult(packed);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('SOURCE.json commit');
+  });
+
+  it('refuses archive metadata that differs from release SHA256SUMS', () => {
+    const packed = nativeFixture({ integrityArchiveSha: 'd'.repeat(64) });
+    const result = verifyNativeResult(packed);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('archive does not match SHA256SUMS');
+  });
+
+  it('refuses an ARM64 executable inside the Linux x64 package', () => {
+    const packed = nativeFixture({ elfMachine: 183 });
+    const result = verifyNativeResult(packed);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('expected linux-x64');
+  });
+
+  it('refuses a previous-version executable with the correct architecture', () => {
+    const packed = nativeFixture({ identityVersion: '0.115.0' });
+    const result = verifyNativeResult(packed);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('expected exactly 0.116.0');
+  });
+
+  it('refuses a stale executable with the expected identity appended as an overlay', () => {
+    const packed = nativeFixture({
+      identityVersion: '0.115.0',
+      appendedIdentity: `0.116.0 (${engineSha.slice(0, 9)})`,
+    });
+    const result = verifyNativeResult(packed);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('expected exactly 0.116.0');
+  });
+});
+
+interface NativeFixtureOptions {
+  executableSha?: string;
+  sourceCommit?: string;
+  integrityArchiveSha?: string;
+  elfMachine?: number;
+  identityVersion?: string;
+  appendedIdentity?: string;
+}
+
+function nativeFixture(options: NativeFixtureOptions = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'nika-native-pack-proof-'));
+  roots.push(root);
+  const packageRoot = path.join(root, 'package');
+  const tarballs = path.join(root, 'tarballs');
+  const binDirectory = path.join(packageRoot, 'bin');
+  mkdirSync(binDirectory, { recursive: true });
+  mkdirSync(tarballs);
+
+  const packageName = '@supernovae-st/nika-linux-x64';
+  const asset = `nika-linux-x64-${version}.tar.gz`;
+  const archiveSha = 'c'.repeat(64);
+  const baseBinary = elf64(options.elfMachine ?? 62, options.identityVersion ?? version);
+  const binary = options.appendedIdentity
+    ? Buffer.concat([baseBinary, Buffer.from(options.appendedIdentity, 'ascii')])
+    : baseBinary;
+  const executableSha = createHash('sha256').update(binary).digest('hex');
+  writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({
+    name: packageName,
+    version,
+    os: ['linux'],
+    cpu: ['x64'],
+    libc: ['glibc'],
+    nikaRelease: { preparedCommit: sha, version },
+  }));
+  const executable = path.join(binDirectory, 'nika');
+  writeFileSync(executable, binary);
+  chmodSync(executable, 0o755);
+  writeFileSync(path.join(packageRoot, 'LICENSE'), 'AGPL fixture\n');
+  writeFileSync(path.join(packageRoot, 'SOURCE.json'), JSON.stringify({
+    repository: 'https://github.com/supernovae-st/nika',
+    tag: `v${version}`,
+    commit: options.sourceCommit ?? engineSha,
+    releaseAsset: asset,
+    sourceArchive: `https://github.com/supernovae-st/nika/archive/refs/tags/v${version}.tar.gz`,
+  }));
+  writeFileSync(path.join(packageRoot, 'INTEGRITY.json'), JSON.stringify({
+    algorithm: 'sha256',
+    os: 'linux',
+    cpu: 'x64',
+    libc: 'glibc',
+    archive: { file: asset, sha256: options.integrityArchiveSha ?? archiveSha },
+    executable: { file: 'bin/nika', sha256: options.executableSha ?? executableSha },
+  }));
+
+  const filename = 'supernovae-st-nika-linux-x64-0.116.0.tgz';
+  execFileSync('tar', ['-czf', path.join(tarballs, filename), '-C', root, 'package']);
+  const report = path.join(root, 'pack.json');
+  writeFileSync(report, JSON.stringify([{
+    name: packageName,
+    version,
+    filename,
+    files: [
+      { path: 'package.json', mode: 0o644 },
+      { path: 'bin/nika', mode: 0o755 },
+      { path: 'LICENSE', mode: 0o644 },
+      { path: 'SOURCE.json', mode: 0o644 },
+      { path: 'INTEGRITY.json', mode: 0o644 },
+    ],
+  }]));
+  const checksums = path.join(root, 'SHA256SUMS');
+  writeFileSync(checksums, `${archiveSha}  ${asset}\n`);
+  return { report, tarballs, checksums };
+}
+
+function verifyNative(packed: ReturnType<typeof nativeFixture>): void {
+  execFileSync(process.execPath, nativeArgs(packed));
+}
+
+function verifyNativeResult(packed: ReturnType<typeof nativeFixture>) {
+  return spawnSync(process.execPath, nativeArgs(packed));
+}
+
+function nativeArgs(packed: ReturnType<typeof nativeFixture>): string[] {
+  return [
+    path.join(repo, 'scripts/verify-native-pack.mjs'),
+    packed.report,
+    packed.tarballs,
+    sha,
+    version,
+    engineSha,
+    packed.checksums,
+  ];
+}
+
+function elf64(machine: number, identityVersion: string): Buffer {
+  const header = Buffer.alloc(256);
+  header.set([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1]);
+  header.writeUInt16LE(2, 16);
+  header.writeUInt16LE(machine, 18);
+  header.writeUInt32LE(1, 20);
+  header.writeBigUInt64LE(128n, 24);
+  header.writeBigUInt64LE(64n, 32);
+  header.writeUInt16LE(64, 52);
+  header.writeUInt16LE(56, 54);
+  header.writeUInt16LE(1, 56);
+  header.writeUInt32LE(1, 64);
+  header.writeUInt32LE(5, 68);
+  header.writeBigUInt64LE(0n, 72);
+  header.writeBigUInt64LE(0n, 80);
+  header.writeBigUInt64LE(BigInt(header.length), 96);
+  header.writeBigUInt64LE(BigInt(header.length), 104);
+  header.writeBigUInt64LE(4096n, 112);
+  header.write(`${identityVersion} (${engineSha.slice(0, 9)})`, 128, 'ascii');
+  return header;
+}

--- a/test/release-stamp.test.ts
+++ b/test/release-stamp.test.ts
@@ -89,6 +89,26 @@ describe('release commit stamping', () => {
     expect(packStep).not.toContain('"$prepared_sha"');
   });
 
+  it('binds release coverage, native proof, and packed execution to engine artifacts', () => {
+    const workflow = readFileSync(path.join(ROOT, '.github/workflows/release.yml'), 'utf8');
+
+    expect(workflow).toContain('cargo test --manifest-path nika-source/Cargo.toml');
+    expect(workflow).toContain('npm run check:coverage');
+    expect(workflow).toContain('gh attestation verify "$asset" --repo supernovae-st/nika');
+    expect(workflow).toContain('engine_commit=$(git -C nika-source rev-parse HEAD)');
+    expect(workflow).toContain('"$engine_commit" engine-assets/SHA256SUMS');
+    expect(workflow).toContain('scripts/verify-packed-install.mjs');
+    for (const target of [
+      'ubuntu-24.04',
+      'ubuntu-24.04-arm',
+      'macos-15-intel',
+      'macos-15',
+    ]) {
+      expect(workflow).toContain(`runner: ${target}`);
+    }
+    expect(workflow).toContain('needs: [prepare, verify-native-runtime]');
+  });
+
   it.each([
     ['CI type drift', '.github/workflows/ci.yml',
       '      - name: Type drift (against live nika serve)\n',


### PR DESCRIPTION
## Summary

- run the tagged engine's semantic `nika-serve` OpenAPI tests before checking SDK coverage and comparing the released binary's exact live contract
- require GitHub build-provenance attestations and `SHA256SUMS` for all four engine assets
- validate native package matrix, source metadata, release checksum, packed executable checksum, ELF/Mach-O architecture and embedded engine identity
- install the freshly packed SDK plus native payload on matching Linux x64, Linux arm64, macOS Intel and macOS arm64 runners
- execute a real SDK `Nika.check()`, CLI `--sdk-identity` and CLI `--version` on every native runner before npm staging can start

## Adversarial coverage

- rejects a matching 64-byte fake ELF header
- rejects wrong asset/package and CPU mappings
- rejects changed executable bytes, changed release checksums and changed source commit metadata
- rejects a valid stale executable and the stale-plus-appended-current-marker mutation
- `stage` now needs the complete four-platform runtime matrix

## Verification

- `npm test` — 12 files, 137 tests passed
- focused release suite — 5 files, 23 tests passed
- `npm run build`
- `npx tsc --noEmit`
- `npm run check:coverage`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `actionlint .github/workflows/release.yml`
- tagged engine source: 2/2 `server::openapi::tests` passed
- existing v0.116.0 engine assets: 4/4 GitHub attestations verified, 4/4 checksums verified, 4/4 native packages rebuilt and inspected
- real packed macOS arm64 consumer: install, `Nika.check()`, identity and version passed
- independent adversarial refuter: `SURVIVED` with high confidence

No version bump, tag or npm publication is included.
