### PR TITLE
fix(sdk): plaintext http stays loopback-only even with the opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Branded opaque `NikaRunId`, `NikaExecutionId`, and `NikaJobId` identity
   types on the run surfaces that already carried those identities.
 
+### Security
+
+- `allowInsecureHttp: true` now admits plaintext HTTP only for a loopback host
+  (`localhost`, `127.0.0.0/8`, `[::1]`); any other host over `http:` is a
+  `NikaConfigurationError`, so the opt-in can no longer send a bearer token in
+  clear text to a routable address.
+
 ## [0.116.2] - 2026-08-31
 
 Lockstep recovery release for engine v0.116.2. The HTTP schema is unchanged

--- a/README.md
+++ b/README.md
@@ -238,9 +238,12 @@ from the workflow's truth, and a still-running record rejects with
 `NikaObservationInterrupted`, whose `lastSequence` feeds
 `attachRun(id, { lastEventId })` to resume.
 
-Plain HTTP is refused unless `allowInsecureHttp: true` is explicit. Use HTTPS
-for a non-loopback deployment. A URL may not contain credentials, a query, or a
-fragment, and a 32–512 byte visible-ASCII token is mandatory.
+Plain HTTP is accepted only for a loopback host (`localhost`, `127.0.0.0/8`,
+`[::1]`), and only when `allowInsecureHttp: true` is explicit. Every other host
+must use HTTPS: the opt-in widens the scheme, never the destination, so the
+bearer token never leaves the machine in plaintext. A URL may not contain
+credentials, a query, or a fragment, and a 32–512 byte visible-ASCII token is
+mandatory.
 
 Remote snapshots currently do not have request envelopes for per-call `vars`,
 `model`, or `maxCostUsd`; declare those facts in the workflow. Likewise,
@@ -402,7 +405,8 @@ unpriced model into `$0`.
 
 - Token files stay out of argv and must be private (`0600`, 32–512 visible
   ASCII bytes).
-- The constructor refuses accidental plaintext HTTP.
+- The constructor refuses plaintext HTTP off loopback, and requires the
+  explicit `allowInsecureHttp: true` opt-in on loopback.
 - `permits` remain default-deny engine policy; SDK types do not grant authority.
 - Machine frames, diagnostics, SSE lines, and observer queues are bounded.
 - Receipts and traces are engine-issued proof. The SDK never synthesizes them.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -20,8 +20,9 @@ route except public `GET /health`; bearer tokens are redacted from failures.
 
 ## Connection rules
 
-- HTTPS is required by default. Loopback HTTP needs
-  `allowInsecureHttp: true`.
+- HTTPS is required for every host except loopback. Plain HTTP is accepted
+  only for `localhost`, `127.0.0.0/8`, or `[::1]`, and only with an explicit
+  `allowInsecureHttp: true`; that opt-in never admits a routable host.
 - URLs containing credentials, a query, or a fragment are rejected.
 - Tokens must contain 32–512 visible ASCII bytes and are never sent to
   `/health`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,15 +193,42 @@ function checkedUrl(value: string, allowInsecureHttp: boolean): string {
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new NikaConfigurationError('Nika URL must use https: or http:');
   }
