### PR TITLE
fix(sdk): type the http event kinds and settle the terminal guard on both transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previous transport shape, so existing callers compile unchanged.
 - Branded opaque `NikaRunId`, `NikaExecutionId`, and `NikaJobId` identity
   types on the run surfaces that already carried those identities.
+- Typed HTTP transport event kinds on the `NikaEvent` union
+  (`NikaExecutionStartedEvent`, `NikaExecutionSettledEvent`,
+  `NikaExecutionCancelledEvent`, `NikaExecutionRefusedEvent`,
+  `NikaExecutionInterruptedEvent`), alongside the transport-agnostic
+  `isNikaTerminalEvent` guard, which narrows any frame the engine reported
+  with a terminal status rather than matching on its kind.
+
+### Fixed
+
+- `isNikaRunSettledEvent` now narrows the HTTP settlement frame
+  (`execution.settled`) as well as the native `run_settled` one. It
+  previously never returned true on a `nika serve` stream, so the documented
+  way to read status, outputs, and receipt together was dead on that
+  transport.
 
 ## [0.116.2] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -348,17 +348,22 @@ Remote-only options:
 
 ### Typed events, outputs, and identities
 
-`NikaEvent` is a discriminated union over the known lifecycle kinds
-(`workflow_started`, `task_scheduled`, `task_started`, `task_completed`,
-`workflow_completed`, `workflow_failed`, `workflow_interrupted`,
-`run_settled`, `run_sealed`). Kinds this SDK version does not know yet stay
-representable through the `NikaUnknownEvent` fallback, so the union is
-intentionally non-exhaustive and every variant keeps its future fields open.
+`NikaEvent` is a discriminated union over the known lifecycle kinds of both
+transports. A native engine process emits `workflow_started`,
+`task_scheduled`, `task_started`, `task_completed`, `workflow_completed`,
+`workflow_failed`, `workflow_interrupted`, `run_settled`, and `run_sealed`. A
+`nika serve` job streams `execution.started`, `execution.settled`,
+`execution.cancelled`, `execution.refused`, and `execution.interrupted` (a
+resident that restarts marks an orphaned running job `interrupted`). Kinds
+this SDK version does not know yet stay representable through the
+`NikaUnknownEvent` fallback, so the union is intentionally non-exhaustive and
+every variant keeps its future fields open.
 
 `run`, `attachRun`, and `events` accept one `Outputs` type argument. It types
 the terminal settlement — `run.done` and the `run_settled` /
-`workflow_completed` frames — without any runtime validation, and defaults to
-`Record<string, unknown>` so untyped callers see no change:
+`execution.settled` / `workflow_completed` frames — without any runtime
+validation, and defaults to `Record<string, unknown>` so untyped callers see
+no change:
 
 ```ts
 const run = await nika.run<{ answer: number }>('flow.nika.yaml');
@@ -366,9 +371,24 @@ const result = await run.done;          // result.outputs?: { answer: number }
 
 for await (const event of nika.events(run)) {
   if (isNikaRunSettledEvent(event)) {
-    // event is NikaRunSettledEvent<{ answer: number }> here:
-    // status, outputs, and receipt typed together on the terminal frame.
+    // The settlement frame of either transport (`run_settled` natively,
+    // `execution.settled` over HTTP): status, outputs, and receipt typed
+    // together on the one frame that carries all three.
     console.log(event.status, event.outputs?.answer, event.receipt);
+  }
+}
+```
+
+A run can also end without settling outputs — cancelled, refused, or
+interrupted. `isNikaTerminalEvent(event)` narrows those too: it reads the
+engine-reported `status` (`succeeded`, `failed`, `interrupted`, `cancelled`)
+rather than the kind, so it holds on either transport and on kinds this SDK
+version does not know yet:
+
+```ts
+for await (const event of nika.events(run)) {
+  if (isNikaTerminalEvent(event)) {
+    console.log('no further frames for this run:', event.status);
   }
 }
 ```

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,18 +1,48 @@
 import type {
   NikaEvent,
+  NikaExecutionSettledEvent,
   NikaRunSealedEvent,
   NikaRunSettledEvent,
 } from './types.js';
 
