### PR TITLE
fix(sdk): abort settles every internal promise — no stray ABORT_ERR rejection (#68)

### DIFF
--- a/test/abort-settlement.test.ts
+++ b/test/abort-settlement.test.ts
@@ -1,0 +1,189 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Nika, NikaObservationInterrupted } from '../src/index.js';
+import type { NikaEvent } from '../src/index.js';
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'fake-nika.mjs',
+);
+const posix = process.platform !== 'win32';
+const SERVER_TOKEN = 's'.repeat(32);
+
+// Issue #68: an abort path must settle every internal promise — a stray
+// rejection is a process-level event, so the suite listens for it directly.
+const stray: unknown[] = [];
+const onStray = (reason: unknown) => {
+  stray.push(reason);
+};
+
+function settle(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function healthResponse(): Response {
+  return new Response(JSON.stringify({
+    status: 'ok',
+    service: 'nika-serve',
+    engineVersion: '0.114.0',
+    machineProtocolVersion: 1,
+    snapshotFormatVersion: 1,
+    checkReportVersion: 1,
+    eventFormatVersion: 1,
+    traceFormatVersion: 1,
+    supportedCapabilities: ['check', 'executionSnapshot', 'eventStream', 'trace'],
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('abort settlement (issue #68)', () => {
+  beforeEach(() => {
+    stray.length = 0;
+    process.on('unhandledRejection', onStray);
+  });
+  afterEach(() => {
+    process.off('unhandledRejection', onStray);
+    expect(stray).toEqual([]);
+  });
+
+  describe.skipIf(!posix)('native-process transport', () => {
+    it('settles every internal promise when an events AbortSignal fires mid-run', async () => {
+      const client = new Nika({ bin: FIXTURE });
+      const run = await client.run('cancel.nika.yaml');
+      const controller = new AbortController();
+      const view = client.events(run, { signal: controller.signal });
+      let failure: unknown;
+      const iteration = (async () => {
+        try {
+          for await (const event of view) void event;
+        } catch (cause) {
+          failure = cause;
+        }
+      })();
+      setTimeout(() => controller.abort(), 50);
+      await iteration;
+      // The events signal is subscriber cleanup: the view ends gracefully.
+      expect(failure).toBeUndefined();
+      // run.done is deliberately never awaited — the webhook persona's shape.
+      await settle(300);
+    });
+
+    it('settles every internal promise when the caller cancels mid-run', async () => {
+      const client = new Nika({ bin: FIXTURE });
+      const run = await client.run('cancel.nika.yaml');
+      await expect(client.cancel(run)).resolves.toMatchObject({
+        runId: run.id,
+        accepted: true,
+        status: 'cancellation_requested',
+      });
+      // run.done is deliberately never awaited.
+      await settle(300);
+    });
+
+    it('settles every internal promise when a check AbortSignal fires mid-capture', async () => {
+      const client = new Nika({ bin: FIXTURE });
+      const controller = new AbortController();
+      const pending = client.check('hang.nika.yaml', { signal: controller.signal });
+      setTimeout(() => controller.abort(), 50);
+      await expect(pending).rejects.toMatchObject({
+        name: 'NikaTransportError',
+        message: expect.stringContaining('aborted'),
+      });
+      await settle(300);
+    });
+  });
+
+  describe('HTTP transport', () => {
+    it('settles every internal promise when an events AbortSignal fires mid-observation', async () => {
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith('/health')) return healthResponse();
+        if (url.endsWith('/v1/jobs/durable-job')) {
+          return jsonResponse({ id: 'durable-job', status: 'running' });
+        }
+        if (url.endsWith('/v1/jobs/durable-job/events')) {
+          const encoder = new TextEncoder();
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(encoder.encode(
+                `id: 5\ndata: ${JSON.stringify({ sequence: 5, kind: 'running', status: 'running' })}\n\n`,
+              ));
+              // The stream never closes: the abort lands mid-observation.
+            },
+          });
+          return new Response(stream, {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          });
+        }
+        throw new Error(`unexpected URL ${url}`);
+      });
+      const client = new Nika({
+        url: 'https://nika.example',
+        token: SERVER_TOKEN,
+        fetch: fetch as typeof globalThis.fetch,
+      });
+      const run = await client.attachRun('durable-job', { lastEventId: 4 });
+      const controller = new AbortController();
+      const collected: NikaEvent[] = [];
+      let failure: unknown;
+      const iteration = (async () => {
+        try {
+          for await (const event of client.events(run, { signal: controller.signal })) {
+            collected.push(event);
+          }
+        } catch (cause) {
+          failure = cause;
+        }
+      })();
+      setTimeout(() => controller.abort(), 100);
+      await iteration;
+      expect(failure).toBeUndefined();
+      expect(collected).toEqual([{ sequence: 5, kind: 'running', status: 'running' }]);
+      // run.done is deliberately never awaited.
+      await settle(300);
+    });
+
+    it('fails the terminal iterator error with runId and lastSequence for re-attach', async () => {
+      // Every observation request resets: observation exhausts its retry
+      // budget and the final durable read stays unreachable.
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.endsWith('/health')) return healthResponse();
+        if (url.endsWith('/v1/jobs/durable-job')) {
+          return jsonResponse({ id: 'durable-job', status: 'running' });
+        }
+        throw new TypeError('connection reset');
+      });
+      const client = new Nika({
+        url: 'https://nika.example',
+        token: SERVER_TOKEN,
+        fetch: fetch as typeof globalThis.fetch,
+      });
+      const run = await client.attachRun('durable-job', { lastEventId: 4 });
+      let failure: unknown;
+      try {
+        for await (const event of client.events(run)) void event;
+      } catch (cause) {
+        failure = cause;
+      }
+      expect(failure).toBeInstanceOf(NikaObservationInterrupted);
+      expect(failure).toMatchObject({
+        transport: 'http',
+        runId: 'durable-job',
+        lastSequence: 4,
+      });
+      // run.done is deliberately never awaited: its rejection is settled by
+      // the session, never leaked to the process.
+      await settle(300);
+    }, 20_000);
+  });
+});

