### PR TITLE
fix(sdk): typed http refusals carry the server's error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- HTTP refusals that `nika serve` types as `{ error: { code, message } }`
+  (401 `unauthorized`, 404 `job_not_found`, 409 `idempotency_conflict`, 422
+  `malformed_snapshot` or a stamped `NIKA-…` admission code) now surface as
+  `NikaOperationError` with `status`, `code`, and the refused `operation`
+  instead of an opaque `HTTP <status> for <path>: [REDACTED]`; untyped bodies
+  keep the redacted transport error, and a reflected bearer token is redacted
+  from any server message. `NikaOperation` widens accordingly.
+
 ### Added
 
 - Discriminated `NikaEvent` union over the known lifecycle kinds with an

--- a/README.md
+++ b/README.md
@@ -398,6 +398,14 @@ closed, redacted `JobEvent` projection advertised by the pinned OpenAPI contract
 unknown HTTP fields are rejected at the trust boundary. The SDK never turns an
 unpriced model into `$0`.
 
+A refusal that `nika serve` types as `{ error: { code, message } }` surfaces as
+`NikaOperationError` with the HTTP `status`, the server `code` (for example
+`unauthorized`, `job_not_found`, `idempotency_conflict`, `malformed_snapshot`,
+or a stamped `NIKA-…` admission code) and the `operation` that was refused.
+Server messages are engine-owned and path-free; a reflected bearer token is
+redacted before it reaches an error message. A non-2xx answer without that
+typed body stays a `NikaTransportError` whose body is redacted entirely.
+
 ## Security boundaries
 
 - Token files stay out of argv and must be private (`0600`, 32–512 visible

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -2,6 +2,10 @@
 
 `openapi.json` is the checked-in contract pin. The SDK authenticates every
 route except public `GET /health`; bearer tokens are redacted from failures.
+A non-2xx answer typed as `{ error: { code, message } }` becomes a
+`NikaOperationError` carrying `status`, `code`, and the refused `operation`;
+any other non-2xx body is discarded and reported as a redacted
+`NikaTransportError`.
 
 | HTTP route | SDK surface | Contract |
 |---|---|---|

--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -130,7 +130,7 @@ export class HttpTransport implements Transport {
       headers: { 'Content-Type': 'application/json' },
       body: captured.bytes,
       signal: options.signal,
-    });
+    }, true, [200], 'check');
     if (
       Object.keys(acknowledged).some((key) => ![
         'status', 'snapshot_digest', 'root', 'units',
@@ -174,7 +174,7 @@ export class HttpTransport implements Transport {
         'Idempotency-Key': idempotencyKey,
       },
       body: captured.bytes,
-    }, true, [200, 202]);
+    }, true, [200, 202], 'run');
     const id = typeof admitted.id === 'string' ? admitted.id as NikaRunId : undefined;
     if (!id) {
       throw new NikaProtocolError(this.kind, 'Job admission response omitted its id');
@@ -192,7 +192,7 @@ export class HttpTransport implements Transport {
     const object = await this.json(`/v1/jobs/${encodeURIComponent(id)}`, {
       method: 'GET',
       headers: { Accept: 'application/json' },
-    });
+    }, true, [200], 'attachRun');
     const durable = durableJob(object, id, this.kind);
     return this.httpRun(id as NikaRunId, options.lastEventId ?? 0, durable);
   }
