### PR TITLE
feat(types): the settlement frame types its cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `NikaRunSettledEvent.error`: engine 0.117+ repeats the first failed task's
+  code, message and task id on the terminal `run_settled` frame; `eventError`
+  already read an `error` object first, so `run.done` carries it on both
+  engines without a code change (the frame is typed and the reader is pinned).
+
 ### Security
 
 - `bin` and `NIKA_BIN` must be absolute paths. A bare name such as `nika`

--- a/src/lib/machine.ts
+++ b/src/lib/machine.ts
@@ -79,9 +79,10 @@ export function eventError(event: NikaEvent | undefined): NikaMachineError | und
 /**
  * A native `task_failed` frame carries its failure as field rows, not as an
  * `error` object: `detail` holds `NIKA-<CODE> · <message>` and `task` names
- * the task. The later `workflow_failed` and `run_settled` frames carry no
- * error at all, so this is the only place the engine states why a run
- * failed. Read it the same way status, receipt, and outputs are read.
+ * the task. Engines before 0.117 name the cause nowhere else; from 0.117 the
+ * terminal `run_settled` frame repeats it as an `error` object, which
+ * `eventError` reads first. Read it the same way status, receipt, and
+ * outputs are read.
  */
 function fieldsError(event: NikaEvent | undefined): NikaMachineError | undefined {
   if (event?.kind !== 'task_failed') return undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,12 @@ export interface NikaRunSettledEvent<
   status?: NikaRunStatus;
   outputs?: Outputs;
   receipt?: NikaReceipt;
+  /**
+   * The cause of a `failed` settlement (engine 0.117+): the first failed
+   * task's code, message and task id. Absent on a succeeded or paused run,
+   * and on engines that only name the cause on their `task_failed` frame.
+   */
+  error?: NikaMachineError;
 }
 
 /** The run's trace chain was sealed. */

--- a/test/native-failure-error.test.ts
+++ b/test/native-failure-error.test.ts
@@ -32,6 +32,21 @@ describe('a failed native run carries the engine failure', () => {
     })).toEqual({ message: 'the provider hung up' });
   });
 
+  it('reads the cause a 0.117+ run_settled frame carries', () => {
+    expect(eventError({
+      kind: 'run_settled',
+      status: 'failed',
+      outputs: { result: null },
+      error: { code: 'NIKA-BUILTIN-READ-001', message: 'no such file: ./missing.md', task: 'brief' },
+    })).toEqual({
+      code: 'NIKA-BUILTIN-READ-001',
+      message: 'no such file: ./missing.md',
+      task: 'brief',
+    });
+    expect(eventError({ kind: 'run_settled', status: 'succeeded', outputs: { result: 1 } }))
+      .toBeUndefined();
+  });
+
   it('reads nothing from frames that carry no failure', () => {
     expect(eventError({ kind: 'task_started', fields: [{ key: 'task', value: 'boom' }] }))
       .toBeUndefined();


### PR DESCRIPTION
Engine 0.117 repeats the first failed task's code, message and task id on the terminal `run_settled` frame (supernovae-st/nika#1403). `eventError` already read an `error` object before the `task_failed` field rows, so `run.done` carries the cause on both engines without a code change; the frame is now typed (`NikaRunSettledEvent.error`) and the reader pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)