### PR TITLE
test(gauntlet): pin the depth schedule pause bound to a fixed date

### DIFF
--- a/gauntlet/projects-depth/results.json
+++ b/gauntlet/projects-depth/results.json
@@ -93,7 +93,7 @@
       "stale_writer_error": {
         "name": "NikaOperationError",
         "code": "schedule_conflict",
-        "current_revision": "sha256:45dbd8366b654950031e6eed5bf1b926676ee8c95e6dcdd23f86041d3138d592"
+        "current_revision": "sha256:a26e0386afe7d36109bf516fb3c0f5c7c8e2220333fbb011f21e1ab473d51314"
       },
       "revision_survived_restart": true,
       "reconnect_event_sequences": [

--- a/gauntlet/projects-depth/scheduled-research-monitor/app.mjs
+++ b/gauntlet/projects-depth/scheduled-research-monitor/app.mjs
@@ -32,7 +32,10 @@ try {
   });
   assert.equal(created.applied, true);
   const originalRevision = created.status.revision;
-  const pauseUntil = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  // Fixed far-future civil date: the declaration feeds the schedule revision,
+  // so a wall-clock date would make the committed replay evidence go stale at
+  // every UTC midnight (#63).
+  const pauseUntil = '2099-01-01';
   const paused = await nika.schedule('workflow.nika.yaml', {
     id: 'research-six-hourly',
     when: { kind: 'cadence', expression: 'TZ=UTC 0 */6 * * *' },


### PR DESCRIPTION
Closes #63.

`scheduled-research-monitor/app.mjs` computed `pauseUntil = Date.now() + 24h`. Since `pause_until` feeds the schedule revision, the committed depth evidence went stale at every UTC midnight — `release-evidence-replay` went red on PR #62 for a change it did not make (reproduced locally on untouched main with the exact 0.116.2 public asset: `45dbd836…` ≠ `78a4e495…`).

- Pin `pauseUntil = '2099-01-01'` (the test only needs a valid future pause bound).
- Regenerate `gauntlet/projects-depth/results.json` with the exact 0.116.2 public asset — one-line diff (the revision hash), everything else byte-identical.
- Verified: fresh replay ≡ committed evidence under `stableDepthEvidence`; `npm test` 167/167.

Merge this before #62; #62 rebases onto it and its replay gate goes green.

🦋 Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