--- a/test/fixtures/fake-nika.mjs
+++ b/test/fixtures/fake-nika.mjs
@@ -25,6 +25,13 @@ if (command === 'wait-for-signal') {
 
 if (command === 'check') {
   const sdkSnapshot = argv.includes('--sdk-snapshot');
+  if (workflow.includes('hang')) {
+    setTimeout(() => {
+      console.log(JSON.stringify({ report_version: 1, clean: true, argv }));
+      process.exit(0);
+    }, 5_000);
+    return;
+  }
   if (sdkSnapshot && workflow.includes('parse-fatal')) {
     console.log(JSON.stringify({
       report_version: 1,


### PR DESCRIPTION
## Root cause

On SDK **0.115.0**, `LocalNika.run` passed the caller's `AbortSignal` straight into `spawn(bin, args, { signal })`. When the signal fired, Node's `abortChildProcess` emitted an `error` event (`AbortError`, `ABORT_ERR`) on the `ChildProcess`, which rejected the generator-internal `done` promise (`child.on('error', rej)`). The `for await` over `child.stdout` threw the same AbortError first, so `await done` was never reached — the internal rejection had no observer and surfaced as a **process-level `unhandledRejection`**, killing any host that didn't install a global handler (cancel button / timeout / server shutdown). Reproduced verbatim against the 0.115.0 source: the iterator throws `AbortError` (expected) **and** `unhandledRejection: AbortError ABORT_ERR` fires.

## The fix

The 0.116 one-sdk rewrite already removed the defect class — no caller signal reaches `spawn`, and every internal promise on the abort paths is settled or deliberately catch-swallowed (`RunSession.done`, native `closed`/`done`, HTTP `done`, the bounded pump / `observeSettlement`). What was missing is the guarantee pinned as a contract. This PR adds `test/abort-settlement.test.ts`, which fires aborts mid-run through every current abort surface on the public `Nika` API **with `run.done` deliberately never awaited** (the webhook persona's exact shape) and asserts **zero `unhandledRejection` events**:

- native `events(run, { signal })` aborted mid-run (subscriber cleanup; the run continues)
- native `cancel(run)` mid-run
- native `check(file, { signal })` aborted mid-capture (new additive `hang` fixture branch)
- HTTP `attachRun` + `events(run, { signal })` aborted mid-observation (never-ending SSE stream)
- HTTP observation retry exhaustion → the terminal iterator error is `NikaObservationInterrupted` carrying `runId` + `lastSequence` — the re-attach cursor feeding `attachRun(id, { lastEventId })`, as the issue requested

Mutation-checked: removing the `RunSession.done` catch-guard turns this suite red with the exact stray-rejection symptom, so the suite genuinely pins the issue's expected behavior.

Verification: `npm test` 180/180 green (175 baseline + 5 new) · `npm run build` ✓ · `npm run check:coverage` ✓.

Closes #68.