+/** The statuses after which the engine sends no further frame for a run. */
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  'succeeded',
+  'failed',
+  'interrupted',
+  'cancelled',
+]);
+
 /**
  * Narrows any run event to the terminal settlement frame, which carries the
- * run's status, outputs, and receipt together. Kind equality alone cannot
- * exclude the forward-compatibility variant; this guard can.
+ * run's status, outputs, and receipt together. Both transports have one: the
+ * native process emits `run_settled`, `nika serve` emits `execution.settled`.
+ * Kind equality alone cannot exclude the forward-compatibility variant; this
+ * guard can.
  */
 export function isNikaRunSettledEvent<
   Outputs extends Record<string, unknown> = Record<string, unknown>,
->(event: NikaEvent<Outputs>): event is NikaRunSettledEvent<Outputs> {
-  return event.kind === 'run_settled';
+>(
+  event: NikaEvent<Outputs>,
+): event is NikaRunSettledEvent<Outputs> | NikaExecutionSettledEvent<Outputs> {
+  return event.kind === 'run_settled' || event.kind === 'execution.settled';
+}
+
+/**
+ * Narrows any run event to a terminal one by the status the engine reported,
+ * not by its kind, so it holds on either transport and across kinds this SDK
+ * version does not know yet. It therefore also covers the frames that end a
+ * run without settling outputs: `execution.cancelled`, `execution.refused`,
+ * `interrupted`, `workflow_failed`, and `workflow_interrupted`.
+ */
+export function isNikaTerminalEvent<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+>(
+  event: NikaEvent<Outputs>,
+): event is NikaEvent<Outputs> & {
+  status: 'succeeded' | 'failed' | 'interrupted' | 'cancelled';
+} {
+  return typeof event.status === 'string' && TERMINAL_STATUSES.has(event.status);
 }
 
 /** Narrows any run event to the frame that sealed the run's trace chain. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,6 +259,7 @@ export { NikaEngineUnavailable };
 export {
   isNikaRunSealedEvent,
   isNikaRunSettledEvent,
+  isNikaTerminalEvent,
 } from './events.js';
 
 export type {
@@ -271,7 +272,12 @@ export type {
   NikaRemoteConfig,
   NikaEvent,
   NikaEventsOptions,
+  NikaExecutionCancelledEvent,
   NikaExecutionId,
+  NikaExecutionInterruptedEvent,
+  NikaExecutionRefusedEvent,
+  NikaExecutionSettledEvent,
+  NikaExecutionStartedEvent,
   NikaJobId,
   NikaMachineError,
   NikaReceipt,

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,8 +134,9 @@ export interface NikaWorkflowInterruptedEvent extends NikaEventFields {
 }
 
 /**
- * The terminal settlement frame of a durable `nika serve` job: the one frame
- * that carries the run's outputs, receipt, and final status together.
+ * The terminal settlement frame of a native engine process: the one frame
+ * that carries the run's outputs, receipt, and final status together. Its
+ * HTTP peer is `execution.settled`; one guard narrows both.
  */
 export interface NikaRunSettledEvent<
   Outputs extends Record<string, unknown> = Record<string, unknown>,
@@ -153,6 +154,46 @@ export interface NikaRunSealedEvent extends NikaEventFields {
 }
 
 /**
+ * The HTTP transport admitted the execution and it is running. This is the
+ * first lifecycle frame `nika serve --bind` streams for a durable job.
+ */
+export interface NikaExecutionStartedEvent extends NikaEventFields {
+  kind: 'execution.started';
+}
+
+/**
+ * The terminal settlement frame of the HTTP transport, and the peer of
+ * `run_settled`: the one frame that carries the run's outputs, receipt, and
+ * final status together.
+ */
+export interface NikaExecutionSettledEvent<
+  Outputs extends Record<string, unknown> = Record<string, unknown>,
+> extends NikaEventFields {
+  kind: 'execution.settled';
+  status?: NikaRunStatus;
+  outputs?: Outputs;
+  receipt?: NikaReceipt;
+}
+
+/** An accepted cancellation ended the execution before it settled. */
+export interface NikaExecutionCancelledEvent extends NikaEventFields {
+  kind: 'execution.cancelled';
+}
+
+/** The server refused the execution. */
+export interface NikaExecutionRefusedEvent extends NikaEventFields {
+  kind: 'execution.refused';
+}
+
+/**
+ * The execution was interrupted before settling. A resident that restarts
+ * marks an orphaned running job with either word, so both are one variant.
+ */
+export interface NikaExecutionInterruptedEvent extends NikaEventFields {
+  kind: 'execution.interrupted' | 'interrupted';
+}
+
+/**
  * Forward-compatibility variant: any kind this SDK version does not know
  * yet stays representable, so the event union is intentionally
  * non-exhaustive.
@@ -162,10 +203,12 @@ export interface NikaUnknownEvent extends NikaEventFields {
 }
 
 /**
- * One engine-owned run event. Known kinds discriminate on `kind`; unknown
- * kinds fall back to `NikaUnknownEvent`. Future fields stay open on every
- * variant. `Outputs` types the terminal frames' outputs and defaults to the
- * transport shape, so untyped callers see no change.
+ * One engine-owned run event, from either transport: the native process emits
+ * the `workflow_*` / `task_*` / `run_*` kinds, `nika serve` emits the
+ * `execution.*` kinds. Known kinds discriminate on `kind`; unknown kinds fall
+ * back to `NikaUnknownEvent`. Future fields stay open on every variant.
+ * `Outputs` types the terminal frames' outputs and defaults to the transport
+ * shape, so untyped callers see no change.
  */
 export type NikaEvent<
   Outputs extends Record<string, unknown> = Record<string, unknown>,
@@ -179,6 +222,11 @@ export type NikaEvent<
   | NikaWorkflowInterruptedEvent
   | NikaRunSettledEvent<Outputs>
   | NikaRunSealedEvent
+  | NikaExecutionStartedEvent
+  | NikaExecutionSettledEvent<Outputs>
+  | NikaExecutionCancelledEvent
+  | NikaExecutionRefusedEvent
+  | NikaExecutionInterruptedEvent
   | NikaUnknownEvent;
 
 /**

--- a/test/typed-terminal.test.ts
+++ b/test/typed-terminal.test.ts
@@ -1,15 +1,21 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import {
   isNikaRunSealedEvent,
   isNikaRunSettledEvent,
+  isNikaTerminalEvent,
   Nika,
 } from '../src/index.js';
 import type {
   NikaCancelResult,
   NikaEvent,
+  NikaExecutionCancelledEvent,
   NikaExecutionId,
+  NikaExecutionInterruptedEvent,
+  NikaExecutionRefusedEvent,
+  NikaExecutionSettledEvent,
+  NikaExecutionStartedEvent,
   NikaJobId,
   NikaReceipt,
   NikaRun,
@@ -19,6 +25,13 @@ import type {
   NikaRunSettledEvent,
   NikaRunStatus,
 } from '../src/index.js';
+import {
+  HTTP_DEPTH_FIXTURE,
+  TOKEN_A,
+  healthResponse,
+  jsonResponse,
+  sseResponse,
+} from './helpers/http-depth-harness.js';
 
 const FIXTURE = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -26,6 +39,24 @@ const FIXTURE = path.join(
   'fake-nika.mjs',
 );
 const posix = process.platform !== 'win32';
+
+/** The engine's terminal statuses, whichever transport reported them. */
+const TERMINAL_STATUSES = ['succeeded', 'failed', 'interrupted', 'cancelled'] as const;
+
+/** An engine-issued receipt for the durable job observed below. */
+const HTTP_RECEIPT = Object.freeze({
+  job_id: 'durable-job',
+  execution_id: 'execution-1',
+  trace_id: 'trace-1',
+  snapshot_digest: 'a'.repeat(64),
+});
+
+// Every expectTypeOf assertion in this file is judged by `tsc`; vitest runs it
+// as a no-op, so a green run alone does not prove one. The repo tsconfig covers
+// `src`, so typecheck this file explicitly to make them speak:
+//   npx tsc --noEmit --strict --target ES2022 --module ESNext \
+//     --moduleResolution bundler --skipLibCheck --lib ES2022,DOM \
+//     test/typed-terminal.test.ts
 
 // Compile-time only: this function is never invoked, so nothing in it runs.
 async function genericFlows(client: Nika): Promise<void> {
@@ -50,11 +81,18 @@ async function genericFlows(client: Nika): Promise<void> {
       >();
     }
     if (isNikaRunSettledEvent(event)) {
-      // The guard narrows to the exact terminal frame.
-      expectTypeOf(event).toEqualTypeOf<NikaRunSettledEvent<{ answer: number }>>();
+      // The guard narrows to the settlement frame of either transport.
+      expectTypeOf(event).toEqualTypeOf<
+        NikaRunSettledEvent<{ answer: number }> | NikaExecutionSettledEvent<{ answer: number }>
+      >();
       expectTypeOf(event.outputs).toEqualTypeOf<{ answer: number } | undefined>();
       expectTypeOf(event.status).toEqualTypeOf<NikaRunStatus | undefined>();
       expectTypeOf(event.receipt).toEqualTypeOf<NikaReceipt | undefined>();
+    }
+    if (isNikaTerminalEvent(event)) {
+      // Status, not kind, is the axis: the frame is terminal and says so.
+      expectTypeOf(event.status).not.toEqualTypeOf<NikaRunStatus | undefined>();
+      expectTypeOf(event.status).toExtend<NikaRunStatus>();
     }
   }
 
@@ -84,6 +122,30 @@ describe('typed terminal hop', () => {
     expectTypeOf<NikaRunResult['diagnostics']>().toEqualTypeOf<unknown>();
   });
 
+  it('types the HTTP transport event kinds the engine actually emits', () => {
+    expectTypeOf<NikaExecutionStartedEvent['kind']>().toEqualTypeOf<'execution.started'>();
+    expectTypeOf<NikaExecutionSettledEvent['kind']>().toEqualTypeOf<'execution.settled'>();
+    expectTypeOf<NikaExecutionCancelledEvent['kind']>().toEqualTypeOf<'execution.cancelled'>();
+    expectTypeOf<NikaExecutionRefusedEvent['kind']>().toEqualTypeOf<'execution.refused'>();
+    // A resident that restarts marks an orphaned running job with either word.
+    expectTypeOf<NikaExecutionInterruptedEvent['kind']>()
+      .toEqualTypeOf<'execution.interrupted' | 'interrupted'>();
+    // The HTTP settlement frame carries the same three payloads as run_settled.
+    expectTypeOf<NikaExecutionSettledEvent<{ answer: number }>['outputs']>()
+      .toEqualTypeOf<{ answer: number } | undefined>();
+    expectTypeOf<NikaExecutionSettledEvent['status']>().toEqualTypeOf<NikaRunStatus | undefined>();
+    expectTypeOf<NikaExecutionSettledEvent['receipt']>().toEqualTypeOf<NikaReceipt | undefined>();
+    // Every new variant keeps its future fields open.
+    expectTypeOf<NikaExecutionSettledEvent['future_field']>().toEqualTypeOf<unknown>();
+    expectTypeOf<NikaExecutionStartedEvent['future_field']>().toEqualTypeOf<unknown>();
+    // The union stays non-exhaustive: the new kinds join, they do not close it.
+    expectTypeOf<NikaExecutionStartedEvent>().toExtend<NikaEvent>();
+    expectTypeOf<NikaExecutionSettledEvent>().toExtend<NikaEvent>();
+    expectTypeOf<NikaExecutionCancelledEvent>().toExtend<NikaEvent>();
+    expectTypeOf<NikaExecutionRefusedEvent>().toExtend<NikaEvent>();
+    expectTypeOf<NikaExecutionInterruptedEvent>().toExtend<NikaEvent>();
+  });
+
   it('keeps unknown event kinds representable by design', () => {
     const future = {
       kind: 'execution.custom_2030',
@@ -93,6 +155,8 @@ describe('typed terminal hop', () => {
     } satisfies NikaEvent;
     expect(isNikaRunSettledEvent(future)).toBe(false);
     expect(isNikaRunSealedEvent(future)).toBe(false);
+    // A kind we cannot name is still terminal when its status says so.
+    expect(isNikaTerminalEvent(future)).toBe(true);
   });
 
   it('brands identities while keeping them assignable to string', () => {
@@ -120,6 +184,48 @@ describe('terminal frame guards', () => {
     expect(isNikaRunSettledEvent({ kind: 'task_completed' })).toBe(false);
     expect(isNikaRunSettledEvent({ kind: 'execution.custom' })).toBe(false);
     expect(isNikaRunSettledEvent({})).toBe(false);
+  });
+
+  it('recognizes the settlement frame of either transport', () => {
+    // Measured HTTP terminal frame: kind execution.settled, status succeeded.
+    expect(isNikaRunSettledEvent({
+      kind: 'execution.settled',
+      status: 'succeeded',
+      outputs: { answer: 42 },
+      receipt: HTTP_RECEIPT,
+    })).toBe(true);
+    expect(isNikaRunSettledEvent({ kind: 'execution.settled' })).toBe(true);
+    // The other HTTP kinds are not the settlement frame.
+    expect(isNikaRunSettledEvent({ kind: 'execution.started', status: 'running' })).toBe(false);
+    expect(isNikaRunSettledEvent({ kind: 'execution.cancelled', status: 'cancelled' })).toBe(false);
+    expect(isNikaRunSettledEvent({ kind: 'execution.refused' })).toBe(false);
+    expect(isNikaRunSettledEvent({ kind: 'interrupted', status: 'interrupted' })).toBe(false);
+  });
+
+  it('recognizes a terminal frame by status on either transport', () => {
+    for (const status of TERMINAL_STATUSES) {
+      expect(isNikaTerminalEvent({ kind: 'execution.settled', status })).toBe(true);
+      expect(isNikaTerminalEvent({ kind: 'run_settled', status })).toBe(true);
+      // A refusal is terminal on whichever terminal status it carries.
+      expect(isNikaTerminalEvent({ kind: 'execution.refused', status })).toBe(true);
+      expect(isNikaTerminalEvent({ status })).toBe(true);
+    }
+    // Measured frames from both transports.
+    expect(isNikaTerminalEvent({ kind: 'execution.cancelled', status: 'cancelled' })).toBe(true);
+    expect(isNikaTerminalEvent({ kind: 'interrupted', status: 'interrupted' })).toBe(true);
+    expect(isNikaTerminalEvent({ kind: 'execution.interrupted', status: 'interrupted' }))
+      .toBe(true);
+    expect(isNikaTerminalEvent({ kind: 'workflow_completed', status: 'succeeded' })).toBe(true);
+    expect(isNikaTerminalEvent({ kind: 'workflow_failed', status: 'failed' })).toBe(true);
+    expect(isNikaTerminalEvent({ kind: 'workflow_interrupted', status: 'interrupted' }))
+      .toBe(true);
+    // Non-terminal or status-free frames are not terminal.
+    expect(isNikaTerminalEvent({ kind: 'execution.started', status: 'running' })).toBe(false);
+    expect(isNikaTerminalEvent({ kind: 'workflow_started', status: 'queued' })).toBe(false);
+    expect(isNikaTerminalEvent({ kind: 'task_completed' })).toBe(false);
+    expect(isNikaTerminalEvent({ kind: 'run_sealed' })).toBe(false);
+    expect(isNikaTerminalEvent({ status: 'paused' })).toBe(false);
+    expect(isNikaTerminalEvent({})).toBe(false);
   });
 
   it('recognizes only the seal frame', () => {
@@ -151,5 +257,109 @@ describe.skipIf(!posix)('typed terminal hop through a real run', () => {
       outputs: { answer: 42 },
     });
     expect(seen).toEqual(['workflow_started', 'task_completed', 'workflow_completed']);
+  });
+});
+
+describe('typed terminal hop through the HTTP transport', () => {
+  it('fires the settlement guard once, on the execution.settled frame', async () => {
+    // The wire vocabulary measured against a live `nika serve --bind`:
+    // [[1,"execution.started","running"],[2,"execution.settled","succeeded"]].
+    const frames = [
+      { sequence: 1, kind: 'execution.started', status: 'running' },
+      {
+        sequence: 2,
+        kind: 'execution.settled',
+        status: 'succeeded',
+        outputs: { answer: 1 },
+        receipt: HTTP_RECEIPT,
+      },
+    ] satisfies NikaEvent[];
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const path = new URL(String(input)).pathname;
+      if (path === '/health') return healthResponse();
+      if (path === '/v1/jobs/durable-job') {
+        return jsonResponse({ id: 'durable-job', status: 'running' });
+      }
+      if (path === '/v1/jobs/durable-job/events') return sseResponse(frames);
+      throw new Error(`unexpected ${path}`);
+    });
+    const client = new Nika({
+      url: 'https://nika.example',
+      token: TOKEN_A,
+      bin: HTTP_DEPTH_FIXTURE,
+      fetch: fetch as typeof globalThis.fetch,
+    });
+
+    const run = await client.attachRun<{ answer: number }>('durable-job');
+    const kinds: Array<string | undefined> = [];
+    const settledAnswers: Array<number | undefined> = [];
+    const terminalKinds: Array<string | undefined> = [];
+    for await (const event of client.events(run)) {
+      kinds.push(event.kind);
+      if (isNikaRunSettledEvent(event)) {
+        expectTypeOf(event.outputs).toEqualTypeOf<{ answer: number } | undefined>();
+        settledAnswers.push(event.outputs?.answer);
+        expect(event.receipt).toEqual(HTTP_RECEIPT);
+        expect(event.status).toBe('succeeded');
+      }
+      if (isNikaTerminalEvent(event)) terminalKinds.push(event.kind);
+    }
+
+    expect(kinds).toEqual(['execution.started', 'execution.settled']);
+    // The guard the README teaches now fires on the HTTP transport too.
+    expect(settledAnswers).toEqual([1]);
+    expect(terminalKinds).toEqual(['execution.settled']);
+    await expect(run.done).resolves.toMatchObject({
+      id: 'durable-job',
+      status: 'succeeded',
+      transport: 'http',
+      outputs: { answer: 1 },
+      receipt: HTTP_RECEIPT,
+    });
+  });
+
+  it('reads cancelled and interrupted frames as terminal without a settlement', async () => {
+    // Measured cancel: [[1,"execution.started","running"],[2,"execution.cancelled","cancelled"]].
+    // Measured resident restart then attachRun: [[2,"interrupted","interrupted"]].
+    for (const terminal of [
+      { sequence: 2, kind: 'execution.cancelled', status: 'cancelled' },
+      { sequence: 2, kind: 'interrupted', status: 'interrupted' },
+    ] satisfies NikaEvent[]) {
+      const frames = [
+        { sequence: 1, kind: 'execution.started', status: 'running' },
+        terminal,
+      ] satisfies NikaEvent[];
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const path = new URL(String(input)).pathname;
+        if (path === '/health') return healthResponse();
+        if (path === '/v1/jobs/durable-job') {
+          return jsonResponse({ id: 'durable-job', status: 'running' });
+        }
+        if (path === '/v1/jobs/durable-job/events') return sseResponse(frames);
+        throw new Error(`unexpected ${path}`);
+      });
+      const client = new Nika({
+        url: 'https://nika.example',
+        token: TOKEN_A,
+        bin: HTTP_DEPTH_FIXTURE,
+        fetch: fetch as typeof globalThis.fetch,
+      });
+
+      const run = await client.attachRun('durable-job');
+      const observed: Array<[string | undefined, boolean, boolean]> = [];
+      for await (const event of client.events(run)) {
+        observed.push([
+          event.kind,
+          isNikaRunSettledEvent(event),
+          isNikaTerminalEvent(event),
+        ]);
+      }
+
+      expect(observed).toEqual([
+        ['execution.started', false, false],
+        [terminal.kind, false, true],
+      ]);
+      await expect(run.done).resolves.toMatchObject({ status: terminal.status });
+    }
   });
 });


