### PR TITLE
test(sdk): compile packed nodenext consumers

### DIFF
--- a/scripts/verify-packed-module-surfaces.mjs
+++ b/scripts/verify-packed-module-surfaces.mjs
@@ -49,8 +49,35 @@ try {
   ].join(' ');
   run(process.execPath, ['--input-type=module', '--eval', esm], { cwd: consumer });
 
+  const typedConsumer = [
+    `import { Nika, type NikaConfig } from '${packageName}';`,
+    "const config: NikaConfig = { bin: '/tmp/nika' };",
+    'const client: Nika = new Nika(config);',
+    'void client;',
+    '',
+  ].join('\n');
+  await writeFile(path.join(consumer, 'consumer.mts'), typedConsumer);
+  await writeFile(path.join(consumer, 'consumer.cts'), typedConsumer);
+  run(process.execPath, [
+    path.join(root, 'node_modules/typescript/bin/tsc'),
+    '--module',
+    'NodeNext',
+    '--moduleResolution',
+    'NodeNext',
+    '--target',
+    'ES2022',
+    '--strict',
+    '--noEmit',
+    '--types',
+    'node',
+    '--typeRoots',
+    path.join(root, 'node_modules/@types'),
+    'consumer.mts',
+    'consumer.cts',
+  ], { cwd: consumer });
+
   process.stdout.write(
-    `Packed ${packageName}@${expectedVersion} exposes ESM, CommonJS and package metadata\n`,
+    `Packed ${packageName}@${expectedVersion} exposes typed ESM, CommonJS and package metadata\n`,
   );
 } finally {
   await rm(scratch, { recursive: true, force: true });

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -10,6 +10,6 @@ describe('packed Node consumer surfaces', () => {
       encoding: 'utf8',
       timeout: 120_000,
     });
-    expect(output).toContain('exposes ESM, CommonJS and package metadata');
+    expect(output).toContain('exposes typed ESM, CommonJS and package metadata');
   });
 });

--- a/test/package-consumer.test.ts
+++ b/test/package-consumer.test.ts
@@ -11,5 +11,5 @@ describe('packed Node consumer surfaces', () => {
       timeout: 120_000,
     });
     expect(output).toContain('exposes typed ESM, CommonJS and package metadata');
-  });
+  }, 120_000);
 });


### PR DESCRIPTION
## Question closed
Can runtime-green ESM/CommonJS imports still ship unusable TypeScript declarations?

## Proof
The existing npm-pack consumer now creates fresh .mts and .cts projects and compiles both with strict NodeNext resolution against the declarations in the tarball.

## Verification
- 17 test files / 188 tests green
- package build green
- packed ESM, CommonJS and metadata runtime probes green
- packed strict TypeScript ESM and CommonJS compilation green