-  if (url.protocol === 'http:' && !allowInsecureHttp) {
-    throw new NikaConfigurationError(
-      'Plain HTTP requires allowInsecureHttp: true; prefer HTTPS for remote engines',
-    );
+  if (url.protocol === 'http:') {
+    if (!allowInsecureHttp) {
+      throw new NikaConfigurationError(
+        'Plain HTTP requires allowInsecureHttp: true; prefer HTTPS for remote engines',
+      );
+    }
+    // The opt-in widens the scheme, never the destination: a bearer token
+    // must not leave the host in plaintext.
+    if (!isLoopbackHost(url.hostname)) {
+      throw new NikaConfigurationError(
+        'Plain HTTP is limited to loopback hosts (localhost, 127.0.0.0/8, [::1]); '
+        + `use HTTPS for ${url.hostname}`,
+      );
+    }
   }
   if (url.username || url.password || url.search || url.hash) {
     throw new NikaConfigurationError('Nika URL cannot contain credentials, a query, or a fragment');
   }
   return url.toString().replace(/\/$/, '');
+}
+
+const LOOPBACK_IPV4 = /^127(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/;
+const IPV4_MAPPED_IPV6 = /^::ffff:([0-9a-f]{1,4}):[0-9a-f]{1,4}$/;
+
+/**
+ * `URL.hostname` is already normalized: IPv4 shorthand becomes a dotted quad,
+ * IPv6 stays bracketed and compressed (`[::ffff:127.0.0.1]` -> `[::ffff:7f00:1]`).
+ */
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (host === 'localhost') return true;
+  if (LOOPBACK_IPV4.test(host)) return true;
+  const literal = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  if (literal === '::1') return true;
+  const mapped = literal.match(IPV4_MAPPED_IPV6);
+  return mapped !== null && Number.parseInt(mapped[1], 16) >>> 8 === 0x7f;
 }
 
 function checkedToken(value: string): string {

--- a/test/http-depth-contract.test.ts
+++ b/test/http-depth-contract.test.ts
@@ -72,6 +72,53 @@ describe('HTTP configuration and bearer boundaries', () => {
       .toThrow(NikaConfigurationError);
   });
 
+  it.each([
+    ['http://198.51.100.7:8787', '198.51.100.7'],
+    ['http://example.test', 'example.test'],
+    ['http://[2001:db8::1]:8787', '[2001:db8::1]'],
+    ['http://127.0.0.1.evil.test', '127.0.0.1.evil.test'],
+  ])('refuses plaintext %s off loopback even with the opt-in', (url, host) => {
+    let thrown: unknown;
+    try {
+      new Nika({ url, token: TOKEN_A, allowInsecureHttp: true, bin: HTTP_DEPTH_FIXTURE });
+    } catch (cause) {
+      thrown = cause;
+    }
+    expect(thrown).toBeInstanceOf(NikaConfigurationError);
+    const message = (thrown as NikaConfigurationError).message;
+    expect(message).toContain('loopback');
+    expect(message).toContain(host);
+    expect(message).not.toContain(TOKEN_A);
+  });
+
+  it.each([
+    'http://127.0.0.1:8787',
+    'http://127.1.2.3:8787',
+    'http://localhost:8787',
+    'http://[::1]:8787',
+    'http://[::ffff:127.0.0.1]:8787',
+  ])('admits explicit loopback plaintext %s', (url) => {
+    expect(new Nika({
+      url,
+      token: TOKEN_A,
+      allowInsecureHttp: true,
+      bin: HTTP_DEPTH_FIXTURE,
+    }).transportKind).toBe('http');
+  });
+
+  it('still demands the explicit opt-in on loopback and never on HTTPS', () => {
+    expect(() => new Nika({
+      url: 'http://127.0.0.1:8787',
+      token: TOKEN_A,
+      bin: HTTP_DEPTH_FIXTURE,
+    })).toThrow(/allowInsecureHttp/);
+    expect(new Nika({
+      url: 'https://198.51.100.7',
+      token: TOKEN_A,
+      bin: HTTP_DEPTH_FIXTURE,
+    }).transportKind).toBe('http');
+  });
+
   it('keeps token rotation instance-scoped and never authenticates health', async () => {
     let activeToken = TOKEN_A;
     const seen: Array<{ path: string; authorization: string | null }> = [];


### PR DESCRIPTION
## The measured defect

`new Nika({ url: 'http://198.51.100.7:8787', token, allowInsecureHttp: true })` constructed an HTTP client (measured 2026-09-01 on the client packed from `main`). The README says the opt-in is "required for explicit loopback HTTP" and "Use HTTPS for a non-loopback deployment"; `docs/http-api.md` says "Loopback HTTP needs allowInsecureHttp: true". The code only checked the scheme, so the opt-in also sent a bearer token in plaintext to any routable host.

## What changes

- `checkedUrl` accepts `http:` only with the explicit opt-in AND a loopback host (`localhost`, `127.0.0.0/8`, `[::1]`, the IPv4-mapped `[::ffff:127.x.y.z]`). Any other host with `http:` throws `NikaConfigurationError` naming the host and the rule; the missing-opt-in message is unchanged and checked first.
- README, `docs/http-api.md` and the changelog now state the gate as it is.

## Tests

Ten new rows in `test/http-depth-contract.test.ts` (red first: the three off-loopback rows failed with "expected undefined to be an instance of NikaConfigurationError"), including `http://127.0.0.1.evil.test` refused, `[::ffff:127.0.0.1]` admitted, and the token never in a message. `npm test` 198/198 · `tsc` · `build` · `check:coverage` green.

## Notes for the reviewer

- `http://0/` (normalises to `0.0.0.0`) is refused; `http://2130706433` (normalises to `127.0.0.1`) is admitted. Both follow the rule; treating `0.0.0.0` as loopback would be a separate decision.
- Pre-1.0 intentional tightening: anyone relying on plaintext off loopback with the opt-in now gets a typed refusal.
- Do not merge on my behalf; squash when you are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)