### PR TITLE
docs(sdk): make the README say what the packed client actually does

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ Observation-only clients need no local engine: `attachRun`, `status`,
 `events`, `cancel`, `schedule`, `scheduleStatus`, `listWorkflows`, `workflow`,
 and `traceVerify` run against the advertised server identity alone.
 
-The current persistent server requires a project file. A minimal `nika.yaml`
-is enough:
+The current persistent server requires a project file. If you ran
+`nika init --project-file` above you already have one (it carries a default
+cost ceiling); do not overwrite it. Otherwise a minimal `nika.yaml` is enough:
 
 ```yaml
 nika: my-project
@@ -400,7 +401,13 @@ for await (const event of nika.events(run)) {
 
 Run, execution, and job identities are branded opaque strings (`NikaRunId`,
 `NikaExecutionId`, `NikaJobId`). They remain assignable to `string`, but a
-plain `string` no longer stands in for one.
+plain `string` no longer stands in for one. Four words name three things:
+a **workflow** is the file (or resident name) you pass in; a **run** is this
+client's handle on one admission (`run.id`), and over HTTP that same string
+is the server's **job** id (`/v1/jobs/{id}`, `attachRun(jobId)`); an
+**execution** is the engine's own identity for what actually ran
+(`execution_id`, the `execution.*` event kinds), distinct from the run id and
+carried by the receipt together with the `trace_id`.
 
 ## Errors
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ terminal `succeeded` line with the outputs and the receipt.
 `run()` returns after stable admission. `run.done` is the sole terminal result.
 An admitted workflow failure is result data with `status: "failed"`; transport,
 protocol, configuration, and compatibility failures throw typed SDK errors.
+A `try { await run.done } catch {}` alone therefore never catches a failed
+workflow: a CI job or an application must read `result.status` and treat
+anything but `succeeded` as its own failure, or a red run passes silently.
 
 ## Verify a local trace
 
@@ -410,6 +413,7 @@ workflow name that escapes the catalog) throws a plain `TypeError` or
 ```text
 NikaError
 ├── NikaConfigurationError
+├── NikaEngineUnavailable
 ├── NikaTransportError
 │   ├── NikaProtocolError
 │   └── NikaObservationInterrupted

--- a/README.md
+++ b/README.md
@@ -137,7 +137,13 @@ if (!proof.verified) throw new Error(proof.output ?? 'trace verification failed'
 ```
 
 The SDK does not implement cryptography or inspect the trace itself. It asks the
-engine to verify the receipt and its signed binding. The remote endpoint
+engine to verify the receipt and its signed binding. A receipt from a native
+run carries the proof-bearing fields (`chain_head`, `chain_len`, `sealed`,
+`trace_path`) and verifies locally. A receipt from a `nika serve` job carries
+identity only (`job_id`, `execution_id`, `trace_id`, `snapshot_digest`,
+`origin`): the resident writes no trace journal yet, so that receipt verifies
+through no door today, and the same `NikaReceipt` type covers both shapes.
+Persist it as the job's identity, not as evidence. The remote endpoint
 currently returns `{ verified: false, verdict: "unavailable", reason:
 "trace_journal_unavailable" }` because the server has no path-free journal
 authority; the typed verdict is preserved instead of being hidden as a 404.
@@ -252,11 +258,14 @@ Plain HTTP is refused unless `allowInsecureHttp: true` is explicit. Use HTTPS
 for a non-loopback deployment. A URL may not contain credentials, a query, or a
 fragment, and a 32–512 byte visible-ASCII token is mandatory.
 
-Remote snapshots currently do not have request envelopes for per-call `vars`,
-`model`, or `maxCostUsd`; declare those facts in the workflow. Likewise,
-remote `check` does not accept `model` or `nativeStrict` overrides. Supplying
-these options returns a typed compatibility refusal instead of silently
-dropping them.
+Remote snapshots currently do not have request envelopes for per-call `vars`
+or `model`; declare those facts in the workflow. There is no per-run spend
+bound over HTTP at all today: `maxCostUsd` is refused, the workflow language
+has no budget field, and the resident applies its own server-wide default
+ceiling. Bound a remote run by its model and `max_tokens` until the request
+envelope carries a ceiling. Likewise, remote `check` does not accept `model`
+or `nativeStrict` overrides. Supplying these options returns a typed
+compatibility refusal instead of silently dropping them.
 
 ## Resident schedules
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ not parse YAML or reconstruct proof in TypeScript.
 
 ## Requirements
 
-- Node.js 22 or newer
+- Node.js 22 or newer (the tested floor; an older major is unsupported, not
+  refused, and `npm install` does not warn about it)
 - a compatible `nika` engine, resolved from `config.bin`, then `NIKA_BIN`,
-  then the exact optional platform package; implicit `PATH` lookup is refused
+  then the exact optional platform package; a `nika` found on `PATH` is
+  deliberately never used
 - a `.nika.yaml` workflow
 
 ## Documentation
@@ -68,8 +70,11 @@ The lowest-friction creation door is the engine-owned scaffold:
 ```
 
 `nika.yaml` is the project control plane. `hello.nika.yaml` is executable
-workflow intent and is the file passed to `check()` and `run()`. The generated
-workflow has this public envelope:
+workflow intent and is the file passed to `check()` and `run()`. The scaffold
+writes the engine's own annotated `01-hello` example (its task is named
+`greet` and its prompt asks for French); the contract this README relies on is
+the `outputs.greeting` key and the `mock/echo` model, and the same file can be
+written by hand with this public envelope:
 
 ```yaml
 nika: sdk-hello
@@ -102,7 +107,8 @@ if (!report.clean) throw new Error('workflow did not pass nika check');
 const run = await nika.run('hello.nika.yaml', { maxCostUsd: 0 });
 const watching = (async () => {
   for await (const event of nika.events(run)) {
-    console.log(event.kind, event.status);
+    // Native progress frames carry no status; only the terminal frame does.
+    console.log(event.kind, event.status ?? '');
   }
 })();
 
@@ -110,6 +116,10 @@ const result = await run.done;
 await watching;
 console.log(result.status, result.outputs, result.receipt);
 ```
