### PR TITLE
fix(sdk): surface the engine's teaching reports instead of hiding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Branded opaque `NikaRunId`, `NikaExecutionId`, and `NikaJobId` identity
   types on the run surfaces that already carried those identities.
 
+### Fixed
+
+- HTTP `check()` of a red workflow now returns the engine's plain teaching
+  report with `findings[]`; the snapshot capture refuses such a workflow with
+  one error line, which is preserved as `snapshot_error`. No workflow bytes
+  are sent on that path.
+- Native `check()` now reads the check report the engine routes to stderr
+  behind its `nika: ` prefix instead of reporting an engine incompatibility;
+  when neither stream carries a report, the typed error appends a bounded
+  single-line excerpt of stderr.
+- A pre-run engine refusal printed as a plain `NIKA-…` line under `--json`
+  now settles `run.done` with `NikaOperationError` (`operation: 'run'`, the
+  engine code, the full refusal line) instead of a protocol error; any other
+  unreadable machine line keeps `NikaProtocolError` and now quotes a bounded
+  excerpt of the offending line. `NikaOperation` gains `'run'`, additively.
+- Engine spawn failures name the engine path and the underlying errno, so a
+  wrong `bin`/`NIKA_BIN` reads as `spawn /path/to/nika ENOENT`.
+
 ## [0.116.2] - 2026-08-31
 
 Lockstep recovery release for engine v0.116.2. The HTTP schema is unchanged

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ await watching;
 console.log(result.status, result.outputs, result.receipt);
 ```
 
+A red `check()` report carries the engine's `findings[]` on both transports, so
+the check → teach → re-draft loop reads one shape whether the engine runs
+locally or behind `nika serve`.
+
 `run()` returns after stable admission. `run.done` is the sole terminal result.
 An admitted workflow failure is result data with `status: "failed"`; transport,
 protocol, configuration, and compatibility failures throw typed SDK errors.
@@ -397,6 +401,10 @@ Native engine event vocabulary stays open. HTTP events instead enforce the
 closed, redacted `JobEvent` projection advertised by the pinned OpenAPI contract;
 unknown HTTP fields are rejected at the trust boundary. The SDK never turns an
 unpriced model into `$0`.
+
+An engine refusal printed before a run starts — a `NIKA-…` code line such as a
+cost-floor refusal — settles `run.done` with a `NikaOperationError` carrying
+`operation: 'run'`, the engine's code, and its full refusal line.
 
 ## Security boundaries
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,9 @@ Some operations deliberately have one authority:
   `NikaCompatibilityError`;
 - remote execution still needs a compatible local engine to capture an
   immutable snapshot before any network admission;
+- when that capture is red the HTTP adapter returns the local engine's plain
+  `nika check --json` report, so `findings[]` stays canonical and no workflow
+  bytes are sent;
 - HTTP observation (attach, durable status, events, cancel, workflow catalog,
   schedule status, trace verdicts) needs no local engine;
 - remote trace verification currently returns the engine's typed unavailable

--- a/src/lib/engine-capture.ts
+++ b/src/lib/engine-capture.ts
@@ -60,9 +60,10 @@ export function captureEngine(
       if (options.signal?.aborted) {
         reject(new NikaTransportError(options.transport, `${options.label} aborted by caller`));
       } else if (spawnError) {
+        // Name the path and the errno: a wrong NIKA_BIN is the common cause.
         reject(new NikaTransportError(
           options.transport,
-          `Cannot spawn engine for ${options.label}`,
+          `Cannot spawn ${bin} for ${options.label}: ${spawnError.message}`,
           { cause: spawnError },
         ));
       } else if (overflow) {

--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -119,7 +119,7 @@ export class HttpTransport implements Transport {
         'Remote snapshot capture does not support model or nativeStrict overrides',
       );
     }
-    const captured = await this.captureSnapshot(workflow, options.signal);
+    const captured = await this.captureSnapshot(workflow, options.signal, true);
     if (captured.bytes === undefined) return captured.report;
     const snapshot = captured.identity;
     if (!snapshot) {
@@ -874,6 +874,7 @@ export class HttpTransport implements Transport {
   private async captureSnapshot(
     workflow: string,
     signal?: AbortSignal,
+    teach = false,
   ): Promise<CapturedSnapshot> {
     const identity = await this.ensureLocalEngine();
     const captured = await captureEngine(
@@ -901,6 +902,9 @@ export class HttpTransport implements Transport {
     delete report.execution_snapshot;
     if (captured.exitCode !== 0 || outer.clean !== true) {
       report.clean = false;
+      if (teach && !Array.isArray(outer.findings)) {
+        return { report: await this.teachingReport(workflow, report, signal) };
+      }
       return { report: report as NikaCheckResult };
     }
     compatibleEngineIdentity(outer, this.kind, identity);
@@ -925,6 +929,48 @@ export class HttpTransport implements Transport {
       bytes,
       identity: snapshotIdentity(bytes, this.kind),
     };
+  }
+
+  /**
+   * A red workflow has no exportable snapshot, so the capture returns one
+   * error line and no findings. Ask the same local engine for its plain
+   * teaching report, so `findings[]` reads the same on both transports. The
+   * refused capture line is preserved as `snapshot_error` rather than
+   * overwriting whatever the engine put in `error`. No bytes leave the
+   * machine on this path: the caller still sees `clean: false`.
+   */
+  private async teachingReport(
+    workflow: string,
+    refused: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<NikaCheckResult> {
+    const captured = await captureEngine(
+      this.localEngine().bin,
+      ['check', workflow, '--json'],
+      {
+        cwd: this.options.cwd,
+        signal,
+        bufferBytes: this.options.machineBufferBytes,
+        transport: this.kind,
+        label: 'SDK teaching check',
+      },
+    );
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(captured.stdout.trim());
+    } catch {
+      return refused as NikaCheckResult;
+    }
+    const plain = machineObject(parsed);
+    if (!plain) return refused as NikaCheckResult;
+    const report: Record<string, unknown> = {
+      ...plain,
+      clean: false,
+      exitCode: captured.exitCode,
+      ...(refused.error === undefined ? {} : { snapshot_error: refused.error }),
+    };
+    delete report.execution_snapshot;
+    return report as NikaCheckResult;
   }
 
   private async json(
@@ -1185,7 +1231,9 @@ function operationFindings(values: unknown[]): NikaOperationFinding[] | undefine
 }
 
 function pathForOperation(operation: NikaOperation): string {
-  return operation === 'schedule' ? 'schedule apply' : 'schedule status';
+  if (operation === 'schedule') return 'schedule apply';
+  if (operation === 'scheduleStatus') return 'schedule status';
+  return operation;
 }
 
 function isTerminal(status: unknown): status is string {

--- a/src/lib/native-process-transport.ts
+++ b/src/lib/native-process-transport.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import type { Readable } from 'node:stream';
 import {
   NikaCompatibilityError,
+  NikaOperationError,
   NikaProtocolError,
   NikaTransportError,
 } from '../errors.js';
@@ -22,6 +23,7 @@ import type {
   NikaScheduleStatus,
   NikaTraceVerifyOptions,
   NikaTraceVerifyResult,
+  NikaTransportKind,
   NikaWorkflowMetadata,
 } from '../types.js';
 import {
@@ -60,14 +62,18 @@ export class NativeProcessTransport implements Transport {
     if (options.model) args.push('--model', options.model);
     if (options.nativeStrict) args.push('--native-strict');
     const captured = await this.capture(args, options.signal);
-    let report: Record<string, unknown>;
-    try {
-      report = parseMachineObject(captured.stdout.trim(), this.kind);
-    } catch (cause) {
+    // The engine routes some reports (a missing file, a parse-fatal read) to
+    // stderr behind a `nika: ` prefix. That is still the engine judging these
+    // bytes, so read it rather than blaming the engine for incompatibility.
+    const report = reportObject(captured.stdout)
+      ?? reportObject(stripEnginePrefix(captured.stderr));
+    if (!report) {
+      const excerpt = diagnosticExcerpt(captured.stderr);
       throw new NikaCompatibilityError(
         'check',
         this.kind,
-        `This engine did not emit the required JSON check report (exit ${captured.exitCode})`,
+        `This engine did not emit the required JSON check report (exit ${captured.exitCode})`
+        + (excerpt ? `: ${excerpt}` : ''),
       );
     }
     return { ...report, exitCode: captured.exitCode } as NikaCheckResult;
@@ -185,6 +191,7 @@ export class NativeProcessTransport implements Transport {
     let outputs: Record<string, unknown> | undefined;
     let machineError: ReturnType<typeof eventError>;
     let streamError: Error | undefined;
+    let refusal: EngineRefusal | undefined;
     let resolveDrained!: () => void;
     const drained = new Promise<void>((resolve) => {
       resolveDrained = resolve;
@@ -215,6 +222,17 @@ export class NativeProcessTransport implements Transport {
 
     const kind = this.kind;
     const machineBufferBytes = this.options.machineBufferBytes;
+    // A plain `NIKA-…` line under --json is the engine refusing the run, not a
+    // broken machine stream. Hold it and let run.done carry the typed verdict
+    // with the real exit status; the event stream simply carried no frame.
+    const lineEvent = (line: string): NikaEvent | undefined => {
+      const refused = engineRefusal(line);
+      if (refused) {
+        refusal ??= refused;
+        return undefined;
+      }
+      return machineLine(line, kind) as NikaEvent;
+    };
     const events: AsyncIterable<NikaEvent> = {
       [Symbol.asyncIterator]: async function* () {
         let buffer = '';
@@ -227,7 +245,8 @@ export class NativeProcessTransport implements Transport {
               const line = buffer.slice(0, newline).trim();
               buffer = buffer.slice(newline + 1);
               if (!line) continue;
-              const event = parseMachineObject(line, kind) as NikaEvent;
+              const event = lineEvent(line);
+              if (!event) continue;
               lastEvent = event;
               receipt = eventReceipt(event) ?? receipt;
               outputs = eventOutputs(event) ?? outputs;
@@ -243,12 +262,14 @@ export class NativeProcessTransport implements Transport {
           }
           const tail = buffer.trim();
           if (tail) {
-            const event = parseMachineObject(tail, kind) as NikaEvent;
-            lastEvent = event;
-            receipt = eventReceipt(event) ?? receipt;
-            outputs = eventOutputs(event) ?? outputs;
-            machineError = eventError(event) ?? machineError;
-            yield event;
+            const event = lineEvent(tail);
+            if (event) {
+              lastEvent = event;
+              receipt = eventReceipt(event) ?? receipt;
+              outputs = eventOutputs(event) ?? outputs;
+              machineError = eventError(event) ?? machineError;
+              yield event;
+            }
           }
         } catch (cause) {
           streamError = cause instanceof Error ? cause : new Error(String(cause));
@@ -262,6 +283,15 @@ export class NativeProcessTransport implements Transport {
 
     const done = Promise.all([closed, drained]).then(([exitCode]): NikaRunResult => {
       if (streamError) throw streamError;
+      if (refusal) {
+        throw new NikaOperationError(
+          'run',
+          this.kind,
+          refusal.code,
+          refusal.line,
+          { status: exitCode },
+        );
+      }
       const status = eventStatus(lastEvent) ?? statusForExit(exitCode, lastEvent?.kind);
       return {
         id,
@@ -358,6 +388,63 @@ export class NativeProcessTransport implements Transport {
   private ensureReady(): Promise<void> {
     this.ready ??= verifyNikaEngine(this.options.engine).then(() => undefined);
     return this.ready;
+  }
+}
+
+interface EngineRefusal {
+  code: string;
+  line: string;
+}
+
+/** The engine prefixes a stream-routed report with its own name. */
+const ENGINE_PREFIX = /^nika:\s*/;
+/** A refusal line opens with the engine code that owns the verdict. */
+const REFUSAL_CODE = /^(NIKA-[A-Z0-9-]+)\b/;
+const DIAGNOSTIC_EXCERPT_LIMIT = 240;
+
+function reportObject(text: string): Record<string, unknown> | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  let value: unknown;
+  try {
+    value = JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+  return machineObject(value);
+}
+
+function stripEnginePrefix(text: string): string {
+  return text.trim().replace(ENGINE_PREFIX, '');
+}
+
+/** One bounded single-line excerpt so a typed refusal still teaches. */
+function diagnosticExcerpt(text: string, limit = DIAGNOSTIC_EXCERPT_LIMIT): string | undefined {
+  const single = stripEnginePrefix(text).replace(/\s+/g, ' ').trim();
+  if (!single) return undefined;
+  return single.length > limit ? `${single.slice(0, limit)}…` : single;
+}
+
+/** No JSON value can open with `NIKA-`, so a match is never a machine frame. */
+function engineRefusal(line: string): EngineRefusal | undefined {
+  const code = REFUSAL_CODE.exec(line)?.[1];
+  return code ? { code, line } : undefined;
+}
+
+/** Keep the protocol verdict, and quote the line that earned it. */
+function machineLine(line: string, kind: NikaTransportKind): Record<string, unknown> {
+  try {
+    return parseMachineObject(line, kind);
+  } catch (cause) {
+    const verdict = cause instanceof Error
+      ? cause.message
+      : 'Engine machine output was unreadable';
+    const excerpt = diagnosticExcerpt(line);
+    throw new NikaProtocolError(
+      kind,
+      excerpt ? `${verdict}: ${excerpt}` : verdict,
+      { cause: cause instanceof Error ? cause : undefined },
+    );
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,8 +281,8 @@ export interface NikaTraceVerifyOptions {
   signal?: AbortSignal;
 }
 
-/** The two operations that can fail before returning an engine projection. */
-export type NikaOperation = 'schedule' | 'scheduleStatus';
+/** The operations that can be refused before they return an engine projection. */
+export type NikaOperation = 'run' | 'schedule' | 'scheduleStatus';
 
 /** One engine-owned schedule finding. The vocabulary remains additive. */
 export interface NikaScheduleFinding {

--- a/test/fixtures/fake-nika.mjs
+++ b/test/fixtures/fake-nika.mjs
@@ -32,6 +32,52 @@ if (command === 'check') {
     }, 5_000);
     return;
   }
+  if (workflow.includes('stderr-report')) {
+    // The engine wrote its report to stderr behind a `nika: ` prefix.
+    console.error(`nika: ${JSON.stringify({
+      clean: false,
+      findings: [{
+        gate: 'PARSE',
+        kind: 'parse',
+        message: `cannot read ${workflow}: No such file or directory (os error 2)`,
+        severity: 'error',
+      }],
+      parse_fatal: true,
+      report_version: 1,
+    }, null, 1)}`);
+    process.exit(3);
+  }
+  if (workflow.includes('stderr-plain')) {
+    // Neither stream carries a JSON object; only prose reaches the caller.
+    console.error('nika: the engine could not produce a check report for this input');
+    process.exit(3);
+  }
+  if (workflow.includes('red-snapshot')) {
+    if (sdkSnapshot) {
+      // A red workflow has no exportable snapshot: one error line, no findings.
+      console.log(JSON.stringify({
+        error: {
+          message: 'cannot export execution snapshot: captured workflow failed check: '
+            + `NIKA-AUTH-006 ${workflow}: invoke \`nika:write\` is not permitted `
+            + '— fix: add "nika:write" to permits.tools',
+        },
+      }));
+      process.exit(2);
+    }
+    console.log(JSON.stringify({
+      report_version: 1,
+      clean: false,
+      argv,
+      findings: [{
+        code: 'NIKA-AUTH-006',
+        gate: 'AUTH',
+        kind: 'permits',
+        severity: 'error',
+        message: 'invoke `nika:write` is not permitted — fix: add "nika:write" to permits.tools',
+      }],
+    }));
+    process.exit(2);
+  }
   if (sdkSnapshot && workflow.includes('parse-fatal')) {
     console.log(JSON.stringify({
       report_version: 1,
@@ -65,6 +111,21 @@ if (command === 'check') {
 
 if (command === 'run' && argv.includes('--json')) {
   const emit = (value) => console.log(JSON.stringify(value));
+
+  if (workflow.includes('refuse-1709')) {
+    // A pre-run refusal: one plain code line under --json, no machine frame.
+    console.log(
+      "NIKA-1709 · refusing to start: the workflow's unavoidable cost floor $0.000005 "
+      + 'exceeds --max-cost-usd $0.000000 (cheapest static path · gates closed · first-try) '
+      + '— raise the budget or trim the workflow (`nika check` shows the envelope)',
+    );
+    process.exit(2);
+  }
+
+  if (workflow.includes('garbage-line')) {
+    console.log('this line is not machine output at all');
+    process.exit(0);
+  }
 
   if (workflow.includes('cancel')) {
     emit({ kind: 'workflow_started' });

--- a/test/teaching-reports.test.ts
+++ b/test/teaching-reports.test.ts
@@ -1,0 +1,138 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { Nika, NikaCompatibilityError, NikaOperationError } from '../src/index.js';
+import type { NikaLocalConfig } from '../src/index.js';
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'fake-nika.mjs',
+);
+const SERVER_TOKEN = 's'.repeat(32);
+
+function native(overrides: Omit<NikaLocalConfig, 'bin'> = {}): Nika {
+  return new Nika({ bin: FIXTURE, ...overrides });
+}
+
+function remote(fetch: typeof globalThis.fetch): Nika {
+  return new Nika({
+    url: 'https://nika.example/',
+    token: SERVER_TOKEN,
+    bin: FIXTURE,
+    fetch,
+  });
+}
+
+function healthResponse(): Response {
+  return new Response(JSON.stringify({
+    status: 'ok',
+    service: 'nika-serve',
+    engineVersion: '0.114.0',
+    machineProtocolVersion: 1,
+    snapshotFormatVersion: 1,
+    checkReportVersion: 1,
+    eventFormatVersion: 1,
+    traceFormatVersion: 1,
+    supportedCapabilities: ['check', 'executionSnapshot', 'eventStream', 'trace'],
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+function findings(report: Record<string, unknown>): Record<string, unknown>[] {
+  expect(Array.isArray(report.findings)).toBe(true);
+  return report.findings as Record<string, unknown>[];
+}
+
+describe('the engine teaching report survives every transport', () => {
+  it('falls back to the plain check report when snapshot capture is red', async () => {
+    const fetch = vi.fn().mockResolvedValueOnce(healthResponse());
+    const report = await remote(fetch as typeof globalThis.fetch)
+      .check('red-snapshot.nika.yaml');
+
+    expect(report).toMatchObject({ clean: false, exitCode: 2, report_version: 1 });
+    expect(findings(report)[0]).toMatchObject({
+      code: 'NIKA-AUTH-006',
+      gate: 'AUTH',
+    });
+    expect(String(findings(report)[0]?.message)).toContain('permits.tools');
+    // The refused snapshot line is kept, never in place of the findings.
+    expect(String((report.snapshot_error as { message?: string })?.message))
+      .toContain('cannot export execution snapshot');
+    expect(report).not.toHaveProperty('execution_snapshot');
+    // Only /health was reached: a red workflow never crosses the network.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls.map(([url]) => String(url)))
+      .toEqual(['https://nika.example/health']);
+  });
+
+  it('keeps a clean remote check on the snapshot admission path', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        status: 'accepted',
+        snapshot_digest: 'a'.repeat(64),
+        root: 'fixture.nika.yaml',
+        units: 1,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const report = await remote(fetch as typeof globalThis.fetch).check('flow.nika.yaml');
+
+    expect(report).toMatchObject({ clean: true, exitCode: 0 });
+    expect(report).not.toHaveProperty('snapshot_error');
+    expect(String(fetch.mock.calls[1]?.[0])).toBe('https://nika.example/v1/check');
+  });
+
+  it('reads the native check report the engine wrote to stderr', async () => {
+    const report = await native().check('stderr-report.nika.yaml');
+
+    expect(report).toMatchObject({
+      clean: false,
+      exitCode: 3,
+      parse_fatal: true,
+      report_version: 1,
+    });
+    expect(String(findings(report)[0]?.message)).toContain('cannot read');
+  });
+
+  it('teaches from stderr when neither stream carries a report', async () => {
+    const failure = await native().check('stderr-plain.nika.yaml').catch((cause) => cause);
+
+    expect(failure).toBeInstanceOf(NikaCompatibilityError);
+    expect((failure as NikaCompatibilityError).capability).toBe('check');
+    expect((failure as Error).message).toContain('(exit 3)');
+    expect((failure as Error).message).toContain('could not produce a check report');
+  });
+
+  it('surfaces a pre-run engine refusal as a typed operation error', async () => {
+    const run = await native().run('refuse-1709.nika.yaml');
+    const failure = await run.done.catch((cause) => cause);
+
+    expect(failure).toBeInstanceOf(NikaOperationError);
+    expect(failure).toMatchObject({
+      name: 'NikaOperationError',
+      operation: 'run',
+      code: 'NIKA-1709',
+      transport: 'native-process',
+      status: 2,
+    });
+    expect((failure as Error).message).toContain('refusing to start');
+    expect((failure as Error).message).toContain('--max-cost-usd');
+  });
+
+  it('keeps a protocol error for machine output that is not a refusal', async () => {
+    const run = await native().run('garbage-line.nika.yaml');
+    const failure = await run.done.catch((cause) => cause);
+
+    expect(failure).toMatchObject({ name: 'NikaProtocolError', transport: 'native-process' });
+    expect((failure as Error).message).toContain('this line is not machine output at all');
+  });
+
+  it('names the engine path and the spawn errno when the engine cannot start', async () => {
+    const failure = await new Nika({ bin: '/nonexistent/nika' })
+      .check('flow.nika.yaml')
+      .catch((cause) => cause);
+
+    expect(failure).toBeInstanceOf(NikaCompatibilityError);
+    expect((failure as Error).message).toContain('/nonexistent/nika');
+    expect((failure as Error).message).toContain('ENOENT');
+  });
+});


### PR DESCRIPTION
## The measured shapes (released engine 0.116.2 · client packed from `main` · 2026-09-01)

| | what the engine did | what the SDK said |
|---|---|---|
| A | HTTP `check()` of any red workflow: `--sdk-snapshot` answers `{"error":{"message":"… NIKA-AUTH-006 … fix: add …"}}` (exit 2), no `findings[]` | `{ clean:false, exitCode:2, error:{…} }` with no findings, while the native transport returns `findings:[{code:'NIKA-AUTH-006'…}]` for the same file |
| B | `nika check missing.nika.yaml --json`: exit 3, stdout empty, the JSON report on stderr behind `nika: ` | `NikaCompatibilityError: This engine did not emit the required JSON check report (exit 3)` (a missing file became an engine incompatibility) |
| C | `nika run priced --json --max-cost-usd 0`: exit 2, stdout is the plain line `NIKA-1709 · refusing to start: …` | `NikaProtocolError: Engine machine output was not valid JSON` (the refusal code was lost) |
| D | `bin: '/nonexistent/nika'` or `NIKA_BIN=<a directory>` | `Engine identity probe failed: Cannot spawn engine for Engine identity probe` (no path, no errno) |

B and C are engine machine-mode defects too (reproductions posted on supernovae-st/nika#1247); the SDK must still read what the engine actually wrote.

## What changes

- A · on a red snapshot capture the HTTP adapter asks the same local engine for its plain `check --json` teaching report, so `findings[]` reads the same on both transports; the refused capture line survives as `snapshot_error`; no bytes leave the machine on that path.
- B · a report the engine routes to stderr behind `nika: ` is parsed and returned; when neither stream carries a report the typed error appends a bounded stderr excerpt.
- C · a plain `NIKA-…` line under `run --json` settles `run.done` with `NikaOperationError` (`operation: 'run'`, the engine code, the full line, the real exit status); any other unreadable line keeps `NikaProtocolError` and now quotes it. `NikaOperation` gains `'run'` (additive).
- D · spawn failures name the engine path and the errno.

## Tests

`test/teaching-reports.test.ts` (7 cases, red first on the fixture shapes) · `npm test` 195/195 · `tsc` · `build` · `check:coverage` green.

## Notes for the reviewer

- The fixture pins the four shapes as measured; no test runs the real binary here (the gauntlet scripts do).
- `startRun()` over HTTP still throws the existing `NikaCompatibilityError` on a red file without spending a second engine call; callers get the findings from `check()`.
- Sibling PR #74 also widens `NikaOperation`; whichever lands second rebases the union.
- Do not merge on my behalf; squash when you are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)