### PR DESCRIPTION
## The measured defect

Frames streamed by a live `nika serve --bind` (released engine 0.116.2, this client packed from `main`):

```
normal run      [[1,"execution.started","running"],[2,"execution.settled","succeeded"]]
after cancel    [[1,"execution.started","running"],[2,"execution.cancelled","cancelled"]]
after a restart [[2,"interrupted","interrupted"]]   (attachRun on an orphaned running job)
```

The serve job store owns that vocabulary (`execution.settled`, `execution.refused`, `execution.interrupted`, `interrupted` in `crates/nika-serve/src/job/store`); the SDK's `NikaEvent` union knew only the native `workflow_*` / `task_*` / `run_*` kinds. So `isNikaRunSettledEvent` never returned true on the HTTP transport and the README's documented way to read status, outputs and receipt off one frame was silently dead on one of the two transports.

## What changes

- `NikaEvent` gains the typed HTTP variants (`execution.started`, `execution.settled` with typed outputs + receipt, `execution.cancelled`, `execution.refused`, `execution.interrupted | interrupted`); `NikaUnknownEvent` stays the open fallback.
- `isNikaRunSettledEvent` narrows the settlement frame of either transport (`run_settled | execution.settled`).
- New `isNikaTerminalEvent` reads the engine-reported status (`succeeded | failed | interrupted | cancelled`), the same predicate the transport already uses to settle `run.done`, so it also covers the frames that end a run without settling outputs.
- README "Typed events" and the changelog say so.

## Tests

`test/typed-terminal.test.ts` grows from 6 to 11 cases (proven red first: the settled guard returned false on `execution.settled` and the terminal guard did not exist); an HTTP case drives a mocked fetch through the real `HttpTransport` (attachRun + SSE + receipt identity). `npm test` 193/193 · `tsc` · `build` · `check:coverage` green.

## Notes for the reviewer

- The narrowed type of `isNikaRunSettledEvent` widens to a two-member union; property access is unchanged.
- Found while reviewing: `tsconfig.json` includes only `src/`, so the `expectTypeOf` assertions in `test/` are runtime no-ops in CI (the new type-level cases were mutation-proved under an ad-hoc `tsc` run; the exact command is a header comment in the test). Wiring a `tsconfig.test.json` type check is a separate change.
- Do not merge on my behalf; squash when you are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)