@@ -202,7 +202,7 @@ export class HttpTransport implements Transport {
     const object = await this.json('/v1/workflows', {
       method: 'GET',
       headers: { Accept: 'application/json' },
-    });
+    }, true, [200], 'listWorkflows');
     if (
       Object.keys(object).some((key) => key !== 'workflows')
       || !Array.isArray(object.workflows)
@@ -219,7 +219,7 @@ export class HttpTransport implements Transport {
     const object = await this.json(`/v1/workflows/${workflowPath(name)}`, {
       method: 'GET',
       headers: { Accept: 'application/json' },
-    });
+    }, true, [200], 'workflow');
     if (
       Object.keys(object).some((key) => key !== 'workflow')
       || !isContainedWorkflowName(object.workflow)
@@ -282,6 +282,9 @@ export class HttpTransport implements Transport {
     const object = await this.json(
       `/v1/jobs/${encodeURIComponent(jobId)}/trace/verify`,
       { method: 'GET', signal: options.signal },
+      true,
+      [200],
+      'traceVerify',
     );
     if (
       typeof object.verdict !== 'string'
@@ -391,7 +394,7 @@ export class HttpTransport implements Transport {
         const object = await this.json(`/v1/jobs/${encodeURIComponent(id)}/status`, {
           method: 'GET',
           headers: { Accept: 'application/json' },
-        });
+        }, true, [200], 'status');
         if (typeof object.status !== 'string' || !JOB_STATUSES.has(object.status)) {
           throw new NikaProtocolError(this.kind, 'Job status response was malformed');
         }
@@ -400,7 +403,7 @@ export class HttpTransport implements Transport {
       cancel: async (): Promise<NikaCancelResult> => {
         const object = await this.json(`/v1/jobs/${encodeURIComponent(id)}/cancel`, {
           method: 'POST',
-        });
+        }, true, [200], 'cancel');
         const durable = durableJob(object, id, this.kind);
         if (!isTerminal(durable.status)) {
           throw new NikaProtocolError(this.kind, 'Cancellation did not return a terminal job');
@@ -932,16 +935,34 @@ export class HttpTransport implements Transport {
     init: RequestInit,
     authenticated = true,
     acceptedStatuses: readonly number[] = [200],
+    operation?: NikaOperation,
   ): Promise<Record<string, unknown>> {
     const response = await this.fetchResponse(path, init, true, authenticated, false);
     if (!acceptedStatuses.includes(response.status)) {
-      await discardResponse(response);
       if (response.ok) {
+        await discardResponse(response);
         throw new NikaProtocolError(
           this.kind,
           `HTTP ${path} returned non-contract status ${response.status}`,
         );
       }
+      // A refusal the server typed as `{ error: { code, message } }` keeps its
+      // code. The message is engine-owned and already path-free; the bearer
+      // token is redacted defensively in case a hostile server echoes it.
+      const refusal = operation === undefined
+        ? undefined
+        : await this.readRefusal(response, path);
+      if (operation !== undefined && refusal) {
+        throw new NikaOperationError(
+          operation,
+          this.kind,
+          refusal.code,
+          `HTTP ${response.status} for ${path}: ${refusal.code}`
+          + (refusal.message ? ` (${refusal.message})` : ''),
+          { status: response.status, machineCode: refusal.code },
+        );
+      }
+      await discardResponse(response);
       throw new NikaTransportError(
         this.kind,
         `HTTP ${response.status} for ${path}: [REDACTED]`,
@@ -957,6 +978,55 @@ export class HttpTransport implements Transport {
       throw new NikaProtocolError(this.kind, `HTTP ${path} returned an invalid content-type`);
     }
     return this.readObservationObject(response, path, init.signal ?? undefined);
+  }
+
+  /**
+   * Read a non-2xx body only when the server typed it as an engine refusal.
+   * Anything else (plain text, oversized, malformed, a code that is not a
+   * plain identifier, a code that carries the bearer token) is discarded and
+   * the caller falls back to the redacted transport error.
+   */
+  private async readRefusal(
+    response: Response,
+    path: string,
+  ): Promise<{ code: string; message?: string } | undefined> {
+    const contentType = response.headers
+      .get('Content-Type')
+      ?.split(';', 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (contentType !== 'application/json') {
+      await discardResponse(response);
+      return undefined;
+    }
+    let object: Record<string, unknown>;
+    try {
+      object = await this.readObservationObject(response, path);
+    } catch {
+      return undefined;
+    }
+    const error = machineObject(object.error);
+    const code = error?.code;
+    if (
+      typeof code !== 'string'
+      || !/^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/.test(code)
+      || code.includes(this.options.token)
+    ) {
+      return undefined;
+    }
+    const message = typeof error?.message === 'string' && error.message.length > 0
+      ? this.redact(error.message)
+      : undefined;
+    return { code, ...(message ? { message } : {}) };
+  }
+
+  /** Engine messages are already path-free; a reflected bearer token never survives. */
+  private redact(text: string): string {
+    const clean = text
+      .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+      .split(this.options.token)
+      .join('[REDACTED]');
+    return clean.length > 240 ? `${clean.slice(0, 240)}...` : clean;
   }
 
   private async operationJson(

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,8 +281,18 @@ export interface NikaTraceVerifyOptions {
   signal?: AbortSignal;
 }
 
-/** The two operations that can fail before returning an engine projection. */
-export type NikaOperation = 'schedule' | 'scheduleStatus';
+/** The SDK operations whose engine refusal can be returned as a typed error. */
+export type NikaOperation =
+  | 'check'
+  | 'run'
+  | 'attachRun'
+  | 'status'
+  | 'cancel'
+  | 'listWorkflows'
+  | 'workflow'
+  | 'traceVerify'
+  | 'schedule'
+  | 'scheduleStatus';
 
 /** One engine-owned schedule finding. The vocabulary remains additive. */
 export interface NikaScheduleFinding {

--- a/test/http-depth-contract.test.ts
+++ b/test/http-depth-contract.test.ts
@@ -95,7 +95,13 @@ describe('HTTP configuration and bearer boundaries', () => {
       .resolves.toMatchObject({ verified: false });
     activeToken = TOKEN_B;
     await expect(oldClient.traceVerify({ job_id: 'job-1', trace_id: 'trace-1' }))
-      .rejects.toMatchObject({ name: 'NikaTransportError', transport: 'http' });
+      .rejects.toMatchObject({
+        name: 'NikaOperationError',
+        transport: 'http',
+        operation: 'traceVerify',
+        code: 'unauthorized',
+        status: 401,
+      });
     const rotatedClient = client(fetch as typeof globalThis.fetch, TOKEN_B);
     await expect(rotatedClient.traceVerify({ job_id: 'job-1', trace_id: 'trace-1' }))
       .resolves.toMatchObject({ trace_id: 'trace-1' });
@@ -297,7 +303,13 @@ describe('cross-client concurrency contracts', () => {
       ]);
       await expect(conflictClient.run('flow.nika.yaml', {
         idempotencyKey: 'shared-key',
-      })).rejects.toMatchObject({ name: 'NikaTransportError', transport: 'http' });
+      })).rejects.toMatchObject({
+        name: 'NikaOperationError',
+        transport: 'http',
+        operation: 'run',
+        code: 'idempotency_conflict',
+        status: 409,
+      });
       expect(admissions).toHaveLength(1);
     } finally {
       fixtureA.cleanup();

--- a/test/http-depth-contract.test.ts
+++ b/test/http-depth-contract.test.ts
@@ -209,9 +209,32 @@ describe('HTTP response framing, status, and deadlines', () => {
     } catch (cause) {
       failure = cause;
     }
-    expect(failure).toBeInstanceOf(NikaTransportError);
-    expect(failure).toMatchObject({ name: 'NikaTransportError', transport: 'http' });
+    expect(failure).toBeInstanceOf(NikaOperationError);
+    expect(failure).toMatchObject({
+      name: 'NikaOperationError',
+      transport: 'http',
+      operation: 'run',
+      code: 'idempotency_conflict',
+      status: 409,
+    });
+    expect(String(failure)).toContain('HTTP 409 for /v1/jobs: idempotency_conflict');
     expect(String(failure)).toContain('[REDACTED]');
+    expect(String(failure)).not.toContain(TOKEN_A);
+  });
+
+  it('keeps an untyped non-2xx body redacted', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response(`reflected ${TOKEN_A}`, { status: 502 }));
+    let failure: unknown;
+    try {
+      await transport(fetch as typeof globalThis.fetch).startRun('flow.nika.yaml', {});
+    } catch (cause) {
+      failure = cause;
+    }
+    expect(failure).toBeInstanceOf(NikaTransportError);
+    expect(failure).not.toBeInstanceOf(NikaOperationError);
+    expect(String(failure)).toContain('HTTP 502 for /v1/jobs: [REDACTED]');
     expect(String(failure)).not.toContain(TOKEN_A);
   });
 });

--- a/test/http-refusals.test.ts
+++ b/test/http-refusals.test.ts
@@ -65,15 +65,25 @@ describe('typed HTTP refusals', () => {
     });
   });
 