+
+Expected output: `workflow_started`, `task_scheduled`, `task_started`,
+`task_completed`, `workflow_completed`, then `run_settled succeeded`, then the
+terminal `succeeded` line with the outputs and the receipt.
 
 `run()` returns after stable admission. `run.done` is the sole terminal result.
 An admitted workflow failure is result data with `status: "failed"`; transport,
@@ -291,8 +301,11 @@ Treat any `status.finding` recovered from older state as non-runnable. New activ
 declarations the current engine cannot plan are refused before durable mutation.
 Timed hash jitter is currently unsupported and returns a typed refusal.
 Cron expressions carry their zone as `TZ=<IANA zone> ...`; `tolerance` uses
-`m/k`; `afterSkip` requires `overlap: "skip"`; and `active: false` requires a
-`pauseUntil` ISO calendar date (`YYYY-MM-DD`).
+`m/k`; `afterSkip` requires `overlap: "skip"` (the engine's default, so an
+omitted `overlap` satisfies it); and `active: false` requires a `pauseReason`
+together with a `pauseUntil` ISO calendar date (`YYYY-MM-DD`). Schedules refuse
+`maxCostUsd: 0` ("must be positive and finite") where a native `run()` accepts
+it; a scheduled budget is always a real number.
 
 ## Transport matrix
 
@@ -379,7 +392,11 @@ plain `string` no longer stands in for one.
 
 ## Errors
 
-Every SDK error extends `NikaError`:
+Every error the SDK raises for an engine, transport, configuration, or
+compatibility condition extends `NikaError`. Misuse of the API itself (an empty
+workflow name, a negative event cursor, a receipt that is not an object, a
+workflow name that escapes the catalog) throws a plain `TypeError` or
+`RangeError` before any engine or network work starts:
 
 ```text
 NikaError

--- a/docs/migrating-to-0.116.md
+++ b/docs/migrating-to-0.116.md
@@ -71,6 +71,31 @@ a process restart instead of rebuilding a handle by hand.
 `nika run --dry-run --json`, and `nika test`) until a future typed authority is
 explicitly admitted. This release does not silently emulate them.
 
+## The check report changed shape
+
+`check()` still returns `clean` and `exitCode`, but the object around them is
+no longer the 0.115 `LocalCheckReport` (eleven curated fields plus a `raw`
+escape hatch). It is the engine's own machine report, passed through: the
+former `raw` contents are now the top level, `reportVersion` is
+`report_version`, and `parseFatal` and `warnings` are gone. The engine emits
+its identity under both casings (`engineVersion` and `engine_version`,
+`buildSha` and `build_sha`, `specSha` and `spec_sha`, `checkReportVersion`
+and `report_version`); read either, do not diff them. In TypeScript only
+`report_version`, `clean`, and `exitCode` are typed; every other field,
+including `cost`, `findings`, and `hints`, is `unknown` behind an index
+signature, so strict callers narrow it themselves. Two problems that look like
+findings (a missing `permits:` block, a missing `max_tokens:`) are reported
+under `hints[]` (`{ kind, task, advice }`, no `code`), not `findings[]`, in
+both versions.
+
+`runToEnd()` returned `{ ok, exitCode, events[] }` with every event buffered.
+`run.done` returns the terminal result only; the events ride `events(run)`
+as a bounded live iterator (default 256), so observe it concurrently or the
+prefix is gone. The removed methods (`version()`, `dryRunPlan()`, path-based
+`traceVerify()`) are absent, not stubbed: calling them throws a plain
+`TypeError: … is not a function`, and a trace that only exists as a file
+path in a later process has no SDK verification door in 0.116.
+
 ## New resident discovery
 
 ```ts

