### PR TITLE
fix(sdk): explicit engine paths must be absolute and probe refusals name the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- `bin` and `NIKA_BIN` must be absolute paths. A bare name such as `nika`
+  reached `spawn()`, where the operating system resolved it through `PATH`,
+  the implicit lookup the README promises never happens; a relative path was
+  resolved against the working directory the same way. Both now refuse with
+  a message that names the value and the rule.
+
+### Fixed
+
+- Engine identity probe refusals name the executable path and, when it did
+  not answer like an engine, the one command that settles it
+  (`<bin> --sdk-identity`) instead of `Engine identity probe failed`.
+
 ### Added
 
 - Discriminated `NikaEvent` union over the known lifecycle kinds with an

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ not parse YAML or reconstruct proof in TypeScript.
 ## Requirements
 
 - Node.js 22 or newer
-- a compatible `nika` engine, resolved from `config.bin`, then `NIKA_BIN`,
-  then the exact optional platform package; implicit `PATH` lookup is refused
+- a compatible `nika` engine, resolved from `config.bin`, then `NIKA_BIN`
+  (absolute paths only), then the exact optional platform package; a bare
+  name or a relative path is refused because the operating system would
+  resolve it through `PATH` or the working directory
 - a `.nika.yaml` workflow
 
 ## Documentation

--- a/src/lib/binary/resolve.ts
+++ b/src/lib/binary/resolve.ts
@@ -36,18 +36,12 @@ export function resolveNikaEngine(
   host: BinaryResolverHost = {},
 ): ResolvedNikaEngine {
   if (configuredBin !== undefined) {
-    if (configuredBin.length === 0) {
-      throw new NikaConfigurationError('bin must be a non-empty string');
-    }
-    return { bin: configuredBin };
+    return { bin: absoluteEnginePath(configuredBin, 'bin') };
   }
 
   const envBin = (host.env ?? process.env).NIKA_BIN;
   if (envBin !== undefined) {
-    if (envBin.length === 0) {
-      throw new NikaConfigurationError('NIKA_BIN must be a non-empty string');
-    }
-    return { bin: envBin };
+    return { bin: absoluteEnginePath(envBin, 'NIKA_BIN') };
   }
 
   const platform = host.platform ?? process.platform;
@@ -75,6 +69,26 @@ export function resolveNikaEngine(
     }
     throw cause;
   }
