### PR TITLE
fix(sdk): run identities settle the same on every path and the native verdict has a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A remote run admitted by `POST /v1/jobs` and settled from its SSE frame
+  now carries `execution_id` and `trace_id` on `run.done`, read from the
+  receipt on that frame after it passed the identity checks; before, only a
+  run settled from a durable read (cancel, attach) named them, so the same
+  script saw them on a cancelled run and not on a succeeded one.
+- Native `traceVerify` returns `verdict` (`verified` or `invalid`, with
+  `reason: receipt_mismatch` when the evidence does not bind the receipt),
+  the vocabulary the HTTP verdict already speaks.
+
 ### Added
 
 - Discriminated `NikaEvent` union over the known lifecycle kinds with an

--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -333,18 +333,28 @@ export class HttpTransport implements Transport {
       ) {
         throw new NikaProtocolError(this.kind, 'Durable trace identity changed after attach');
       }
-      const executionId = attachedState?.execution_id ?? durable?.execution_id;
-      const traceId = attachedState?.trace_id ?? durable?.trace_id;
+      const knownExecutionId = attachedState?.execution_id ?? durable?.execution_id;
+      const knownTraceId = attachedState?.trace_id ?? durable?.trace_id;
       if (receipt) {
         assertReceiptIdentity(
           receipt,
           id,
           this.kind,
-          executionId,
-          traceId,
+          knownExecutionId,
+          knownTraceId,
           expectedSnapshotDigest,
         );
       }
+      // A run admitted by POST and settled from its SSE frame has no durable
+      // read to name its identities; the receipt on that frame carries them
+      // and was just checked against every identity already known, so the
+      // result names the same execution and trace on both settlement paths.
+      const executionId = knownExecutionId
+        ?? (typeof receipt?.execution_id === 'string'
+          ? receipt.execution_id as NikaExecutionId
+          : undefined);
+      const traceId = knownTraceId
+        ?? (typeof receipt?.trace_id === 'string' ? receipt.trace_id : undefined);
       terminalObserved = true;
       const outputs = event ? eventOutputs(event) : durable?.outputs;
       const error = event ? eventError(event) : durable?.error;