-  it('keeps a durable-job refusal typed on status and cancel', async () => {
-    const fetch = vi.fn()
-      .mockResolvedValueOnce(healthResponse())
-      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'running' }))
-      .mockResolvedValueOnce(jsonResponse(
-        { error: { code: 'job_not_found', message: 'job not found' } },
-        404,
-      ));
-    const nika = client(fetch as typeof globalThis.fetch);
+  it('keeps a durable-job refusal typed on status, then settles cancel', async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const path = new URL(String(input)).pathname;
+      if (path === '/health') return healthResponse();
+      if (path === '/v1/jobs/job-1') return jsonResponse({ id: 'job-1', status: 'running' });
+      if (path === '/v1/jobs/job-1/events') {
+        // An open stream that never yields: the run stays observed and non-terminal.
+        return new Response(new ReadableStream<Uint8Array>({ start() {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      }
+      if (path === '/v1/jobs/job-1/status') {
+        return jsonResponse({ error: { code: 'job_not_found', message: 'job not found' } }, 404);
+      }
+      if (path === '/v1/jobs/job-1/cancel') return jsonResponse({ id: 'job-1', status: 'cancelled' });
+      throw new Error(`unexpected ${path}`);
+    });
+    const nika = client(fetch as unknown as typeof globalThis.fetch);
     const run = await nika.attachRun('job-1');
     const refused = await failure(nika.status(run));
     expect(refused).toMatchObject({
@@ -82,6 +92,8 @@ describe('typed HTTP refusals', () => {
       code: 'job_not_found',
       status: 404,
     });
+    await expect(nika.cancel(run)).resolves.toMatchObject({ accepted: true, status: 'cancelled' });
+    await expect(run.done).resolves.toMatchObject({ status: 'cancelled' });
   });
 
   it('redacts a reflected bearer token inside the server message', async () => {

--- a/test/http-refusals.test.ts
+++ b/test/http-refusals.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Nika,
+  NikaOperationError,
+  NikaTransportError,
+} from '../src/index.js';
+import {
+  HTTP_DEPTH_FIXTURE,
+  TOKEN_A,
+  healthResponse,
+  jsonResponse,
+} from './helpers/http-depth-harness.js';
+
+function client(fetch: typeof globalThis.fetch): Nika {
+  return new Nika({
+    url: 'https://nika.example',
+    token: TOKEN_A,
+    bin: HTTP_DEPTH_FIXTURE,
+    fetch,
+  });
+}
+
+async function failure(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (cause) {
+    return cause;
+  }
+  throw new Error('expected a refusal');
+}
+
+describe('typed HTTP refusals', () => {
+  it('carries the server code for an unauthorized bearer', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(
+        { error: { code: 'unauthorized', message: 'authentication required' } },
+        401,
+      ));
+    const refused = await failure(client(fetch as typeof globalThis.fetch).listWorkflows());
+    expect(refused).toBeInstanceOf(NikaOperationError);
+    expect(refused).toMatchObject({
+      operation: 'listWorkflows',
+      transport: 'http',
+      code: 'unauthorized',
+      machineCode: 'unauthorized',
+      status: 401,
+      message: 'HTTP 401 for /v1/workflows: unauthorized (authentication required)',
+    });
+  });
+
+  it('names the admission refusal code the engine stamped on a 422', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(
+        { error: { code: 'NIKA-AUTH-006', message: 'effect under an absent permits block' } },
+        422,
+      ));
+    const refused = await failure(client(fetch as typeof globalThis.fetch).run('flow.nika.yaml'));
+    expect(refused).toMatchObject({
+      name: 'NikaOperationError',
+      operation: 'run',
+      code: 'NIKA-AUTH-006',
+      status: 422,
+    });
+  });
+
+  it('keeps a durable-job refusal typed on status and cancel', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'running' }))
+      .mockResolvedValueOnce(jsonResponse(
+        { error: { code: 'job_not_found', message: 'job not found' } },
+        404,
+      ));
+    const nika = client(fetch as typeof globalThis.fetch);
+    const run = await nika.attachRun('job-1');
+    const refused = await failure(nika.status(run));
+    expect(refused).toMatchObject({
+      name: 'NikaOperationError',
+      operation: 'status',
+      code: 'job_not_found',
+      status: 404,
+    });
+  });
+
+  it('redacts a reflected bearer token inside the server message', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(
+        { error: { code: 'unauthorized', message: `bad bearer ${TOKEN_A}\n\ttry again` } },
+        401,
+      ));
+    const refused = await failure(client(fetch as typeof globalThis.fetch).workflow('flow.nika.yaml'));
+    expect(refused).toBeInstanceOf(NikaOperationError);
+    expect(String(refused)).toContain('[REDACTED]');
+    expect(String(refused)).not.toContain(TOKEN_A);
+    expect(String(refused)).not.toMatch(/[\n\t]/);
+  });
+
+  it('falls back to the redacted transport error when the code is not an identifier', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(
+        { error: { code: `<script>${TOKEN_A}</script>`, message: 'nope' } },
+        403,
+      ));
+    const refused = await failure(client(fetch as typeof globalThis.fetch).listWorkflows());
+    expect(refused).toBeInstanceOf(NikaTransportError);
+    expect(refused).not.toBeInstanceOf(NikaOperationError);
+    expect(String(refused)).toBe('NikaTransportError: HTTP 403 for /v1/workflows: [REDACTED]');
+  });
+
+  it('falls back to the redacted transport error when the body is not JSON', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response('<html>gateway</html>', {
+        status: 503,
+        headers: { 'Content-Type': 'text/html' },
+      }));
+    const refused = await failure(client(fetch as typeof globalThis.fetch).listWorkflows());
+    expect(refused).toBeInstanceOf(NikaTransportError);
+    expect(String(refused)).toContain('HTTP 503 for /v1/workflows: [REDACTED]');
+  });
+
+  it('bounds an oversized refusal message', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(
+        { error: { code: 'unauthorized', message: 'x'.repeat(4_000) } },
+        401,
+      ));
+    const refused = await failure(client(fetch as typeof globalThis.fetch).listWorkflows());
+    expect(refused).toBeInstanceOf(NikaOperationError);
+    expect(String(refused).length).toBeLessThan(400);
+  });
+});

