### PR TITLE
fix(sdk): export installed package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ not implement the root facade documented below. The publication is complete
 only when the four matching native payload packages and this root client are
 all visible on npm.
 
+Verify the package that the current project actually resolved:
+
+```sh
+node -p "require('@supernovae-st/nika-client/package.json').version"
+```
+
+This package metadata subpath is exported for CommonJS, ESM build tools and CI
+pin checks. It reports the installed dependency, not a moving registry tag.
+
 ## First local run
 
 The lowest-friction creation door is the engine-owned scaffold:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -49,6 +50,7 @@
     "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",
+    "check:package-surface": "node scripts/verify-packed-module-surfaces.mjs",
     "check:coverage": "node scripts/check-sdk-coverage.js",
     "check:release-evidence": "node scripts/verify-release-evidence.mjs",
     "check:release-replay": "node scripts/verify-release-replay.mjs",

--- a/scripts/verify-packed-module-surfaces.mjs
+++ b/scripts/verify-packed-module-surfaces.mjs
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const scratch = await mkdtemp(path.join(tmpdir(), 'nika-package-surface-'));
+const consumer = path.join(scratch, 'consumer');
+
+try {
+  run('npm', ['run', 'build'], { cwd: root });
+  const packed = JSON.parse(run('npm', [
+    'pack',
+    '--ignore-scripts',
+    '--json',
+    '--pack-destination',
+    scratch,
+  ], { cwd: root }).stdout);
+  const filename = packed[0]?.filename;
+  if (typeof filename !== 'string') throw new Error('npm pack returned no filename');
+
+  await mkdir(consumer);
+  await writeFile(path.join(consumer, 'package.json'), '{"private":true}\n');
+  run('npm', [
+    'install',
+    '--ignore-scripts',
+    '--omit=optional',
+    '--no-audit',
+    '--no-fund',
+    '--package-lock=false',
+    path.join(scratch, filename),
+  ], { cwd: consumer });
+
+  const expectedVersion = packed[0]?.version;
+  if (typeof expectedVersion !== 'string') throw new Error('npm pack returned no version');
+  const packageName = '@supernovae-st/nika-client';
+  const commonJs = [
+    `const sdk = require('${packageName}');`,
+    `const manifest = require('${packageName}/package.json');`,
+    `if (!sdk.Nika || manifest.version !== '${expectedVersion}') process.exit(1);`,
+  ].join(' ');
+  run(process.execPath, ['--eval', commonJs], { cwd: consumer });
+
+  const esm = [
+    `import { Nika } from '${packageName}';`,
+    `const manifest = await import('${packageName}/package.json', { with: { type: 'json' } });`,
+    `if (!Nika || manifest.default.version !== '${expectedVersion}') process.exit(1);`,
+  ].join(' ');
+  run(process.execPath, ['--input-type=module', '--eval', esm], { cwd: consumer });
+
+  process.stdout.write(
+    `Packed ${packageName}@${expectedVersion} exposes ESM, CommonJS and package metadata\n`,
+  );
+} finally {
+  await rm(scratch, { recursive: true, force: true });
+}
+
+function run(command, args, options) {
+  const result = execFileSync(command, args, {
+    encoding: 'utf8',
+    timeout: 120_000,
+    ...options,
+  });
+  return { stdout: result };
+}

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -1,0 +1,15 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const script = new URL('../scripts/verify-packed-module-surfaces.mjs', import.meta.url);
+
+describe('packed Node consumer surfaces', () => {
+  it('exports ESM, CommonJS and installed package metadata', () => {
+    const output = execFileSync(process.execPath, [fileURLToPath(script)], {
+      encoding: 'utf8',
+      timeout: 120_000,
+    });
+    expect(output).toContain('exposes ESM, CommonJS and package metadata');
+  });
+});

--- a/test/readme-surface.test.ts
+++ b/test/readme-surface.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
 const mediaScript = readFileSync(new URL('../scripts/media/render.sh', import.meta.url), 'utf8');
+const manifest = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { exports?: Record<string, unknown> };
 
 describe('packed public documentation', () => {
   it('names the exported One SDK surface and current runtime floor', () => {
@@ -21,6 +24,11 @@ describe('packed public documentation', () => {
     expect(readme).toContain('NIKA_BIN');
     expect(readme).toContain('maxCostUsd: 0.01');
     expect(readme).toContain('pauseUntil:');
+  });
+
+  it('exports package metadata so consumers can prove the installed pin', () => {
+    expect(manifest.exports?.['./package.json']).toBe('./package.json');
+    expect(readme).toContain("require('@supernovae-st/nika-client/package.json').version");
   });
 
   it('does not regress to removed APIs or claim a webhook verifier', () => {


### PR DESCRIPTION
## Why
A public-only first-contact persona tried to prove the installed SDK version and hit ERR_PACKAGE_PATH_NOT_EXPORTED. Reading a moving npm tag is not equivalent to proving the dependency resolved by the current project.

## What
- export @supernovae-st/nika-client/package.json
- document the installed-version probe
- install the actual npm pack output in a fresh project
- prove ESM, CommonJS and package metadata resolution

## Verification
- 17 test files / 188 tests green
- SDK HTTP coverage green
- 100/100 workflows checked and executed
- 5/5 mini-SaaS and 5/5 depth projects green
- 14/14 hostile scenarios green
- two-process recovery green
- mock/echo only; cost 0 USD