### PR TITLE
fix(sdk): a failed native run settles run.done with the engine's failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A failed native run now settles `run.done` with the failure the engine
+  named. The engine states a task failure as field rows on `task_failed`
+  (`detail: "NIKA-EXEC-001 · command exited with status 1"`, `task`), and
+  the later `workflow_failed` and `run_settled` frames carry no error, so
+  `NikaRunResult.error` stayed undefined on every native failure. It now
+  carries `{ code, message, task }`; `NikaMachineError` gains an optional
+  `task`.
+
 ### Added
 
 - Discriminated `NikaEvent` union over the known lifecycle kinds with an

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ console.log(result.status, result.outputs, result.receipt);
 ```
 
 `run()` returns after stable admission. `run.done` is the sole terminal result.
-An admitted workflow failure is result data with `status: "failed"`; transport,
+An admitted workflow failure is result data with `status: "failed"` and, when
+the engine named the failing task, `error: { code, message, task }`; transport,
 protocol, configuration, and compatibility failures throw typed SDK errors.
 
 ## Verify a local trace

--- a/src/lib/machine.ts
+++ b/src/lib/machine.ts
@@ -73,7 +73,35 @@ export function eventError(event: NikaEvent | undefined): NikaMachineError | und
       ...(typeof event.message === 'string' ? { message: event.message } : {}),
     };
   }
-  return undefined;
+  return fieldsError(event);
+}
+
+/**
+ * A native `task_failed` frame carries its failure as field rows, not as an
+ * `error` object: `detail` holds `NIKA-<CODE> · <message>` and `task` names
+ * the task. The later `workflow_failed` and `run_settled` frames carry no
+ * error at all, so this is the only place the engine states why a run
+ * failed. Read it the same way status, receipt, and outputs are read.
+ */
+function fieldsError(event: NikaEvent | undefined): NikaMachineError | undefined {
+  if (event?.kind !== 'task_failed') return undefined;
+  const fields = Array.isArray(event.fields) ? event.fields : [];
+  let detail: string | undefined;
+  let task: string | undefined;
+  for (const field of fields) {
+    const row = machineObject(field);
+    if (row?.key === 'detail' && typeof row.value === 'string') detail = row.value;
+    if (row?.key === 'task' && typeof row.value === 'string') task = row.value;
+  }
+  if (detail === undefined) return undefined;
+  const match = detail.trim().match(/^(NIKA-[A-Z0-9-]+)\s*·?\s*([\s\S]*)$/);
+  const code = match?.[1];
+  const message = (match ? match[2] : detail).trim();
+  return {
+    ...(code ? { code } : {}),
+    ...(message.length > 0 ? { message } : {}),
+    ...(task ? { task } : {}),
+  };
 }
 
 export function receiptTraceLocator(receipt: NikaReceipt): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,8 @@ export type NikaReceipt = Readonly<Record<string, unknown>>;
 export interface NikaMachineError {
   code?: string;
   message?: string;
+  /** The task that failed, when a native `task_failed` frame named it. */
+  task?: string;
   [key: string]: unknown;
 }
 

--- a/test/fixtures/fake-nika.mjs
+++ b/test/fixtures/fake-nika.mjs
@@ -85,6 +85,22 @@ if (command === 'run' && argv.includes('--json')) {
     for (let index = 0; index < count; index += 1) {
       emit({ kind: 'task_completed', sequence: index + 1, value: index });
     }
+    if (workflow.includes('fields-failure')) {
+      // The released engine's shape: the failure rides field rows on
+      // task_failed; workflow_failed and run_settled carry no error.
+      emit({
+        kind: 'task_failed',
+        fields: [
+          { key: 'task', value: 'boom' },
+          { key: 'note', value: 'exec · false' },
+          { key: 'detail', value: 'NIKA-EXEC-001 · command exited with status 1: ' },
+          { key: 'duration_ms', value: 7 },
+        ],
+      });
+      emit({ kind: 'workflow_failed', fields: [{ key: 'workflow', value: 'fixture' }] });
+      emit({ kind: 'run_settled', status: 'failed', outputs: { boom: null } });
+      process.exit(1);
+    }
     if (workflow.includes('failing')) {
       emit({
         kind: 'workflow_failed',

--- a/test/native-failure-error.test.ts
+++ b/test/native-failure-error.test.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { Nika } from '../src/index.js';
+import { eventError } from '../src/lib/machine.js';
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'fake-nika.mjs',
+);
+
+describe('a failed native run carries the engine failure', () => {
+  it('reads the code, message and task from a task_failed frame', () => {
+    expect(eventError({
+      kind: 'task_failed',
+      fields: [
+        { key: 'task', value: 'boom' },
+        { key: 'detail', value: 'NIKA-EXEC-001 · command exited with status 1: ' },
+      ],
+    })).toEqual({
+      code: 'NIKA-EXEC-001',
+      message: 'command exited with status 1:',
+      task: 'boom',
+    });
+  });
+
+  it('keeps a detail without a code as the message alone', () => {
+    expect(eventError({
+      kind: 'task_failed',
+      fields: [{ key: 'detail', value: 'the provider hung up' }],
+    })).toEqual({ message: 'the provider hung up' });
+  });
+
+  it('reads nothing from frames that carry no failure', () => {
+    expect(eventError({ kind: 'task_started', fields: [{ key: 'task', value: 'boom' }] }))
+      .toBeUndefined();
+    expect(eventError({ kind: 'workflow_failed', fields: [{ key: 'workflow', value: 'x' }] }))
+      .toBeUndefined();
+    expect(eventError({ kind: 'task_failed' })).toBeUndefined();
+  });
+
+  it('settles run.done with the failure the engine named', async () => {
+    const nika = new Nika({ bin: FIXTURE });
+    const run = await nika.run('fields-failure.nika.yaml');
+    const kinds: string[] = [];
+    for await (const event of nika.events(run)) kinds.push(String(event.kind));
+    const result = await run.done;
+    expect(kinds).toEqual(['workflow_started', 'task_completed', 'task_failed', 'workflow_failed', 'run_settled']);
+    expect(result.status).toBe('failed');
+    expect(result.error).toEqual({
+      code: 'NIKA-EXEC-001',
+      message: 'command exited with status 1:',
+      task: 'boom',
+    });
+  });
+});


### PR DESCRIPTION
## The measured defect

Reproduced on the released engine `0.116.2 (c4cdbeafb)` with the client packed from `main`: a workflow whose `exec` task exits 1 settles `run.done` as

```
{ status: "failed", exitCode: 1, error: undefined }
```

while the engine's own `--json` stream names the failure. The engine states it as field rows on the `task_failed` frame:

```
task_failed   fields: [{key:"task",value:"boom"}, {key:"detail",value:"NIKA-EXEC-001 · command exited with status 1: "}, …]
workflow_failed fields: [{key:"workflow",value:"red-exec"}]          (no error)
run_settled   {status:"failed", outputs:{boom:null}}                 (no error)
```

`eventError()` only read an `error` object or top-level `code`/`message`, so `NikaRunResult.error` stayed `undefined` on every native failure and a CI job had to open `.nika/traces/*.ndjson` to learn what the CLI prints for free. Found by the CI persona of the 0.116.2 gauntlet.

## What changes

- `eventError()` also reads the `task_failed` field rows (the way `eventStatus`, `eventReceipt` and `eventOutputs` already read rows): the `NIKA-…` code is split from `detail`, the `task` is kept, and the native transport carries it to `run.done`.
- `NikaMachineError` gains an optional `task` (additive).
- README first-run paragraph and the changelog say so.

## Proof

- Fixture: `fields-failure` in `test/fixtures/fake-nika.mjs` mirrors the released shape; `test/native-failure-error.test.ts` (4 cases) pins the derivation and the settled result.
- Released engine: `run.done` now settles `{ status: "failed", exitCode: 1, error: { code: "NIKA-EXEC-001", message: "command exited with status 1:", task: "boom" } }` on the reproduction workflow.
- `npm test` 192/192 · `tsc` · `build` · `check:coverage` green.

## Notes

- The engine could also carry the terminal error on `workflow_failed`/`run_settled` (that is part of supernovae-st/nika#1247, leg 3); this PR reads what 0.116.2 already emits.
- Do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)