### PR TITLE
fix(sdk): observe remote runs without a local engine + settle observation exhaustion durably

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,12 @@ in for `cancel(run)`.
 
 Remote admission is bytes-first: the local compatible engine captures an
 immutable execution snapshot, then the SDK sends those exact bytes to the
-authenticated server. A remote client therefore still needs a local `nika`
-binary through `bin`, `NIKA_BIN`, or the exact optional platform package.
+authenticated server. Capturing those snapshots for `check` and `run`
+therefore still needs a local `nika` binary through `bin`, `NIKA_BIN`, or the
+exact optional platform package, resolved lazily at capture time.
+Observation-only clients need no local engine: `attachRun`, `status`,
+`events`, `cancel`, `schedule`, `scheduleStatus`, `listWorkflows`, `workflow`,
+and `traceVerify` run against the advertised server identity alone.
 
 The current persistent server requires a project file. A minimal `nika.yaml`
 is enough:

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ idempotency namespace spans the server's entire `state-root` and currently has
 no TTL; use globally unique business keys and do not recycle them between
 workflows.
 
+When observation loses connectivity past its retry budget, the SDK performs
+one final durable read before giving up: a terminal record settles `run.done`
+from the workflow's truth, and a still-running record rejects with
+`NikaObservationInterrupted`, whose `lastSequence` feeds
+`attachRun(id, { lastEventId })` to resume.
+
 Plain HTTP is refused unless `allowInsecureHttp: true` is explicit. Use HTTPS
 for a non-loopback deployment. A URL may not contain credentials, a query, or a
 fragment, and a 32–512 byte visible-ASCII token is mandatory.
@@ -323,7 +329,8 @@ Every SDK error extends `NikaError`:
 NikaError
 ├── NikaConfigurationError
 ├── NikaTransportError
-│   └── NikaProtocolError
+│   ├── NikaProtocolError
+│   └── NikaObservationInterrupted
 ├── NikaCompatibilityError
 ├── NikaOperationError
 ├── NikaEventBufferOverflowError

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,9 +27,10 @@ local nika process         authenticated nika serve
 - `src/lib/native-process-transport.ts` is the local Adapter. It spawns the
   selected engine without a shell and consumes newline-delimited machine
   events.
-- `src/lib/http-transport.ts` is the remote Adapter. It verifies local and
-  remote engine identities, captures immutable snapshot bytes locally, then
-  uses the authenticated HTTP contract.
+- `src/lib/http-transport.ts` is the remote Adapter. It verifies the remote
+  server identity once per client, resolves and verifies a local engine only
+  for caller-owned snapshot capture, then uses the authenticated HTTP
+  contract.
 - `src/lib/run-session.ts` is the lifecycle Seam. It owns the eager event
   pump, bounded independent observers, cancellation memoization, and the sole
   terminal `run.done` settlement.
@@ -50,6 +51,8 @@ Some operations deliberately have one authority:
   `NikaCompatibilityError`;
 - remote execution still needs a compatible local engine to capture an
   immutable snapshot before any network admission;
+- HTTP observation (attach, durable status, events, cancel, workflow catalog,
+  schedule status, trace verdicts) needs no local engine;
 - remote trace verification currently returns the engine's typed unavailable
   verdict because the server has no path-free journal authority.
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -52,6 +52,33 @@ export class NikaProtocolError extends NikaTransportError {
   }
 }
 