--- a/test/one-sdk.test.ts
+++ b/test/one-sdk.test.ts
@@ -461,7 +461,10 @@ describe('HTTP transport', () => {
       .mockResolvedValueOnce(jsonResponse({ error: { code: 'not_found' } }, 404));
     await expect(remote(fetch as typeof globalThis.fetch).attachRun('absent'))
       .rejects.toMatchObject({
-        name: 'NikaTransportError',
+        name: 'NikaOperationError',
+        operation: 'attachRun',
+        code: 'not_found',
+        status: 404,
         message: expect.stringContaining('HTTP 404'),
       });
     expect(fetch).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## The measured defect

Against the released engine `0.116.2 (c4cdbeafb)` and this client packed from `main`, every refusal `nika serve` sends is typed on the wire:

| wire | body |
|---|---|
| 401 | `{"error":{"code":"unauthorized","message":"authentication required"}}` |
| 404 | `{"error":{"code":"job_not_found","message":"job not found"}}` |
| 409 | `{"error":{"code":"idempotency_conflict","message":"idempotency key is already bound to another request"}}` |
| 422 | `{"error":{"code":"malformed_snapshot","message":"request body is not a valid execution snapshot"}}` |

and the client threw `NikaTransportError: HTTP <status> for <path>: [REDACTED]` for all of them (`http-transport.ts` `json()`), so an application could not tell an expired bearer from an idempotency conflict without matching the message text. The docs promise "an engine conflict, not a retry success" for a reused key; the error carried no way to see it.

## What changes

- A non-2xx body typed as `{ error: { code, message } }` now surfaces as `NikaOperationError` with `status`, `code` (also `machineCode`) and the refused `operation` (`check` · `run` · `attachRun` · `status` · `cancel` · `listWorkflows` · `workflow` · `traceVerify`). `NikaOperation` widens accordingly (additive).
- The code must be a plain identifier and may not carry the bearer token; the message is bounded to 240 chars, control characters are collapsed, and a reflected bearer token is replaced by `[REDACTED]`.
- Any other non-2xx body (plain text, HTML, malformed JSON, an illegal code) keeps the redacted `NikaTransportError`, so the hostile-server tests keep their meaning.
- README "Errors", `docs/http-api.md` and the changelog say so.

## Tests

`test/http-refusals.test.ts` (7 new cases: 401 · 422 with a stamped `NIKA-…` code · durable status 404 then cancel · reflected-token redaction · illegal code fallback · non-JSON fallback · oversized message bound) plus the three existing expectations that pinned the old shape (rotation 401 · conflict 409 · attach 404) now pin the typed one. `npm test` 196/196 · `tsc` · `build` · `check:coverage` green.

## Notes for the reviewer

- Pre-1.0 intentional change of class for typed 4xx bodies (`NikaTransportError` → `NikaOperationError`); catchers of `NikaError` are unaffected.
- A sibling PR (teaching reports) also adds `'run'` to `NikaOperation`; whichever lands second rebases a one-line type union.
- Do not merge on my behalf; squash when you are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)