### PR TITLE
feat(sdk): discriminated terminal union + output generics + branded ids (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Discriminated `NikaEvent` union over the known lifecycle kinds with an
+  intentional `NikaUnknownEvent` fallback, typed `status`/`outputs`/`receipt`
+  on the terminal `run_settled` and `workflow_completed` frames, and the
+  `isNikaRunSettledEvent` / `isNikaRunSealedEvent` narrowing guards.
+- Caller-owned `Outputs` type argument on `run`, `attachRun`, and `events`,
+  flowing into `NikaRunResult` and the terminal frames; it defaults to the
+  previous transport shape, so existing callers compile unchanged.
+- Branded opaque `NikaRunId`, `NikaExecutionId`, and `NikaJobId` identity
+  types on the run surfaces that already carried those identities.
+
 ## [0.116.2] - 2026-08-31
 
 Lockstep recovery release for engine v0.116.2. The HTTP schema is unchanged

--- a/README.md
+++ b/README.md
@@ -321,6 +321,37 @@ Remote-only options:
 | `listWorkflows()` | contained resident workflow names |
 | `workflow(name)` | path-free resident workflow metadata |
 
+### Typed events, outputs, and identities
+
+`NikaEvent` is a discriminated union over the known lifecycle kinds
+(`workflow_started`, `task_scheduled`, `task_started`, `task_completed`,
+`workflow_completed`, `workflow_failed`, `workflow_interrupted`,
+`run_settled`, `run_sealed`). Kinds this SDK version does not know yet stay
+representable through the `NikaUnknownEvent` fallback, so the union is
+intentionally non-exhaustive and every variant keeps its future fields open.
+
+`run`, `attachRun`, and `events` accept one `Outputs` type argument. It types
+the terminal settlement — `run.done` and the `run_settled` /
+`workflow_completed` frames — without any runtime validation, and defaults to
+`Record<string, unknown>` so untyped callers see no change:
+
+```ts
+const run = await nika.run<{ answer: number }>('flow.nika.yaml');
+const result = await run.done;          // result.outputs?: { answer: number }
+
+for await (const event of nika.events(run)) {
+  if (isNikaRunSettledEvent(event)) {
+    // event is NikaRunSettledEvent<{ answer: number }> here:
+    // status, outputs, and receipt typed together on the terminal frame.
+    console.log(event.status, event.outputs?.answer, event.receipt);
+  }
+}
+```
+
+Run, execution, and job identities are branded opaque strings (`NikaRunId`,
+`NikaExecutionId`, `NikaJobId`). They remain assignable to `string`, but a
+plain `string` no longer stands in for one.
+
 ## Errors
 
 Every SDK error extends `NikaError`:

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,23 @@
+import type {
+  NikaEvent,
+  NikaRunSealedEvent,
+  NikaRunSettledEvent,
+} from './types.js';
+
+/**
+ * Narrows any run event to the terminal settlement frame, which carries the
+ * run's status, outputs, and receipt together. Kind equality alone cannot
+ * exclude the forward-compatibility variant; this guard can.
+ */
+export function isNikaRunSettledEvent<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+>(event: NikaEvent<Outputs>): event is NikaRunSettledEvent<Outputs> {
+  return event.kind === 'run_settled';
+}
+
+/** Narrows any run event to the frame that sealed the run's trace chain. */
+export function isNikaRunSealedEvent<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+>(event: NikaEvent<Outputs>): event is NikaRunSealedEvent {
+  return event.kind === 'run_sealed';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,15 +99,25 @@ export class Nika {
     return this.transport.check(workflowName(workflow), options);
   }
 
-  async run(workflow: string, options: NikaRunOptions = {}): Promise<NikaRun> {
+  /**
+   * `Outputs` is the caller's projection of the engine-emitted outputs map;
+   * the SDK transports outputs without validating their shape.
+   */
+  async run<Outputs extends Record<string, unknown> = Record<string, unknown>>(
+    workflow: string,
+    options: NikaRunOptions = {},
+  ): Promise<NikaRun<Outputs>> {
     const source = await this.transport.startRun(workflowName(workflow), options);
     const session = new RunSession(source, this.eventBufferSize);
     this.sessions.set(session.run, session);
-    return session.run;
+    return session.run as NikaRun<Outputs>;
   }
 
   /** Reattach this client process to an already-admitted durable HTTP job. */
-  async attachRun(id: string, options: NikaAttachRunOptions = {}): Promise<NikaRun> {
+  async attachRun<Outputs extends Record<string, unknown> = Record<string, unknown>>(
+    id: string,
+    options: NikaAttachRunOptions = {},
+  ): Promise<NikaRun<Outputs>> {
     const lastEventId = options.lastEventId ?? 0;
     if (!Number.isSafeInteger(lastEventId) || lastEventId < 0) {
       throw new RangeError('lastEventId must be a non-negative safe integer');
@@ -115,7 +125,7 @@ export class Nika {
     const source = await this.transport.attachRun(jobId(id), { lastEventId });
     const session = new RunSession(source, this.eventBufferSize);
     this.sessions.set(session.run, session);
-    return session.run;
+    return session.run as NikaRun<Outputs>;
   }
 
   /** List contained workflow names from a resident HTTP authority. */
@@ -128,8 +138,11 @@ export class Nika {
     return this.transport.workflow(workflowName(name));
   }
 
-  events(run: NikaRun, options: NikaEventsOptions = {}): AsyncIterable<NikaEvent> {
-    return this.session(run).events(options);
+  events<Outputs extends Record<string, unknown> = Record<string, unknown>>(
+    run: NikaRun<Outputs>,
+    options: NikaEventsOptions = {},
+  ): AsyncIterable<NikaEvent<Outputs>> {
+    return this.session(run).events(options) as AsyncIterable<NikaEvent<Outputs>>;
   }
 
   cancel(run: NikaRun): Promise<NikaCancelResult> {
@@ -243,6 +256,11 @@ export {
 
 export { NikaEngineUnavailable };
 
+export {
+  isNikaRunSealedEvent,
+  isNikaRunSettledEvent,
+} from './events.js';
+
 export type {
   NikaCancelResult,
   NikaAttachRunOptions,
@@ -253,13 +271,18 @@ export type {
   NikaRemoteConfig,
   NikaEvent,
   NikaEventsOptions,
+  NikaExecutionId,
+  NikaJobId,
   NikaMachineError,
   NikaReceipt,
   NikaOperation,
   NikaOperationFinding,
   NikaRun,
+  NikaRunId,
   NikaRunOptions,
   NikaRunResult,
+  NikaRunSealedEvent,
+  NikaRunSettledEvent,
   NikaRunStatus,
   NikaScheduleAfterSkip,
   NikaScheduleApplyResult,
@@ -275,8 +298,16 @@ export type {
   NikaScheduleSlot,
   NikaScheduleStatus,
   NikaScheduleWhen,
+  NikaTaskCompletedEvent,
+  NikaTaskScheduledEvent,
+  NikaTaskStartedEvent,
   NikaTraceVerifyOptions,
   NikaTraceVerifyResult,
   NikaTransportKind,
+  NikaUnknownEvent,
+  NikaWorkflowCompletedEvent,
+  NikaWorkflowFailedEvent,
+  NikaWorkflowInterruptedEvent,
   NikaWorkflowMetadata,
+  NikaWorkflowStartedEvent,
 } from './types.js';

--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -12,7 +12,9 @@ import type {
   NikaCheckOptions,
   NikaCheckResult,
   NikaEvent,
+  NikaExecutionId,
   NikaReceipt,
+  NikaRunId,
   NikaRunOptions,
   NikaRunResult,
   NikaRunStatus,
@@ -69,7 +71,7 @@ interface ObservationState {
 interface DurableJob {
   id: string;
   status: string;
-  execution_id?: string;
+  execution_id?: NikaExecutionId;
   trace_id?: string;
   outputs?: Record<string, unknown>;
   receipt?: NikaReceipt;
@@ -173,7 +175,7 @@ export class HttpTransport implements Transport {
       },
       body: captured.bytes,
     }, true, [200, 202]);
-    const id = typeof admitted.id === 'string' ? admitted.id : undefined;
+    const id = typeof admitted.id === 'string' ? admitted.id as NikaRunId : undefined;
     if (!id) {
       throw new NikaProtocolError(this.kind, 'Job admission response omitted its id');
     }
@@ -192,7 +194,7 @@ export class HttpTransport implements Transport {
       headers: { Accept: 'application/json' },
     });
     const durable = durableJob(object, id, this.kind);
-    return this.httpRun(id, options.lastEventId ?? 0, durable);
+    return this.httpRun(id as NikaRunId, options.lastEventId ?? 0, durable);
   }
 
   async listWorkflows(): Promise<readonly string[]> {
@@ -298,7 +300,7 @@ export class HttpTransport implements Transport {
   }
 
   private httpRun(
-    id: string,
+    id: NikaRunId,
     initialSequence = 0,
     attachedState?: DurableJob,
     expectedSnapshotDigest?: string,
@@ -1295,7 +1297,9 @@ function durableJob(
   return {
     id: value.id,
     status: value.status,
-    ...(typeof value.execution_id === 'string' ? { execution_id: value.execution_id } : {}),
+    ...(typeof value.execution_id === 'string'
+      ? { execution_id: value.execution_id as NikaExecutionId }
+      : {}),
     ...(typeof value.trace_id === 'string' ? { trace_id: value.trace_id } : {}),
     ...(outputs ? { outputs } : {}),
     ...(receipt ? { receipt: Object.freeze(receipt) } : {}),

--- a/src/lib/native-process-transport.ts
+++ b/src/lib/native-process-transport.ts
@@ -13,6 +13,7 @@ import type {
   NikaCheckResult,
   NikaEvent,
   NikaReceipt,
+  NikaRunId,
   NikaRunOptions,
   NikaRunResult,
   NikaRunStatus,
@@ -87,7 +88,7 @@ export class NativeProcessTransport implements Transport {
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: false,
     });
-    return this.processRun(randomUUID(), child);
+    return this.processRun(randomUUID() as NikaRunId, child);
   }
 
   async attachRun(_id: string, _options: NikaAttachRunOptions): Promise<TransportRun> {
@@ -177,7 +178,7 @@ export class NativeProcessTransport implements Transport {
     };
   }
 
-  private processRun(id: string, child: ChildProcessByStdio<null, Readable, Readable>): TransportRun {
+  private processRun(id: NikaRunId, child: ChildProcessByStdio<null, Readable, Readable>): TransportRun {
     let settled = false;
     let lastEvent: NikaEvent | undefined;
     let receipt: NikaReceipt | undefined;

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -5,6 +5,7 @@ import type {
   NikaCheckResult,
   NikaEvent,
   NikaReceipt,
+  NikaRunId,
   NikaRunOptions,
   NikaRunResult,
   NikaRunStatus,
@@ -18,7 +19,7 @@ import type {
 } from '../types.js';
 
 export interface TransportRun {
-  readonly id: string;
+  readonly id: NikaRunId;
   readonly events: AsyncIterable<NikaEvent>;
   readonly done: Promise<NikaRunResult>;
   status(): Promise<NikaRunStatus>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,26 @@ export type NikaConfig = NikaLocalConfig | NikaRemoteConfig;
 
 export type NikaTransportKind = 'native-process' | 'http';
 
+/**
+ * Brand carrier for engine-issued identities. The SDK brands an identity
+ * only where the engine (or its durable record) issues it; it never invents
+ * one itself.
+ */
+declare const NikaIdentityBrand: unique symbol;
+
+interface NikaIdentity<Name extends string> {
+  readonly [NikaIdentityBrand]: Name;
+}
+
+/** A run identity issued by `run()` or `attachRun()`. Assignable to `string`. */
+export type NikaRunId = string & NikaIdentity<'NikaRunId'>;
+
+/** An engine execution identity carried by terminal settlements and receipts. */
+export type NikaExecutionId = string & NikaIdentity<'NikaExecutionId'>;
+
+/** A durable `nika serve` job identity accepted by `attachRun()`. */
+export type NikaJobId = string & NikaIdentity<'NikaJobId'>;
+
 /** Machine vocabulary is additive. Known words aid completion without closing the set. */
 export type NikaRunStatus =
   | 'queued'
@@ -60,15 +80,106 @@ export interface NikaCheckResult {
   [key: string]: unknown;
 }
 
-/** One engine-owned run event. Event kinds and future fields stay open. */
-export interface NikaEvent {
-  kind?: string;
+/** Fields every engine event can carry, whether its kind is known or not. */
+interface NikaEventFields {
   status?: NikaRunStatus;
   sequence?: number;
   receipt?: NikaReceipt;
   outputs?: Record<string, unknown>;
   [key: string]: unknown;
 }
+
+/** The workflow graph started executing. */
+export interface NikaWorkflowStartedEvent extends NikaEventFields {
+  kind: 'workflow_started';
+}
+
+/** A task was scheduled for execution. */
+export interface NikaTaskScheduledEvent extends NikaEventFields {
+  kind: 'task_scheduled';
+}
+
+/** A task started executing. */
+export interface NikaTaskStartedEvent extends NikaEventFields {
+  kind: 'task_started';
+}
+
+/** A task settled. Per-task payloads ride the open fields. */
+export interface NikaTaskCompletedEvent extends NikaEventFields {
+  kind: 'task_completed';
+}
+
+/**
+ * The workflow graph settled. This is the terminal frame of a native-process
+ * run and carries the run's outputs, receipt, and final status together.
+ */
+export interface NikaWorkflowCompletedEvent<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+> extends NikaEventFields {
+  kind: 'workflow_completed';
+  status?: NikaRunStatus;
+  outputs?: Outputs;
+  receipt?: NikaReceipt;
+}
+
+/** The workflow graph failed. */
+export interface NikaWorkflowFailedEvent extends NikaEventFields {
+  kind: 'workflow_failed';
+  error?: NikaMachineError;
+}
+
+/** The workflow graph was interrupted before settling. */
+export interface NikaWorkflowInterruptedEvent extends NikaEventFields {
+  kind: 'workflow_interrupted';
+}
+
+/**
+ * The terminal settlement frame of a durable `nika serve` job: the one frame
+ * that carries the run's outputs, receipt, and final status together.
+ */
+export interface NikaRunSettledEvent<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+> extends NikaEventFields {
+  kind: 'run_settled';
+  status?: NikaRunStatus;
+  outputs?: Outputs;
+  receipt?: NikaReceipt;
+}
+
+/** The run's trace chain was sealed. */
+export interface NikaRunSealedEvent extends NikaEventFields {
+  kind: 'run_sealed';
+  receipt?: NikaReceipt;
+}
+
+/**
+ * Forward-compatibility variant: any kind this SDK version does not know
+ * yet stays representable, so the event union is intentionally
+ * non-exhaustive.
+ */
+export interface NikaUnknownEvent extends NikaEventFields {
+  kind?: string;
+}
+
+/**
+ * One engine-owned run event. Known kinds discriminate on `kind`; unknown
+ * kinds fall back to `NikaUnknownEvent`. Future fields stay open on every
+ * variant. `Outputs` types the terminal frames' outputs and defaults to the
+ * transport shape, so untyped callers see no change.
+ */
+export type NikaEvent<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+> =
+  | NikaWorkflowStartedEvent
+  | NikaTaskScheduledEvent
+  | NikaTaskStartedEvent
+  | NikaTaskCompletedEvent
+  | NikaWorkflowCompletedEvent<Outputs>
+  | NikaWorkflowFailedEvent
+  | NikaWorkflowInterruptedEvent
+  | NikaRunSettledEvent<Outputs>
+  | NikaRunSealedEvent
+  | NikaUnknownEvent;
 
 /**
  * Engine-issued proof material. The SDK transports it but never constructs,
@@ -83,25 +194,31 @@ export interface NikaMachineError {
 }
 
 /** The only terminal value for a run. */
-export interface NikaRunResult {
-  id: string;
+export interface NikaRunResult<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+> {
+  id: NikaRunId;
   status: NikaRunStatus;
   transport: NikaTransportKind;
   exitCode?: number;
-  outputs?: Record<string, unknown>;
+  outputs?: Outputs;
   receipt?: NikaReceipt;
   error?: NikaMachineError;
+  /** Engine execution identity, when the transport surface reports one. */
+  execution_id?: NikaExecutionId;
   [key: string]: unknown;
 }
 
 /** A run identity plus its one terminal settlement. */
-export interface NikaRun {
-  readonly id: string;
-  readonly done: Promise<NikaRunResult>;
+export interface NikaRun<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+> {
+  readonly id: NikaRunId;
+  readonly done: Promise<NikaRunResult<Outputs>>;
 }
 
 export interface NikaCancelResult {
-  runId: string;
+  runId: NikaRunId;
   accepted: boolean;
   status: string;
   transport: NikaTransportKind;

--- a/test/one-sdk.test.ts
+++ b/test/one-sdk.test.ts
@@ -18,6 +18,7 @@ import type {
   NikaEvent,
   NikaLocalConfig,
   NikaRun,
+  NikaRunId,
   NikaRunOptions,
   NikaScheduleOptions,
 } from '../src/index.js';
@@ -313,9 +314,9 @@ describe.skipIf(!posix)('native-process transport', () => {
     await expect(client.run('ok.nika.yaml', { idempotencyKey: 'remote-only' }))
       .rejects.toBeInstanceOf(NikaCompatibilityError);
     const foreign: NikaRun = {
-      id: 'foreign',
+      id: 'foreign' as NikaRunId,
       done: Promise.resolve({
-        id: 'foreign',
+        id: 'foreign' as NikaRunId,
         status: 'succeeded',
         transport: 'native-process',
       }),

--- a/test/typed-terminal.test.ts
+++ b/test/typed-terminal.test.ts
@@ -1,0 +1,155 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  isNikaRunSealedEvent,
+  isNikaRunSettledEvent,
+  Nika,
+} from '../src/index.js';
+import type {
+  NikaCancelResult,
+  NikaEvent,
+  NikaExecutionId,
+  NikaJobId,
+  NikaReceipt,
+  NikaRun,
+  NikaRunId,
+  NikaRunResult,
+  NikaRunSealedEvent,
+  NikaRunSettledEvent,
+  NikaRunStatus,
+} from '../src/index.js';
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'fake-nika.mjs',
+);
+const posix = process.platform !== 'win32';
+
+// Compile-time only: this function is never invoked, so nothing in it runs.
+async function genericFlows(client: Nika): Promise<void> {
+  // The caller's Outputs type flows run → done → events.
+  const run = await client.run<{ answer: number }>('flow.nika.yaml');
+  expectTypeOf(run).toEqualTypeOf<NikaRun<{ answer: number }>>();
+  expectTypeOf(run.id).toEqualTypeOf<NikaRunId>();
+  expectTypeOf(run.done).toEqualTypeOf<Promise<NikaRunResult<{ answer: number }>>>();
+  const result = await run.done;
+  expectTypeOf(result.outputs).toEqualTypeOf<{ answer: number } | undefined>();
+  expectTypeOf(result.execution_id).toEqualTypeOf<NikaExecutionId | undefined>();
+
+  const attached = await client.attachRun<{ answer: number }>('durable-job');
+  expectTypeOf(attached.done).toEqualTypeOf<Promise<NikaRunResult<{ answer: number }>>>();
+
+  for await (const event of client.events(run)) {
+    expectTypeOf(event).toEqualTypeOf<NikaEvent<{ answer: number }>>();
+    if (event.kind === 'run_settled') {
+      // Kind equality keeps the forward-compat variant: outputs widen.
+      expectTypeOf(event.outputs).toEqualTypeOf<
+        { answer: number } | Record<string, unknown> | undefined
+      >();
+    }
+    if (isNikaRunSettledEvent(event)) {
+      // The guard narrows to the exact terminal frame.
+      expectTypeOf(event).toEqualTypeOf<NikaRunSettledEvent<{ answer: number }>>();
+      expectTypeOf(event.outputs).toEqualTypeOf<{ answer: number } | undefined>();
+      expectTypeOf(event.status).toEqualTypeOf<NikaRunStatus | undefined>();
+      expectTypeOf(event.receipt).toEqualTypeOf<NikaReceipt | undefined>();
+    }
+  }
+
+  // Omitting the generic keeps the transport shape, so existing code compiles.
+  const untyped = await client.run('flow.nika.yaml');
+  expectTypeOf(untyped).toEqualTypeOf<NikaRun>();
+  const untypedResult = await untyped.done;
+  expectTypeOf(untypedResult.outputs).toEqualTypeOf<Record<string, unknown> | undefined>();
+  for await (const event of client.events(untyped)) {
+    expectTypeOf(event).toEqualTypeOf<NikaEvent>();
+    expectTypeOf(event.kind).toEqualTypeOf<string | undefined>();
+    expectTypeOf(event.outputs).toEqualTypeOf<Record<string, unknown> | undefined>();
+  }
+}
+void genericFlows;
+
+describe('typed terminal hop', () => {
+  it('types the terminal frame payload without closing its fields', () => {
+    expectTypeOf<NikaRunSettledEvent['kind']>().toEqualTypeOf<'run_settled'>();
+    expectTypeOf<NikaRunSealedEvent['kind']>().toEqualTypeOf<'run_sealed'>();
+    expectTypeOf<NikaRunSettledEvent<{ answer: number }>['outputs']>()
+      .toEqualTypeOf<{ answer: number } | undefined>();
+    expectTypeOf<NikaRunSettledEvent['status']>().toEqualTypeOf<NikaRunStatus | undefined>();
+    expectTypeOf<NikaRunSettledEvent['receipt']>().toEqualTypeOf<NikaReceipt | undefined>();
+    // Future engine fields stay open on the terminal frame and the result.
+    expectTypeOf<NikaRunSettledEvent['future_field']>().toEqualTypeOf<unknown>();
+    expectTypeOf<NikaRunResult['diagnostics']>().toEqualTypeOf<unknown>();
+  });
+
+  it('keeps unknown event kinds representable by design', () => {
+    const future = {
+      kind: 'execution.custom_2030',
+      status: 'succeeded',
+      sequence: 9,
+      future_field: { nested: true },
+    } satisfies NikaEvent;
+    expect(isNikaRunSettledEvent(future)).toBe(false);
+    expect(isNikaRunSealedEvent(future)).toBe(false);
+  });
+
+  it('brands identities while keeping them assignable to string', () => {
+    expectTypeOf<NikaRun['id']>().toEqualTypeOf<NikaRunId>();
+    expectTypeOf<NikaRunResult['id']>().toEqualTypeOf<NikaRunId>();
+    expectTypeOf<NikaCancelResult['runId']>().toEqualTypeOf<NikaRunId>();
+    expectTypeOf<NikaRunId>().toExtend<string>();
+    expectTypeOf<string>().not.toExtend<NikaRunId>();
+    expectTypeOf<NikaRunId>().not.toExtend<NikaExecutionId>();
+    expectTypeOf<NikaExecutionId>().not.toExtend<NikaRunId>();
+    expectTypeOf<NikaJobId>().not.toExtend<NikaRunId>();
+  });
+});
+
+describe('terminal frame guards', () => {
+  it('recognizes only the terminal settlement frame', () => {
+    expect(isNikaRunSettledEvent({ kind: 'run_settled' })).toBe(true);
+    expect(isNikaRunSettledEvent({
+      kind: 'run_settled',
+      status: 'succeeded',
+      outputs: { answer: 42 },
+    })).toBe(true);
+    expect(isNikaRunSettledEvent({ kind: 'run_sealed' })).toBe(false);
+    expect(isNikaRunSettledEvent({ kind: 'workflow_completed' })).toBe(false);
+    expect(isNikaRunSettledEvent({ kind: 'task_completed' })).toBe(false);
+    expect(isNikaRunSettledEvent({ kind: 'execution.custom' })).toBe(false);
+    expect(isNikaRunSettledEvent({})).toBe(false);
+  });
+
+  it('recognizes only the seal frame', () => {
+    expect(isNikaRunSealedEvent({ kind: 'run_sealed' })).toBe(true);
+    expect(isNikaRunSealedEvent({ kind: 'run_settled' })).toBe(false);
+    expect(isNikaRunSealedEvent({ kind: 'workflow_completed' })).toBe(false);
+    expect(isNikaRunSealedEvent({ kind: 'execution.custom' })).toBe(false);
+    expect(isNikaRunSealedEvent({})).toBe(false);
+  });
+});
+
+describe.skipIf(!posix)('typed terminal hop through a real run', () => {
+  it('flows the caller outputs type through events and the terminal result', async () => {
+    const client = new Nika({ bin: FIXTURE });
+    const run = await client.run<{ answer: number }>('ok.nika.yaml');
+    expectTypeOf(run.id).toEqualTypeOf<NikaRunId>();
+    const seen: Array<string | undefined> = [];
+    for await (const event of client.events(run)) {
+      seen.push(event.kind);
+      if (isNikaRunSettledEvent(event)) {
+        expectTypeOf(event.outputs).toEqualTypeOf<{ answer: number } | undefined>();
+      }
+    }
+    const result = await run.done;
+    expectTypeOf(result.outputs).toEqualTypeOf<{ answer: number } | undefined>();
+    expect(result).toMatchObject({
+      status: 'succeeded',
+      transport: 'native-process',
+      outputs: { answer: 42 },
+    });
+    expect(seen).toEqual(['workflow_started', 'task_completed', 'workflow_completed']);
+  });
+});


### PR DESCRIPTION
## What

- **`NikaEvent<Outputs>`** is now a discriminated union over the known lifecycle kinds (`workflow_started`, `task_scheduled`, `task_started`, `task_completed`, `workflow_completed`, `workflow_failed`, `workflow_interrupted`, `run_settled`, `run_sealed`). Kinds this SDK version does not know yet stay representable through an intentional **`NikaUnknownEvent`** fallback, so the union is non-exhaustive by design and every variant keeps its future fields open (`[key: string]: unknown`).
- **The terminal hop is typed**: `run_settled` (HTTP) and `workflow_completed` (native) frames carry typed `{ status, outputs, receipt }` together, and the new **`isNikaRunSettledEvent` / `isNikaRunSealedEvent`** guards narrow to the exact terminal variant — something `kind ===` alone cannot do in a non-exhaustive union (the fallback keeps widened outputs, which the tests pin deliberately).
- **Output generics**: `run<Outputs>`, `attachRun<Outputs>`, and `events(run)` flow one caller-owned `Outputs` type into `NikaRunResult<Outputs>` and the terminal frames. It defaults to `Record<string, unknown>` — the previous transport shape — so existing callers compile unchanged.
- **Branded identities**: `NikaRunId` / `NikaExecutionId` / `NikaJobId` (opaque `string & brand`) on the surfaces that already carried those identities (`NikaRun.id`, `NikaRunResult.id` + typed `execution_id`, `NikaCancelResult.runId`). They stay assignable to `string`; a plain `string` no longer stands in for one.

## Why (#61, five independent gauntlet personas)

> "NikaEvent is an open bag `{kind: string; [k:string]: unknown}`; the terminal run_settled frame carries the payload a SaaS needs (outputs/receipt/status) yet is the least typed thing in the SDK; I hand-wrote narrowing guards + revalidated outputs with zod" — senior-TS Express persona

> "runToEnd returns events but outputs ride run_settled/task_completed untyped; the outputs extraction is the one untyped, undocumented hop" — beginner + Next.js + CJS + NestJS personas (one invented a 17-piece wrapper including a WorkflowRunResult DTO to unify local/serve result shapes)

The SDK now ships the narrowing guards and the terminal-frame typing those personas hand-wrote, and documents the hop in the README.

## Non-breaking evidence

- Same exports map, same entry points, zero runtime behavior change (new code is types + two pure predicates).
- `NikaUnknownEvent` is field-for-field the old `NikaEvent`, so every literal that compiled before still compiles; generics default to the old shape.
- Consumer-compile check against the packed `dist/`: pre-#61 style (no generics, `string` ids, open bag) and post-#61 style both pass `tsc --strict`.
- Full existing suite type-checked (`tsc --noEmit` on `src/` and every test file): zero new errors vs baseline (the 6 pre-existing errors in never-type-gated test files are unchanged).
- One in-repo construction site needed the brand (`test/one-sdk.test.ts` foreign run handle: `'foreign' as NikaRunId`) — expected: brands are opt-in at construction boundaries.

## Test proof

- `npm test`: **181 passed** (175 baseline + 6 new) — `test/typed-terminal.test.ts` adds `expectTypeOf` proofs (union narrows, generic flows run→done→events, defaults preserve the old shape, brand (non-)assignability, forward-compat literal) plus runtime guard tests and a real fixture run flowing `run<{ answer: number }>()` through `events` and `run.done`. The type assertions are verified under `tsc --noEmit --strict` (vitest does not typecheck them).
- `npm run build` green; `dist/index.d.ts`/`.d.cts` emit the brand, union, and guards; ESM+CJS smoke passes.
- `npm run check:coverage` green.
- Note: `test/packed-native.test.ts > reports NikaEngineUnavailable after npm install --omit=optional` is a pre-existing 5s-timeout flake (real `npm install` staging) — it fails identically on `main` under load and passes in isolation (8/8).

Closes #61.