### PR TITLE
fix(release): the packed-client verifier accepts the package.json export

### DIFF
--- a/scripts/verify-client-pack.mjs
+++ b/scripts/verify-client-pack.mjs
@@ -40,11 +40,16 @@ if (
 ) {
   throw new Error(`${result.name} packed release metadata does not bind ${preparedCommit}`);
 }
+// The canonical entrypoints of the root client. The repository manifest is
+// held to this exact shape by test/release-pack-verification.test.ts, so a
+// manifest change that forgets this verifier turns red at `npm test`, not at
+// release time.
 const expectedExports = {
   '.': {
     import: { types: './dist/index.d.ts', default: './dist/index.js' },
     require: { types: './dist/index.d.cts', default: './dist/index.cjs' },
   },
+  './package.json': './package.json',
 };
 if (
   manifest.name !== '@supernovae-st/nika-client'

--- a/test/release-pack-verification.test.ts
+++ b/test/release-pack-verification.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,6 +35,7 @@ function fixture(
         import: { types: './dist/index.d.ts', default: './dist/index.js' },
         require: { types: './dist/index.d.cts', default: './dist/index.cjs' },
       },
+      './package.json': './package.json',
     },
     main: './dist/index.cjs',
     module: './dist/index.js',
@@ -73,6 +74,48 @@ describe('packed release commit proof', () => {
       sha,
       version,
     ])).not.toThrow();
+  });
+
+  it('accepts the repository manifest entrypoints as canonical', () => {
+    // The release gate runs only at tag time. Binding it to the checked-in
+    // manifest here keeps a manifest edit from turning the train red later.
+    const manifest = JSON.parse(readFileSync(path.join(repo, 'package.json'), 'utf8')) as {
+      exports: unknown; main: string; module: string; types: string; bin: unknown;
+    };
+    const packed = fixture(sha, {
+      exports: manifest.exports,
+      main: manifest.main,
+      module: manifest.module,
+      types: manifest.types,
+      bin: manifest.bin,
+    });
+    expect(() => execFileSync('node', [
+      path.join(repo, 'scripts/verify-client-pack.mjs'),
+      packed.report,
+      packed.tarballs,
+      sha,
+      version,
+    ])).not.toThrow();
+  });
+
+  it('refuses a tarball that drops the package.json export', () => {
+    const packed = fixture(sha, {
+      exports: {
+        '.': {
+          import: { types: './dist/index.d.ts', default: './dist/index.js' },
+          require: { types: './dist/index.d.cts', default: './dist/index.cjs' },
+        },
+      },
+    });
+    const result = spawnSync('node', [
+      path.join(repo, 'scripts/verify-client-pack.mjs'),
+      packed.report,
+      packed.tarballs,
+      sha,
+      version,
+    ]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr.toString()).toContain('manifest entrypoints are not canonical');
   });
 
   it('refuses a tarball stamped for another commit', () => {


### PR DESCRIPTION
## The measured defect

`gh workflow run release.yml -f version=0.116.2 -f dry_run=true` → run [33553576887](https://github.com/supernovae-st/nika-client/actions/runs/33553576887) failed in `prepare` at **Pack and inspect all packages**:

```
Error: @supernovae-st/nika-client packed client manifest entrypoints are not canonical
    at file:///…/scripts/verify-client-pack.mjs:58:9
```

PR #72 added `"./package.json": "./package.json"` to the root `exports` (so consumers can prove the installed pin); `scripts/verify-client-pack.mjs` still demanded the pre-#72 map. Every CI check on `main` stayed green because the gate only runs at release time and its test fixture had not moved with the manifest. The real train (after trusted publishing is configured) would block at the same step.

## What changes

- The verifier's canonical exports include `./package.json`.
- `test/release-pack-verification.test.ts` builds a fixture from the repository's own `package.json` entrypoints (exports · main · module · types · bin), so a manifest edit that forgets the verifier fails at `npm test`; a tarball that drops the export is refused explicitly (new negative case).

`npm test` green (`release-pack-verification` 12/12) · `tsc` green.

## After merge

Re-run the dry-run: `gh workflow run release.yml --repo supernovae-st/nika-client -f version=0.116.2 -f dry_run=true` and read `prepare → verify-native-runtime`; the `stage` job stays skipped by `dry_run`.

Do not merge on my behalf; squash when you are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)