+}
+
+/**
+ * An explicit engine path must be absolute. A bare name (`nika`) or a
+ * relative path would be resolved by the operating system through PATH or
+ * the working directory, which is exactly the implicit lookup this client
+ * refuses: the README promises that a `nika` found on PATH is never used.
+ */
+function absoluteEnginePath(value: string, source: 'bin' | 'NIKA_BIN'): string {
+  if (value.length === 0) {
+    throw new NikaConfigurationError(`${source} must be a non-empty string`);
+  }
+  if (!path.isAbsolute(value)) {
+    throw new NikaConfigurationError(
+      `${source} must be an absolute path to a nika engine (got "${value}"); `
+      + 'a bare name or a relative path would be resolved through PATH or the '
+      + 'working directory, which this client refuses',
+    );
+  }
+  return value;
 }
 
 function runtimeIsGlibc(platform: NodeJS.Platform): boolean {

--- a/src/lib/binary/verify.ts
+++ b/src/lib/binary/verify.ts
@@ -78,27 +78,37 @@ async function verifyManagedPayload(engine: ResolvedNikaEngine): Promise<string>
 }
 
 async function probeIdentity(bin: string): Promise<NikaEngineIdentity> {
+  // The probe is version negotiation with whatever executable sits at `bin`;
+  // it authenticates nothing. When it fails, the likeliest cause is the path
+  // (a wrong NIKA_BIN, a script that is not the engine), so every refusal
+  // names the path and the one command that settles the question.
+  const notAnEngine = `is ${bin} a nika engine? (run "${bin} --sdk-identity" by hand)`;
   const captured = await captureEngine(bin, ['--sdk-identity'], {
     bufferBytes: IDENTITY_BUFFER_BYTES,
     transport: 'native-process',
     label: 'Engine identity probe',
   }).catch((cause: unknown) => {
     throw incompatible(
-      'Engine identity probe failed',
+      `Engine identity probe of ${bin} failed`,
       cause,
     );
   });
   if (captured.exitCode !== 0) {
-    throw incompatible(`Engine identity probe exited with code ${captured.exitCode}`);
+    throw incompatible(
+      `Engine identity probe of ${bin} exited with code ${captured.exitCode}; ${notAnEngine}`,
+    );
   }
   let value: unknown;
   try {
     value = JSON.parse(captured.stdout.trim());
   } catch (cause) {
-    throw incompatible('Engine identity probe did not emit one JSON object', cause);
+    throw incompatible(
+      `Engine identity probe of ${bin} did not emit one JSON object; ${notAnEngine}`,
+      cause,
+    );
   }
   if (captured.stderr.trim()) {
-    throw incompatible('Engine identity probe wrote unexpected diagnostics');
+    throw incompatible(`Engine identity probe of ${bin} wrote unexpected diagnostics`);
   }
   try {
     return compatibleEngineIdentity(value, 'native-process');

--- a/test/engine-probe-message.test.ts
+++ b/test/engine-probe-message.test.ts
@@ -1,0 +1,62 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NikaCompatibilityError } from '../src/errors.js';
+import { verifyNikaEngine } from '../src/lib/binary/index.js';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function script(body: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'nika-probe-'));
+  roots.push(root);
+  const file = path.join(root, 'not-nika');
+  writeFileSync(file, `#!/bin/sh\n${body}\n`);
+  chmodSync(file, 0o755);
+  return file;
+}
+
+describe.skipIf(process.platform === 'win32')('engine identity probe refusals teach', () => {
+  it('names the path and the hand probe when the executable is not an engine', async () => {
+    const bin = script('echo hello');
+    let caught: unknown;
+    try {
+      await verifyNikaEngine({ bin });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(NikaCompatibilityError);
+    const message = String((caught as Error).message);
+    expect(message).toContain(bin);
+    expect(message).toContain(`is ${bin} a nika engine?`);
+    expect(message).toContain(`"${bin} --sdk-identity"`);
+  });
+
+  it('names the path and the exit code when the probe fails', async () => {
+    const bin = script('exit 7');
+    let caught: unknown;
+    try {
+      await verifyNikaEngine({ bin });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(NikaCompatibilityError);
+    expect(String((caught as Error).message)).toContain(`probe of ${bin} exited with code 7`);
+  });
+
+  it('names the path when nothing can be spawned there', async () => {
+    const bin = path.join(mkdtempSync(path.join(tmpdir(), 'nika-probe-')), 'missing');
+    roots.push(path.dirname(bin));
+    let caught: unknown;
+    try {
+      await verifyNikaEngine({ bin });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(NikaCompatibilityError);
+    expect(String((caught as Error).message)).toContain(`probe of ${bin} failed`);
+  });
+});

--- a/test/native-resolver.test.ts
+++ b/test/native-resolver.test.ts
@@ -34,6 +34,27 @@ describe('native binary resolver', () => {
       .toThrow(NikaConfigurationError);
   });
 
+  it('refuses a bare name or a relative path, which the OS would resolve through PATH or cwd', () => {
+    // A bare `nika` in NIKA_BIN used to reach spawn(), where the operating
+    // system walked PATH for it: the implicit lookup the README refuses.
+    for (const value of ['nika', './nika', 'bin/nika', '../nika']) {
+      expect(() => resolveNikaBinary(value, { env: {} })).toThrow(NikaConfigurationError);
+      expect(() => resolveNikaBinary(undefined, { env: { NIKA_BIN: value } }))
+        .toThrow(NikaConfigurationError);
+    }
+    let caught: unknown;
+    try {
+      resolveNikaBinary(undefined, { env: { NIKA_BIN: 'nika' } });
+    } catch (error) {
+      caught = error;
+    }
+    const message = String((caught as Error).message);
+    expect(message).toContain('NIKA_BIN must be an absolute path');
+    expect(message).toContain('"nika"');
+    expect(message).toContain('PATH');
+    expect(resolveNikaBinary('/absolute/nika', { env: {} })).toBe('/absolute/nika');
+  });
+
   it('uses the stable unavailable error for unsupported and missing payloads', () => {
     expect(() => resolveNikaBinary(undefined, {
       env: {},


### PR DESCRIPTION
## The measured defect

The README promises that a `nika` found on `PATH` is never used, and the resolver refuses an unset or empty `NIKA_BIN`. It did not refuse a bare name. Measured 2026-09-01 by the security persona of the 0.116.2 gauntlet: with `NIKA_BIN=nika` and a hostile `./fakebin` first on `PATH`, the fake executed the identity probe (replaying the genuine `--sdk-identity` JSON) and then answered `check` with `{"clean":true,"findings":[]}` for a workflow the real engine refuses with two permit violations. The README's own guard, `if (!report.clean) throw`, passed. A relative path (`./nika`, `bin/nika`) was resolved against the working directory the same way.

Second shape: pointing `NIKA_BIN` at a non-engine executable produced `Engine identity probe failed: Cannot spawn engine for Engine identity probe` or `… did not emit one JSON object: Unexpected end of JSON input`, which reads like an engine crash; a developer debugs the engine instead of the path.

## What changes

- `bin` and `NIKA_BIN` must be absolute paths. Anything else refuses with `NikaConfigurationError`: `NIKA_BIN must be an absolute path to a nika engine (got "nika"); a bare name or a relative path would be resolved through PATH or the working directory, which this client refuses`.
- Identity probe refusals name the executable and, when it did not answer like an engine, the one command that settles it: `Engine identity probe of /x/not-nika did not emit one JSON object; is /x/not-nika a nika engine? (run "/x/not-nika --sdk-identity" by hand)`.
- README requirements and the changelog say so.

## Tests

`test/native-resolver.test.ts`: four relative shapes refused on both sources, the absolute path accepted, the message pinned. `test/engine-probe-message.test.ts` (new): three probe refusals (a shell script that is not an engine, a non-zero exit, nothing to spawn) name the path. `npm test` 192/192 · `tsc` · `build` · `check:coverage` green.

## Notes for the reviewer

- Pre-1.0 tightening: a consumer that set `NIKA_BIN=nika` on purpose now gets a typed refusal instead of whatever `PATH` held.
- The probe remains version negotiation, not authentication: a substituted binary at an absolute path is still trusted. Pinning the engine by digest (`expectedEngineDigest`) is a design proposal for a separate discussion; the payload package path already verifies `INTEGRITY.json`.
- Do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)