--- a/src/lib/native-process-transport.ts
+++ b/src/lib/native-process-transport.ts
@@ -151,6 +151,7 @@ export class NativeProcessTransport implements Transport {
     if (captured.exitCode !== 0) {
       return {
         verified: false,
+        verdict: 'invalid',
         exitCode: captured.exitCode,
         output: captured.stdout + captured.stderr,
       };
@@ -172,6 +173,10 @@ export class NativeProcessTransport implements Transport {
     const mismatch = receiptMismatch(receipt, manifest);
     return {
       verified: mismatch === undefined,
+      // The same vocabulary the HTTP verdict speaks, so a caller reads one
+      // field on both transports instead of inferring it from exitCode.
+      verdict: mismatch === undefined ? 'verified' : 'invalid',
+      ...(mismatch === undefined ? {} : { reason: 'receipt_mismatch' }),
       exitCode: mismatch === undefined ? 0 : 2,
       output: captured.stdout + captured.stderr
         + (mismatch === undefined ? '' : `\nRECEIPT MISMATCH: ${mismatch}\n`),

--- a/test/http-depth-lifecycle.test.ts
+++ b/test/http-depth-lifecycle.test.ts
@@ -647,6 +647,9 @@ describe('cancellation and terminal identity', () => {
       id: 'job-1',
       status: 'succeeded',
       transport: 'http',
+      // Named by the engine on the receipt, checked against admission, never invented.
+      execution_id: 'execution-1',
+      trace_id: 'trace-1',
       outputs: { answer: 42 },
       receipt: RECEIPT,
     });

--- a/test/identities-consistent.test.ts
+++ b/test/identities-consistent.test.ts
@@ -1,0 +1,116 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { Nika } from '../src/index.js';
+import {
+  HTTP_DEPTH_FIXTURE,
+  TOKEN_A,
+  healthResponse,
+  jsonResponse,
+  sseResponse,
+} from './helpers/http-depth-harness.js';
+
+const NATIVE_FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'fake-nika.mjs',
+);
+
+const receipt = {
+  job_id: 'job-1',
+  execution_id: 'exe-1',
+  trace_id: 'trace-1',
+  snapshot_digest: 'a'.repeat(64),
+  origin: { kind: 'manual' },
+};
+
+describe('run identities are the same on every settlement path', () => {
+  it('names the execution and trace from the receipt when POST admission had none', async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/health') return healthResponse();
+      if (url.pathname === '/v1/jobs') return jsonResponse({ id: 'job-1', status: 'queued' }, 202);
+      if (url.pathname === '/v1/jobs/job-1/events') {
+        return sseResponse([
+          { sequence: 1, kind: 'execution.started', status: 'running' },
+          {
+            sequence: 2,
+            kind: 'execution.settled',
+            status: 'succeeded',
+            outputs: { answer: 1 },
+            receipt,
+          },
+        ]);
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+    const nika = new Nika({
+      url: 'https://nika.example',
+      token: TOKEN_A,
+      bin: HTTP_DEPTH_FIXTURE,
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    });
+    const run = await nika.run('flow.nika.yaml', { idempotencyKey: 'ids-1' });
+    const result = await run.done;
+    expect(result).toMatchObject({
+      status: 'succeeded',
+      execution_id: 'exe-1',
+      trace_id: 'trace-1',
+      receipt,
+    });
+  });
+
+  it('still refuses a receipt whose identity contradicts the durable record', async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/health') return healthResponse();
+      if (url.pathname === '/v1/jobs/job-1') {
+        return jsonResponse({ id: 'job-1', status: 'running', execution_id: 'exe-other' });
+      }
+      if (url.pathname === '/v1/jobs/job-1/events') {
+        return sseResponse([
+          { sequence: 1, kind: 'execution.settled', status: 'succeeded', receipt },
+        ]);
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+    const nika = new Nika({
+      url: 'https://nika.example',
+      token: TOKEN_A,
+      bin: HTTP_DEPTH_FIXTURE,
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    });
+    const run = await nika.attachRun('job-1');
+    await expect(run.done).rejects.toMatchObject({ name: 'NikaProtocolError' });
+  });
+});
+
+describe('the native trace verdict speaks the HTTP vocabulary', () => {
+  const bound = Object.freeze({
+    receipt_format: 1,
+    execution_id: 'exe-fixture',
+    trace_id: 'trace-fixture',
+    snapshot_digest: 'snapshot-fixture',
+    trace_path: 'fixture-trace.ndjson',
+    chain_head: 'fixture-head',
+    chain_len: 7,
+    sealed: true,
+  });
+
+  it('says verified on a receipt the evidence binds', async () => {
+    const nika = new Nika({ bin: NATIVE_FIXTURE });
+    await expect(nika.traceVerify(bound)).resolves.toMatchObject({
+      verified: true,
+      verdict: 'verified',
+      exitCode: 0,
+    });
+  });
+
+  it('says invalid with a reason on a receipt the evidence does not bind', async () => {
+    const nika = new Nika({ bin: NATIVE_FIXTURE });
+    await expect(nika.traceVerify({ ...bound, execution_id: 'other' }))
+      .resolves.toMatchObject({ verified: false, verdict: 'invalid', reason: 'receipt_mismatch', exitCode: 2 });
+    await expect(nika.traceVerify({ ...bound, trace_path: 'broken-trace.ndjson' }))
+      .resolves.toMatchObject({ verified: false, verdict: 'invalid', exitCode: 2 });
+  });
+});


### PR DESCRIPTION
## The measured defects (0.116.2 client · released engine 0.116.2 · 2026-09-01)

1. In one script against one `nika serve`, a **cancelled** remote run settled with `execution_id: "exe-01a05eef-…"` while a **succeeded** one settled with `execution_id: undefined`. A run admitted by `POST /v1/jobs` gets `{id, status: "queued"}` and no execution identity; its `execution.settled` SSE frame carries the identities only inside the receipt, and `settle()` read them only from a durable record (which cancel and attach have). Same server, same script, two answers to "which execution was this?".
2. `traceVerify` on the native transport returned `{ verified, exitCode, output }` with no `verdict`, while the HTTP transport always names one (`verified` / `unavailable`); a caller inferred the native verdict from the exit code.

Both found by the rival-SDK persona of the 0.116.2 gauntlet.

## What changes

- `settle()` reads `execution_id` and `trace_id` from the receipt when no durable record named them, **after** `assertReceiptIdentity` has checked that receipt against every identity already known (job id, attached execution/trace, admission snapshot digest). Nothing is invented: the identities are engine-issued on the receipt.
- Native `traceVerify` returns `verdict: "verified" | "invalid"` and `reason: "receipt_mismatch"` when the evidence manifest does not bind the receipt.
- Changelog says so.

## Tests

`test/identities-consistent.test.ts` (4 cases): POST admission + SSE settlement now names the receipt's execution and trace; a receipt contradicting an attached record is still refused; native verdict `verified` / `invalid`+reason. `test/http-depth-lifecycle.test.ts` "without synthesizing fields" now expects the two engine-named identities. `npm test` 192/192 · `tsc` · `build` · `check:coverage` green.

Do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)