+/**
+ * Observation broke before terminal settlement and the final durable read
+ * stayed non-terminal. The cursor feeds attachRun(id, { lastEventId }).
+ */
+export class NikaObservationInterrupted extends NikaTransportError {
+  readonly runId: string;
+  readonly lastSequence: number;
+  readonly attempts: number;
+
+  constructor(
+    transport: NikaTransportKind,
+    runId: string,
+    lastSequence: number,
+    attempts: number,
+  ) {
+    super(
+      transport,
+      `HTTP observation interrupted after ${attempts} retries; `
+      + `run ${runId} last acknowledged sequence ${lastSequence}`,
+    );
+    this.name = 'NikaObservationInterrupted';
+    this.runId = runId;
+    this.lastSequence = lastSequence;
+    this.attempts = attempts;
+  }
+}
+
 /** One taxonomy for engine refusals returned by an SDK operation. */
 export class NikaOperationError extends NikaError {
   readonly operation: NikaOperation;

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,10 @@ export class Nika {
           'requestTimeout',
         ),
         machineBufferBytes,
-        engine: resolveNikaEngine(config.bin),
+        // Lazy: HTTP observation needs no local engine. Resolution (and its
+        // typed NikaEngineUnavailable refusal) is deferred to caller-owned
+        // source capture in check/run.
+        resolveEngine: () => resolveNikaEngine(config.bin),
         cwd: config.cwd,
       });
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ export {
   NikaConfigurationError,
   NikaError,
   NikaEventBufferOverflowError,
+  NikaObservationInterrupted,
   NikaOperationError,
   NikaProtocolError,
   NikaRunOwnershipError,

--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -40,7 +40,7 @@ export interface HttpTransportOptions {
   fetch: typeof globalThis.fetch;
   requestTimeout: number;
   machineBufferBytes: number;
-  engine: ResolvedNikaEngine;
+  resolveEngine: () => ResolvedNikaEngine;
   cwd?: string;
   retryDelay?: (milliseconds: number, signal: AbortSignal) => Promise<void>;
 }
@@ -96,7 +96,9 @@ const RETRY_MAX_MILLISECONDS = 5_000;
 
 export class HttpTransport implements Transport {
   readonly kind = 'http' as const;
-  private ready?: Promise<NikaEngineIdentity>;
+  private serverIdentity?: Promise<NikaEngineIdentity>;
+  private localIdentity?: Promise<NikaEngineIdentity>;
+  private resolvedEngine?: ResolvedNikaEngine;
   private remoteIdentity?: NikaEngineIdentity;
 
   constructor(private readonly options: HttpTransportOptions) {}
@@ -177,7 +179,7 @@ export class HttpTransport implements Transport {
   }
 
   async attachRun(id: string, options: NikaAttachRunOptions): Promise<TransportRun> {
-    await this.ensureReady();
+    await this.ensureServerIdentity();
     const object = await this.json(`/v1/jobs/${encodeURIComponent(id)}`, {
       method: 'GET',
       headers: { Accept: 'application/json' },
@@ -187,7 +189,7 @@ export class HttpTransport implements Transport {
   }
 
   async listWorkflows(): Promise<readonly string[]> {
-    await this.ensureReady();
+    await this.ensureServerIdentity();
     const object = await this.json('/v1/workflows', {
       method: 'GET',
       headers: { Accept: 'application/json' },
@@ -204,7 +206,7 @@ export class HttpTransport implements Transport {
   }
 
   async workflow(name: string): Promise<NikaWorkflowMetadata> {
-    await this.ensureReady();
+    await this.ensureServerIdentity();
     const object = await this.json(`/v1/workflows/${workflowPath(name)}`, {
       method: 'GET',
       headers: { Accept: 'application/json' },
@@ -263,7 +265,7 @@ export class HttpTransport implements Transport {
     receipt: NikaReceipt,
     options: NikaTraceVerifyOptions,
   ): Promise<NikaTraceVerifyResult> {
-    await this.ensureReady();
+    await this.ensureServerIdentity();
     const jobId = receipt.job_id;
     if (typeof jobId !== 'string' || jobId.length === 0) {
       throw this.gap('traceVerify', 'The engine receipt does not carry a remote job_id');
@@ -794,15 +796,12 @@ export class HttpTransport implements Transport {
     return new NikaCompatibilityError(capability, this.kind, message);
   }
 
-  private ensureReady(): Promise<NikaEngineIdentity> {
-    this.ready ??= this.verifyIdentities();
-    return this.ready;
+  private ensureServerIdentity(): Promise<NikaEngineIdentity> {
+    this.serverIdentity ??= this.probeServerIdentity();
+    return this.serverIdentity;
   }
 
-  private async verifyIdentities(): Promise<NikaEngineIdentity> {
-    // Verify local package integrity first: a modified capture engine must not
-    // reach even the remote liveness probe.
-    const local = await verifyNikaEngine(this.options.engine);
+  private async probeServerIdentity(): Promise<NikaEngineIdentity> {
     const health = await this.json('/health', { method: 'GET' }, false);
     if (health.status !== 'ok' || health.service !== 'nika-serve') {
       throw new NikaCompatibilityError(
@@ -811,12 +810,33 @@ export class HttpTransport implements Transport {
         'GET /health did not identify a live nika-serve engine',
       );
     }
-    this.remoteIdentity = compatibleEngineIdentity(health, this.kind, local);
+    // Server-only comparison: the advertised identity must satisfy the SDK's
+    // expected protocol vector without any local engine involvement.
+    this.remoteIdentity = compatibleEngineIdentity(health, this.kind);
+    return this.remoteIdentity;
+  }
+
+  private ensureLocalEngine(): Promise<NikaEngineIdentity> {
+    this.localIdentity ??= this.verifyLocalEngine();
+    return this.localIdentity;
+  }
+
+  private localEngine(): ResolvedNikaEngine {
+    this.resolvedEngine ??= this.options.resolveEngine();
+    return this.resolvedEngine;
+  }
+
+  private async verifyLocalEngine(): Promise<NikaEngineIdentity> {
+    // Verify local package integrity first: a modified capture engine must not
+    // reach even the remote liveness probe.
+    const local = await verifyNikaEngine(this.localEngine());
+    const remote = await this.ensureServerIdentity();
+    compatibleEngineIdentity(remote, this.kind, local);
     return local;
   }
 
   private async ensureScheduleCapability(): Promise<void> {
-    await this.ensureReady();
+    await this.ensureServerIdentity();
     if (!this.remoteIdentity?.supportedCapabilities.includes('schedule')) {
       throw this.gap(
         'schedule',
@@ -829,9 +849,9 @@ export class HttpTransport implements Transport {
     workflow: string,
     signal?: AbortSignal,
   ): Promise<CapturedSnapshot> {
-    const identity = await this.ensureReady();
+    const identity = await this.ensureLocalEngine();
     const captured = await captureEngine(
-      this.options.engine.bin,
+      this.localEngine().bin,
       ['check', workflow, '--json', '--sdk-snapshot'],
       {
         cwd: this.options.cwd,

--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import {
   NikaCompatibilityError,
+  NikaObservationInterrupted,
   NikaOperationError,
   NikaProtocolError,
   NikaTransportError,
@@ -78,6 +79,12 @@ interface DurableJob {
 interface RetryObservation {
   retry: true;
   retryAfterMilliseconds?: number;
+}
+
+interface ObservationSettlement {
+  jobPath: string;
+  id: string;
+  settle: (source: NikaEvent | DurableJob) => void;
 }
 
 const JOB_STATUSES = new Set([
@@ -424,6 +431,7 @@ export class HttpTransport implements Transport {
     };
     const jobPath = `/v1/jobs/${encodeURIComponent(id)}`;
     const eventsPath = `/v1/jobs/${encodeURIComponent(id)}/events`;
+    const settlement: ObservationSettlement = { jobPath, id, settle };
 
     while (!state.terminalObserved) {
       const headers = new Headers({ Accept: 'text/event-stream' });
@@ -435,7 +443,7 @@ export class HttpTransport implements Transport {
       } catch {
         await this.retryObservation(state, signal, {
           retry: true,
-        });
+        }, settlement);
         continue;
       }
 
@@ -443,7 +451,7 @@ export class HttpTransport implements Transport {
         await discardResponse(response);
         const durable = await this.inspectDurableJob(jobPath, id, signal);
         if (isRetryObservation(durable)) {
-          await this.retryObservation(state, signal, durable);
+          await this.retryObservation(state, signal, durable, settlement);
           continue;
         }
         if (isTerminal(durable.status)) {
@@ -451,7 +459,7 @@ export class HttpTransport implements Transport {
           settle(durable);
           return;
         }
-        await this.retryObservation(state, signal, { retry: true });
+        await this.retryObservation(state, signal, { retry: true }, settlement);
         continue;
       }
 
@@ -461,7 +469,7 @@ export class HttpTransport implements Transport {
         await this.retryObservation(state, signal, {
           retry: true,
           ...(retryAfterMilliseconds !== undefined ? { retryAfterMilliseconds } : {}),
-        });
+        }, settlement);
         continue;
       }
 
@@ -515,7 +523,7 @@ export class HttpTransport implements Transport {
 
       const durable = await this.inspectDurableJob(jobPath, id, signal);
       if (isRetryObservation(durable)) {
-        await this.retryObservation(state, signal, durable);
+        await this.retryObservation(state, signal, durable, settlement);
         continue;
       }
       if (isTerminal(durable.status)) {
@@ -523,7 +531,7 @@ export class HttpTransport implements Transport {
         settle(durable);
         return;
       }
-      await this.retryObservation(state, signal, { retry: true });
+      await this.retryObservation(state, signal, { retry: true }, settlement);
     }
   }
 
@@ -766,11 +774,27 @@ export class HttpTransport implements Transport {
     state: ObservationState,
     signal: AbortSignal,
     retry: RetryObservation,
+    settlement: ObservationSettlement,
   ): Promise<void> {
     if (state.attempt >= MAX_OBSERVATION_RETRIES) {
-      throw new NikaTransportError(
+      // Exhaustion is a settlement question, not an error by itself: the
+      // durable record is the workflow's truth, so one final read wins over
+      // observer connectivity. Only a still non-terminal record interrupts.
+      const durable = await this.inspectDurableJob(
+        settlement.jobPath,
+        settlement.id,
+        signal,
+      );
+      if (!isRetryObservation(durable) && isTerminal(durable.status)) {
+        state.terminalObserved = true;
+        settlement.settle(durable);
+        return;
+      }
+      throw new NikaObservationInterrupted(
         this.kind,
-        `HTTP observation exhausted ${MAX_OBSERVATION_RETRIES} retries`,
+        settlement.id,
+        state.lastSequence,
+        state.attempt,
       );
     }
     state.attempt += 1;

--- a/test/http-depth-contract.test.ts
+++ b/test/http-depth-contract.test.ts
@@ -30,7 +30,7 @@ function transport(
     fetch,
     requestTimeout: options.requestTimeout ?? 1_000,
     machineBufferBytes: options.machineBufferBytes ?? 64 * 1024,
-    engine: resolveNikaEngine(HTTP_DEPTH_FIXTURE),
+    resolveEngine: () => resolveNikaEngine(HTTP_DEPTH_FIXTURE),
     retryDelay: async () => {},
   });
 }

--- a/test/http-depth-lifecycle.test.ts
+++ b/test/http-depth-lifecycle.test.ts
@@ -61,7 +61,7 @@ function transport(
     fetch,
     requestTimeout: options.requestTimeout ?? 1_000,
     machineBufferBytes: options.machineBufferBytes ?? 64 * 1024,
-    engine: resolveNikaEngine(HTTP_DEPTH_FIXTURE),
+    resolveEngine: () => resolveNikaEngine(HTTP_DEPTH_FIXTURE),
     retryDelay: async () => {},
   });
 }

--- a/test/http-sse.test.ts
+++ b/test/http-sse.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { Nika, NikaProtocolError, NikaTransportError } from '../src/index.js';
-import { resolveNikaEngine } from '../src/lib/binary/index.js';
+import { NikaEngineUnavailable, resolveNikaEngine } from '../src/lib/binary/index.js';
 import { HttpTransport } from '../src/lib/http-transport.js';
 import { SseParseError, SseParser } from '../src/lib/sse/parser.js';
 import type { NikaEvent } from '../src/types.js';
@@ -72,7 +72,7 @@ function transport(
     fetch,
     requestTimeout: 1_000,
     machineBufferBytes: 64 * 1024,
-    engine: resolveNikaEngine(FIXTURE),
+    resolveEngine: () => resolveNikaEngine(FIXTURE),
     retryDelay: async (milliseconds) => {
       delays.push(milliseconds);
     },
@@ -334,5 +334,53 @@ describe('HTTP observation state machine', () => {
     await expect(source.done).rejects.not.toThrow(/server-token/);
     expect(delays).toHaveLength(5);
     expect(fetch).toHaveBeenCalledTimes(8);
+  });
+});
+
+describe('HTTP engine resolution boundary', () => {
+  function lazyTransport(
+    fetch: ReturnType<typeof vi.fn>,
+    resolveEngine: () => ReturnType<typeof resolveNikaEngine>,
+  ): HttpTransport {
+    return new HttpTransport({
+      url: 'https://nika.example',
+      token: SERVER_TOKEN,
+      fetch: fetch as typeof globalThis.fetch,
+      requestTimeout: 1_000,
+      machineBufferBytes: 64 * 1024,
+      resolveEngine,
+      retryDelay: async () => {},
+    });
+  }
+
+  it('resolves the local engine only for caller-owned source capture', async () => {
+    const resolveEngine = vi.fn(() => resolveNikaEngine(FIXTURE));
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ workflows: ['flow.nika.yaml'] }))
+      .mockResolvedValueOnce(jsonResponse({
+        status: 'accepted',
+        snapshot_digest: 'a'.repeat(64),
+        root: 'fixture.nika.yaml',
+        units: 1,
+      }));
+    const transport = lazyTransport(fetch, resolveEngine);
+    await expect(transport.listWorkflows()).resolves.toEqual(['flow.nika.yaml']);
+    expect(resolveEngine).not.toHaveBeenCalled();
+    await expect(transport.check('flow.nika.yaml', {}))
+      .resolves.toMatchObject({ clean: true });
+    expect(resolveEngine).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers the typed engine-unavailable refusal to capture time', async () => {
+    const fetch = vi.fn();
+    const transport = lazyTransport(fetch, () => {
+      throw new NikaEngineUnavailable('darwin', 'arm64', '@supernovae-st/nika-darwin-arm64');
+    });
+    await expect(transport.check('flow.nika.yaml', {}))
+      .rejects.toBeInstanceOf(NikaEngineUnavailable);
+    await expect(transport.startRun('flow.nika.yaml', {}))
+      .rejects.toBeInstanceOf(NikaEngineUnavailable);
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/test/http-sse.test.ts
+++ b/test/http-sse.test.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
-import { Nika, NikaProtocolError, NikaTransportError } from '../src/index.js';
+import {
+  Nika,
+  NikaObservationInterrupted,
+  NikaProtocolError,
+  NikaTransportError,
+} from '../src/index.js';
 import { NikaEngineUnavailable, resolveNikaEngine } from '../src/lib/binary/index.js';
 import { HttpTransport } from '../src/lib/http-transport.js';
 import { SseParseError, SseParser } from '../src/lib/sse/parser.js';
@@ -328,12 +333,86 @@ describe('HTTP observation state machine', () => {
     const delays: number[] = [];
     const fetch = admittedFetch(
       ...Array.from({ length: 6 }, () => new TypeError('reset server-token')),
+      jsonResponse({ id: 'job-1', status: 'running' }),
     );
     const { source, events } = await startObserved(fetch, delays);
-    await expect(events).rejects.toThrow(/exhausted 5 retries/);
+    await expect(events).rejects.toBeInstanceOf(NikaObservationInterrupted);
+    await expect(source.done).rejects.toBeInstanceOf(NikaObservationInterrupted);
     await expect(source.done).rejects.not.toThrow(/server-token/);
     expect(delays).toHaveLength(5);
-    expect(fetch).toHaveBeenCalledTimes(8);
+    expect(fetch).toHaveBeenCalledTimes(9);
+  });
+
+  it('settles done from a final durable read when observation exhausts', async () => {
+    const fetch = admittedFetch(
+      ...Array.from({ length: 6 }, () => new TypeError('connection reset')),
+      jsonResponse({
+        id: 'job-1',
+        status: 'succeeded',
+        execution_id: 'exe-1',
+        trace_id: 'trace-1',
+      }),
+    );
+    const { source, events } = await startObserved(fetch);
+    await expect(events).resolves.toEqual([]);
+    await expect(source.done).resolves.toMatchObject({
+      id: 'job-1',
+      status: 'succeeded',
+      execution_id: 'exe-1',
+      trace_id: 'trace-1',
+    });
+    expect(String(fetch.mock.calls[8]?.[0])).toBe('https://nika.example/v1/jobs/job-1');
+  });
+
+  it('interrupts with a resumable cursor when the final durable read stays non-terminal', async () => {
+    const one = { sequence: 1, kind: 'running', status: 'running' } as const;
+    const two = { sequence: 2, kind: 'settled', status: 'succeeded' } as const;
+    const delays: number[] = [];
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'queued' }, 202))
+      .mockResolvedValueOnce(sse(frame(one), true))
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'running' }))
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'running' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'running' }))
+      .mockResolvedValueOnce(sse(frame(two)));
+    const direct = transport(fetch as typeof globalThis.fetch, delays);
+    const source = await direct.startRun('flow.nika.yaml', {});
+    const events = collect(source.events);
+
+    await expect(events).rejects.toBeInstanceOf(NikaObservationInterrupted);
+    let failure: unknown;
+    try {
+      await source.done;
+    } catch (cause) {
+      failure = cause;
+    }
+    expect(failure).toBeInstanceOf(NikaObservationInterrupted);
+    expect(failure).toBeInstanceOf(NikaTransportError);
+    expect(failure).toMatchObject({
+      name: 'NikaObservationInterrupted',
+      transport: 'http',
+      runId: 'job-1',
+      lastSequence: 1,
+      attempts: 5,
+    });
+    expect(delays).toHaveLength(5);
+
+    const cursor = (failure as NikaObservationInterrupted).lastSequence;
+    const resumed = await direct.attachRun('job-1', { lastEventId: cursor });
+    const resumedEvents = collect(resumed.events);
+    await expect(resumed.done).resolves.toMatchObject({
+      id: 'job-1',
+      status: 'succeeded',
+    });
+    await expect(resumedEvents).resolves.toEqual([two]);
+    const resumeHeaders = new Headers(fetch.mock.calls[11]?.[1]?.headers);
+    expect(resumeHeaders.get('Last-Event-ID')).toBe('1');
   });
 });
 

--- a/test/one-sdk.test.ts
+++ b/test/one-sdk.test.ts
@@ -8,10 +8,12 @@ import {
   Nika,
   NikaCompatibilityError,
   NikaConfigurationError,
+  NikaEngineUnavailable,
   NikaEventBufferOverflowError,
   NikaOperationError,
   NikaRunOwnershipError,
 } from '../src/index.js';
+import { resolveNikaEngine } from '../src/lib/binary/index.js';
 import type {
   NikaEvent,
   NikaLocalConfig,
@@ -881,4 +883,184 @@ describe('HTTP transport', () => {
     expect(String(failure)).toContain('[REDACTED]');
     expect(String(failure)).not.toContain(SERVER_TOKEN);
   });
+});
+
+describe('remote observation without a local engine', () => {
+  const scheduleOptions: NikaScheduleOptions = {
+    id: 'daily',
+    when: { kind: 'cadence', expression: 'daily at 09:00 Europe/Paris' },
+    maxCostUsd: 0.25,
+    missed: 'catch-up-once',
+    maxLatenessSeconds: 3600,
+    overlap: 'skip',
+    afterSkip: 'next_slot',
+  };
+
+  const hostEngineUnavailable = (() => {
+    try {
+      resolveNikaEngine(undefined, { env: {} });
+      return false;
+    } catch (cause) {
+      if (cause instanceof NikaEngineUnavailable) return true;
+      throw cause;
+    }
+  })();
+
+  function withoutNikaBin(run: () => void): void {
+    const saved = process.env.NIKA_BIN;
+    delete process.env.NIKA_BIN;
+    try {
+      run();
+    } finally {
+      if (saved === undefined) delete process.env.NIKA_BIN;
+      else process.env.NIKA_BIN = saved;
+    }
+  }
+
+  it('constructs a remote observer without resolving any local engine', () => {
+    withoutNikaBin(() => {
+      const client = new Nika({
+        url: 'https://nika.example',
+        token: SERVER_TOKEN,
+        fetch: vi.fn() as typeof globalThis.fetch,
+      });
+      expect(client.transportKind).toBe('http');
+    });
+  });
+
+  it('runs every observer operation with zero local engine contact', async () => {
+    const status = scheduleProjection();
+    let lastEventId: string | null = null;
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/health') {
+        return healthResponse({
+          supportedCapabilities: [
+            'check',
+            'executionSnapshot',
+            'eventStream',
+            'trace',
+            'schedule',
+          ],
+        });
+      }
+      if (url.pathname === '/v1/workflows') {
+        return jsonResponse({ workflows: ['flow.nika.yaml'] });
+      }
+      if (url.pathname === '/v1/workflows/flow.nika.yaml') {
+        return jsonResponse({ workflow: 'flow.nika.yaml' });
+      }
+      if (url.pathname === '/v1/jobs/durable-job') {
+        return jsonResponse({ id: 'durable-job', status: 'running' });
+      }
+      if (url.pathname === '/v1/jobs/durable-job/events') {
+        lastEventId = new Headers(init?.headers).get('Last-Event-ID');
+        return sseResponse([{ sequence: 5, kind: 'settled', status: 'succeeded' }]);
+      }
+      if (url.pathname === '/v1/jobs/durable-job/status') {
+        return jsonResponse({ status: 'running' });
+      }
+      if (url.pathname === '/v1/jobs/durable-job/cancel') {
+        return jsonResponse({ id: 'durable-job', status: 'succeeded' });
+      }
+      if (url.pathname === '/v1/schedules/daily' && init?.method === 'PUT') {
+        return jsonResponse({ applied: true, changed: true, status });
+      }
+      if (url.pathname === '/v1/schedules/daily') return jsonResponse(status);
+      if (url.pathname === '/v1/jobs/job-1/trace/verify') {
+        return jsonResponse({
+          verdict: 'unavailable',
+          reason: 'trace_journal_unavailable',
+          trace_id: 'trace-remote',
+        });
+      }
+      throw new Error(`unexpected URL ${url.pathname}`);
+    });
+    // A bin that can never spawn: any local engine contact fails this test.
+    const client = new Nika({
+      url: 'https://nika.example',
+      token: SERVER_TOKEN,
+      bin: '/nonexistent/nika-engine',
+      fetch: fetch as typeof globalThis.fetch,
+    });
+
+    const run = await client.attachRun('durable-job', { lastEventId: 4 });
+    await expect(run.done).resolves.toMatchObject({
+      id: 'durable-job',
+      status: 'succeeded',
+      transport: 'http',
+    });
+    expect(lastEventId).toBe('4');
+    await expect(client.status(run)).resolves.toBe('running');
+    await expect(collect(client.events(run))).resolves.toEqual([
+      { sequence: 5, kind: 'settled', status: 'succeeded' },
+    ]);
+    await expect(client.cancel(run)).resolves.toMatchObject({
+      accepted: false,
+      status: 'already_settled',
+      transport: 'http',
+    });
+    await expect(client.listWorkflows()).resolves.toEqual(['flow.nika.yaml']);
+    await expect(client.workflow('flow.nika.yaml')).resolves.toEqual({
+      workflow: 'flow.nika.yaml',
+    });
+    await expect(client.schedule('flow.nika.yaml', scheduleOptions)).resolves.toEqual({
+      applied: true,
+      changed: true,
+      status,
+    });
+    await expect(client.scheduleStatus('daily')).resolves.toEqual(status);
+    await expect(client.traceVerify({ job_id: 'job-1', trace_id: 'trace-remote' }))
+      .resolves.toMatchObject({ verified: false, verdict: 'unavailable' });
+    expect(
+      fetch.mock.calls.filter(([url]) => String(url).endsWith('/health')),
+    ).toHaveLength(1);
+  });
+
+  it('gates caller-owned capture behind a verifiable local engine', async () => {
+    const fetch = vi.fn();
+    const client = new Nika({
+      url: 'https://nika.example',
+      token: SERVER_TOKEN,
+      bin: '/nonexistent/nika-engine',
+      fetch: fetch as typeof globalThis.fetch,
+    });
+    await expect(client.check('flow.nika.yaml')).rejects.toMatchObject({
+      name: 'NikaCompatibilityError',
+      capability: 'engineIdentity',
+    });
+    await expect(client.run('flow.nika.yaml')).rejects.toMatchObject({
+      name: 'NikaCompatibilityError',
+      capability: 'engineIdentity',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.runIf(hostEngineUnavailable)(
+    'refuses remote capture with the typed engine-unavailable error when no engine resolves',
+    async () => {
+      const saved = process.env.NIKA_BIN;
+      delete process.env.NIKA_BIN;
+      try {
+        const fetch = vi.fn();
+        const client = new Nika({
+          url: 'https://nika.example',
+          token: SERVER_TOKEN,
+          fetch: fetch as typeof globalThis.fetch,
+        });
+        await expect(client.check('flow.nika.yaml')).rejects.toMatchObject({
+          name: 'NikaEngineUnavailable',
+          code: 'NIKA_ENGINE_UNAVAILABLE',
+        });
+        await expect(client.run('flow.nika.yaml')).rejects.toMatchObject({
+          name: 'NikaEngineUnavailable',
+          code: 'NIKA_ENGINE_UNAVAILABLE',
+        });
+        expect(fetch).not.toHaveBeenCalled();
+      } finally {
+        if (saved === undefined) delete process.env.NIKA_BIN;
+        else process.env.NIKA_BIN = saved;
+      }
+    },
+  );
 });


### PR DESCRIPTION
Closes #59, closes #60.

Found by the Nika System Perfection Campaign socratic pass (evidence: monorepo `dx/state/gauntlet/2026-09-01-perfection/evidence/socratic-pass.md` Q11, Q14).

## #59 — HTTP observers no longer need a local engine

- `new Nika({ url, token })` no longer resolves a local engine at construction (lazy thunk, memoized).
- `ensureReady` split: `ensureServerIdentity` (`GET /health` + capability vector — attachRun, status, events, cancel, scheduleStatus, listWorkflows, workflow, traceVerify, remote schedule) vs `ensureLocalEngine` (resolve + integrity verify + capture — only `check`/`run` remote, which capture caller-owned bytes).
- The integrity-first ordering is preserved: a modified capture engine still never reaches even the liveness probe.
- README + `docs/architecture.md` updated to the new reality (capture needs the binary; observation does not).

## #60 — observation exhaustion settles through the durable record

- On retry exhaustion the observer performs one final durable `GET /v1/jobs/:id`: a terminal record settles `run.done` from the workflow's truth instead of rejecting.
- A still non-terminal record throws new typed `NikaObservationInterrupted` carrying `{ runId, lastSequence, attempts }`; the cursor feeds `attachRun(id, { lastEventId })`. RUN TRUTH and OBSERVER CONNECTIVITY are now distinguishable.
- Retry budget numbers unchanged (time-windowed observation is a separate design wave).

## Evidence

- `npm test` 175/175 (baseline 167; +8 regression tests incl. zero-engine-contact observer suite and durable-settlement/cursor-resume paths)
- `tsc --noEmit` clean · `npm run build` green · `npm run check:coverage` green
- ESM + CJS smoke: `Nika` and `NikaObservationInterrupted` both exported

🦋 Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
