### PR TITLE
docs(sdk): publish first-contact gauntlet evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,28 @@ not parse YAML or reconstruct proof in TypeScript.
 ## Install
 
 ```sh
-npm install @supernovae-st/nika-client
+npm view @supernovae-st/nika-client@0.116.2 version  # must report 0.116.2
+npm install @supernovae-st/nika-client@0.116.2
 ```
+
+If the registry reports any other version, the 0.116.2 release train is not
+complete. Earlier packages expose the retired `LocalNika`/HTTP split and do
+not implement the root facade documented below. The publication is complete
+only when the four matching native payload packages and this root client are
+all visible on npm.
 
 ## First local run
 
-Create `hello.nika.yaml`:
+The lowest-friction creation door is the engine-owned scaffold:
+
+```sh
+./node_modules/.bin/nika init --project-file
+./node_modules/.bin/nika new 01-hello hello.nika.yaml
+```
+
+`nika.yaml` is the project control plane. `hello.nika.yaml` is executable
+workflow intent and is the file passed to `check()` and `run()`. The generated
+workflow has this public envelope:
 
 ```yaml
 nika: sdk-hello

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,9 @@ was originally written.
    binary/help, loopback HTTP, and public documentation. They are synthetic
    users, never substitutes for human usability evidence.
 
+The latest public-only first-contact wave and its convergent debt are recorded
+in [`gauntlet/personas/REPORT.md`](../gauntlet/personas/REPORT.md).
+
 ## Socratic risk matrix
 
 Every release wave must ask and demonstrate an answer to these questions:

--- a/gauntlet/personas/REPORT.md
+++ b/gauntlet/personas/REPORT.md
@@ -1,0 +1,64 @@
+# Public first-contact Persona gauntlet
+
+## Verdict
+
+Fifteen isolated synthetic users started from public surfaces only on
+2026-09-01. Each created a fresh Node project, installed the npm package, used
+only `mock/echo`, capped spend at USD 0.01, and attempted a real workflow plus
+SDK integration. All fifteen eventually completed at least one checked run;
+all successful runs cost USD 0 and emitted a sealed trace.
+
+This is reproducible usability evidence from clean-room agent personas, not a
+claim about observed human behavior. A real-human study remains a separate
+gate.
+
+## Public state under test
+
+- npm latest: `@supernovae-st/nika-client@0.115.0`
+- released engine: `nika 0.116.2`
+- reviewed One SDK source: `@supernovae-st/nika-client@0.116.2`
+- personas installed only the npm latest package; several independently
+  downloaded the public engine release and verified its checksum
+
+The version gap is the dominant onboarding defect. Public `0.115.0` exposes
+the retired `LocalNika` plus HTTP surfaces, while the reviewed `0.116.2`
+documentation teaches the root `Nika` facade. Users must not be told those APIs
+are interchangeable.
+
+## Persona matrix
+
+| Persona | Starting posture | Outcome | First-contact finding |
+|---|---|---|---|
+| CLI skeptic | weak | recovered | guessed `name`/`prompt`; `nika new` unlocked the path |
+| Rival-tool user | medium | succeeded | strong DAG and trace proof; release versions conflict |
+| Oracle-first agent | medium | succeeded | schema/template tools worked; npm did not bring the engine |
+| Production operator | strong | succeeded | TypeScript integration worked; version and trace custody need clearer setup |
+| Nontechnical founder | weak | recovered | first YAML failed; mock success can be mistaken for business value |
+| Script migrator | medium | partial parity | syntax migrated; semantic artifact equivalence was not proven |
+| Security reviewer | strong | succeeded with finding | boundaries held; `0.115.0` pre-abort handling could escape the caller |
+| Syntax learner | weak | partial | inferred envelope failed; one-task scaffold worked |
+| Rule author | medium | succeeded | schema/retry worked; business decision and escalation example missing |
+| Batch developer | medium | succeeded | five-item fan-out worked; per-item failure path not demonstrated |
+| Human-gate integrator | strong | headless succeeded | pause/recovery worked; TTY and `0.115.0` SDK answer path were ambiguous |
+| Multi-model builder | medium | succeeded with finding | unknown provider failed late and weakly |
+| CI engineer | medium | succeeded | hermetic HOME and exit codes held; engine pin is outside npm 0.115 |
+| Beginner debugger | weak | recovered | parse guidance helped; invalid reference needed a concrete repair |
+| Team integrator | medium | recovered | confused project `nika.yaml` with executable `*.nika.yaml` |
+
+## Convergent debt
+
+| Priority | Convergence | Evidence | Required closure |
+|---|---|---:|---|
+| P0 | npm and documentation expose incompatible release trains | 8 personas | publish all four native payloads and root client at 0.116.2, then prove a registry-only install |
+| P1 | beginners guess an invalid workflow before finding `nika new` | 5 personas | keep one copy-paste scaffold command above hand-authored YAML |
+| P1 | project `nika.yaml` versus executable `*.nika.yaml` is easy to conflate | 3 personas | name both files and the method boundary in quickstarts |
+| P1 | npm 0.115 requires a separately discovered engine | 5 personas | One SDK 0.116 native payloads must install in the same npm transaction |
+| P1 | multi-step dataflow and dependency examples are too hard to discover | 4 personas | ship a two-task example with a real interpolation and asserted output |
+| P1 | mock green can be over-read as business correctness | 4 personas | label rehearsal output and distinguish runtime proof from answer quality |
+| P2 | failure examples stop before per-item, provider, or reference repair | 4 personas | add focused negative fixtures with expected codes and recovery steps |
+| P2 | trace retention, key location, and cleanup are not one visible runbook | 3 personas | document CI HOME, key custody, retention, and cleanup together |
+
+The Persona abort finding belongs to registry package 0.115.0. It remains a
+public defect until the replacement reaches npm, even when a later source
+branch carries a regression test. The release gate must therefore judge a
+fresh registry-only install rather than source state.


### PR DESCRIPTION
## Outcome

- records the 15-persona public-only first-contact gauntlet without claiming human evidence
- makes the 0.116.2 registry gate exact and prevents fallback to the unrelated npm `nika` package
- separates `nika.yaml` project policy from executable `*.nika.yaml` intent in the first local run
- links convergent usability debt from the SDK testing contract

## Evidence

- `npm test` — 186/186 tests
- `npm run build` — ESM, CJS, CLI and declarations built
- `npm run check:coverage` — live OpenAPI coverage green
- `npm run check:release-evidence` — 5 current + 2 historical evidence sets match 0.116.2
- `npm run gauntlet:check` — 100/100 workflows
- `npm run gauntlet:projects` — 5/5 mini-SaaS projects
- `npm run gauntlet:depth` — 5/5 depth projects
- `npm run gauntlet:recovery` — two-process recovery green
- `npm run gauntlet:hostile` — 14/14 hostile scenarios
- packed 0.116.2 client + macOS arm64 payload installed and executed from a fresh Node project

## Release-train note

This is a release-train hotfix. Keep the PR open until the 0.116 publisher incorporates it or the train closes. npm still requires a fresh five-platform run from current main plus trusted-publishing authorization for all five packages.