--- a/src/lib/binary/error.ts
+++ b/src/lib/binary/error.ts
@@ -10,11 +10,14 @@ export class NikaEngineUnavailable extends NikaError {
   constructor(platform: string, arch: string, packageName?: string) {
     const target = `${platform}-${arch}`;
     const detail = packageName
-      ? `the optional payload ${packageName} is not installed`
+      ? `the optional payload ${packageName} is not installed `
+        + '(npm leaves it UNMET OPTIONAL when the registry has no version matching this client)'
       : 'there is no packaged payload for this host';
     super(
       `Nika engine unavailable for ${target}: ${detail}. `
-      + 'Install optional dependencies, set NIKA_BIN, or pass config.bin.',
+      + 'A nika found on PATH is deliberately not used. '
+      + 'Set NIKA_BIN=/absolute/path/to/nika, pass config.bin, '
+      + 'or install the matching payload package.',
     );
     this.name = 'NikaEngineUnavailable';
     this.platform = platform;

--- a/test/native-resolver.test.ts
+++ b/test/native-resolver.test.ts
@@ -62,5 +62,12 @@ describe('native binary resolver', () => {
       code: 'NIKA_ENGINE_UNAVAILABLE',
       packageName: '@supernovae-st/nika-darwin-arm64',
     });
+    // The refusal teaches every valid path and names the one it will not take.
+    const message = String((caught as Error).message);
+    expect(message).toContain('NIKA_BIN=/absolute/path/to/nika');
+    expect(message).toContain('config.bin');
+    expect(message).toContain('payload package');
+    expect(message).toContain('PATH is deliberately not used');
+    expect(message).toContain('UNMET OPTIONAL');
   });
 });


### PR DESCRIPTION
## Six claims measured on 2026-09-01 (released engine 0.116.2 · client packed from `main`) that did not hold as written

| claim | measured | change |
|---|---|---|
| first-run example prints `event.kind, event.status` | native progress frames carry no status: five `undefined` lines before `run_settled succeeded` | prints `event.status ?? ''`, says what to expect |
| "the generated workflow has this public envelope" | `nika new 01-hello` writes the engine's annotated example (task `greet`, French prompt, 2048 tokens) | the README envelope is the hand-written form; the contract is `outputs.greeting` + `mock/echo` |
| `afterSkip` requires `overlap: "skip"` | accepted without `overlap` (skip is the engine default) | says so |
| `active: false` requires a `pauseUntil` | each of `pauseReason` / `pauseUntil` alone is refused; both are required | says so; also notes schedules refuse `maxCostUsd: 0` where a native run accepts it |
| "Every SDK error extends `NikaError`" | caller misuse (`''` workflow, negative cursor, non-object receipt, path traversal) throws `TypeError`/`RangeError` | scopes the claim |
| "Node.js 22 or newer" | `npm install` on Node 20 and 18 prints no engines warning and the client runs there | names the floor as tested, not refused |

Plus the resolver refusal: `NikaEngineUnavailable` told users to "install optional dependencies" that npm had already left UNMET OPTIONAL (no matching payload on the registry) and never said that a `nika` on `PATH` is deliberately ignored. The message now names the three valid paths and the one it refuses; `test/native-resolver.test.ts` pins that text.

`npm test` 188/188 · `tsc` · `build` green · `test/readme-surface.test.ts` unchanged and green.

Do not merge on my behalf; squash when you are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)