### PR TITLE
fix(sdk): recover resident admission and verified execution evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,7 @@ jobs:
             --pattern "$asset" \
             --pattern SHA256SUMS
           cd "$asset_root"
-          gh attestation verify "$asset" --repo supernovae-st/nika
-          grep -E "[[:space:]]${asset}$" SHA256SUMS | sha256sum --check --strict
+          node "$GITHUB_WORKSPACE/scripts/verify-engine-archive.mjs" "$asset" SHA256SUMS "$version"
           tar xzf "$asset"
           chmod +x nika
           test "$(./nika --version | awk '{print $2}')" = "$version"
@@ -97,6 +96,7 @@ jobs:
         env:
           NIKA_BIN: ${{ runner.temp }}/nika-release-asset/nika
           NIKA_GAUNTLET_RESULTS_DIR: ${{ runner.temp }}/nika-release-replay
+          NIKA_ONE_DOOR_REPORT: ${{ runner.temp }}/nika-release-replay/one-door.json
         run: |
           npm run check:release-evidence
           npm run gauntlet:run
@@ -104,7 +104,17 @@ jobs:
           npm run gauntlet:depth
           npm run gauntlet:hostile
           npm run gauntlet:recovery
+          npm run gauntlet:one-door
           npm run check:release-replay -- "$NIKA_GAUNTLET_RESULTS_DIR"
+
+      - name: Preserve the exact replay evidence, including an incomplete proof
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: released-engine-replay
+          path: |
+            ${{ runner.temp }}/nika-release-replay
+          if-no-files-found: warn
 
   # ── Type Drift Check ──────────────────────────────────
   # Starts a live nika serve, generates types from OpenAPI,
@@ -113,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -132,16 +143,18 @@ jobs:
           gh release download "v$version" \
             --repo supernovae-st/nika \
             --dir "$asset_root" \
-            --pattern "nika-linux-x64-$version.tar.gz"
-          tar xzf "$asset_root/nika-linux-x64-$version.tar.gz" -C "$asset_root"
+            --pattern "nika-linux-x64-$version.tar.gz" \
+            --pattern SHA256SUMS
+          cd "$asset_root"
+          asset="nika-linux-x64-$version.tar.gz"
+          node "$GITHUB_WORKSPACE/scripts/verify-engine-archive.mjs" "$asset" SHA256SUMS "$version"
+          tar xzf "$asset"
           chmod +x "$asset_root/nika"
           sudo mv "$asset_root/nika" /usr/local/bin/
 
       - run: npm ci
-      # The type-drift check needs the target-facing HTTP `nika serve` surface
-      # (see CHANGELOG). The released CLI already owns `nika serve` for its
-      # resident scheduler, so command existence alone is not a capability
-      # probe. Re-activate only when help exposes both HTTP contract flags.
+      # This train promises the HTTP contract. An unavailable or incompatible
+      # artifact is a failed gate, never an advisory success.
       - name: Type drift (against live nika serve)
         env:
           NIKA_SERVE_TOKEN: ci-test-token-32-chars-minimum!!
@@ -151,13 +164,13 @@ jobs:
           sdk_version=$(node -p "require('./package.json').version")
           engine_version=$(nika --version | awk '{print $2}')
           if [ "$sdk_version" != "$engine_version" ]; then
-            echo "::warning::type-drift deferred — SDK $sdk_version targets the next engine train; latest release is $engine_version"
-            exit 0
+            echo "::error::SDK $sdk_version requires engine $sdk_version, received $engine_version"
+            exit 1
           fi
           serve_help=$(nika serve --help 2>&1 || true)
           if [[ "$serve_help" != *"--bind"* || "$serve_help" != *"--workflows"* ]]; then
-            echo "::warning::type-drift advisory — nika serve currently exposes the resident scheduler, not the target-facing HTTP surface. Re-activates when --bind and --workflows ship."
-            exit 0
+            echo "::error::The exact engine artifact is missing the promised HTTP serve contract"
+            exit 1
           fi
           # The fixture speaks the shipped nine-key envelope — this exact file
           # passes `nika check` clean (rc=0) on the released binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,9 @@ jobs:
             --pattern "nika-linux-x64-$VERSION.tar.gz" \
             --pattern SHA256SUMS
           cd engine-assets
+          source_commit=$(git -C "$GITHUB_WORKSPACE/nika-source" rev-parse HEAD)
           for asset in nika-*"$VERSION".tar.gz; do
-            gh attestation verify "$asset" --repo supernovae-st/nika
-            grep -E "[[:space:]]${asset}$" SHA256SUMS | sha256sum --check --strict
+            node "$GITHUB_WORKSPACE/scripts/verify-engine-archive.mjs" "$asset" SHA256SUMS "$VERSION" "$source_commit"
           done
 
       - name: Prove the pinned contract and generated types against the released binary
@@ -296,10 +296,7 @@ jobs:
             @supernovae-st/nika-client
           )
           for package_name in "${packages[@]}"; do
-            if npm view "$package_name@$VERSION" version >/dev/null 2>&1; then
-              echo "::error::$package_name@$VERSION already exists publicly"
-              exit 1
-            fi
+            node scripts/npm-publication.mjs assert-absent "$package_name" "$VERSION"
           done
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -424,16 +421,12 @@ jobs:
             echo "::error::NPM_TOKEN is not set on this repository · nothing can publish"
             exit 1
           fi
-          # A replay after a partial publish must not fail on the packages that
-          # already landed: a version already on the registry is skipped, never
-          # re-published (npm refuses to publish over a version anyway).
+          # A partial-publish replay accepts occupied coordinates only after
+          # matching their SRI AND downloaded bytes to this prepared artifact.
+          # Registry errors are not absence; divergent versions never pass.
           publish_once() {
             local pkg="$1" tarball="$2"
-            if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
-              echo "already on npm: $pkg@$VERSION · skipped"
-              return 0
-            fi
-            npm publish "$tarball" --access public --provenance
+            node scripts/npm-publication.mjs publish "$pkg" "$VERSION" "$tarball"
           }
           tarballs=release-candidate/release-tarballs
           publish_once "@supernovae-st/nika-darwin-arm64" "$tarballs/supernovae-st-nika-darwin-arm64-$VERSION.tgz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- Resolve HTTP workflow names at the resident without a local engine; explicit
+  local paths retain snapshot capture and digest verification.
+- Preserve pending cancellation, paused observation and recovered native
+  settlement facts across transports.
+- Add six-door runtime parity and bounded, owned process supervision for the
+  corpus and packed application harnesses.
+- Verify exact engine release provenance and prepared npm tarball integrity
+  before release operations; type drift fails when its promised engine is absent.
+
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ not parse YAML or reconstruct proof in TypeScript.
 
 - Node.js 22 or newer (the tested floor; an older major is unsupported, not
   refused, and `npm install` does not warn about it)
-- a compatible `nika` engine, resolved from `config.bin`, then `NIKA_BIN`
+- for native execution or local snapshot capture, a compatible `nika` engine, resolved from `config.bin`, then `NIKA_BIN`
   (absolute paths only), then the exact optional platform package; a bare
   name or a relative path is refused because the operating system would
   resolve it through `PATH` or the working directory, and a `nika` found on
@@ -123,9 +123,10 @@ Expected output: `workflow_started`, `task_scheduled`, `task_started`,
 `task_completed`, `workflow_completed`, then `run_settled succeeded`, then the
 terminal `succeeded` line with the outputs and the receipt.
 
-A red `check()` report carries the engine's `findings[]` on both transports, so
-the check → teach → re-draft loop reads one shape whether the engine runs
-locally or behind `nika serve`.
+Native checks and explicit local snapshot checks preserve the engine's
+`findings[]` and `exitCode`. A check by served name returns the resident's
+compact acknowledgement with `clean: true`, or its typed workflow refusal
+with `clean: false`; it does not invent local findings or an exit code.
 
 `run()` returns after stable admission. `run.done` is the sole terminal result.
 An admitted workflow failure is result data with `status: "failed"` and, when
@@ -194,14 +195,16 @@ transport signals its process the same way and settles `interrupted`.
 
 ## Connect to `nika serve`
 
-Remote admission is bytes-first: the local compatible engine captures an
-immutable execution snapshot, then the SDK sends those exact bytes to the
-authenticated server. Capturing those snapshots for `check` and `run`
-therefore still needs a local `nika` binary through `bin`, `NIKA_BIN`, or the
-exact optional platform package, resolved lazily at capture time.
-Observation-only clients need no local engine: `attachRun`, `status`,
-`events`, `cancel`, `schedule`, `scheduleStatus`, `listWorkflows`, `workflow`,
-and `traceVerify` run against the advertised server identity alone.
+A contained workflow name such as `hello.nika.yaml` or
+`daily/report.nika.yaml` is resolved by the resident registry. `check()` and
+`run()` send that name without a local engine or a local workflow file.
+Use `listWorkflows()` to discover the served names.
+
+To capture your local file instead, pass an explicit path such as
+`./hello.nika.yaml`. The compatible local engine captures an immutable
+snapshot, and the SDK sends its exact bytes and verifies the acknowledgement.
+Only this path needs `bin`, `NIKA_BIN`, or the exact optional native package.
+Observation and scheduling also use the server identity alone.
 
 The current persistent server requires a project file. If you ran
 `nika init --project-file` above you already have one (it carries a default
@@ -380,7 +383,7 @@ Remote-only options:
 
 | Method | Result |
 |---|---|
-| `check(workflow, options?)` | engine check report, including `clean` and `exitCode` |
+| `check(workflow, options?)` | `clean` plus the native check report or resident acknowledgement/refusal |
 | `run(workflow, options?)` | admitted `NikaRun` |
 | `attachRun(id, options?)` | reattached durable HTTP `NikaRun` |
 | `status(run)` | current durable HTTP status |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,8 @@ Some operations deliberately have one authority:
 - resident workflow discovery, durable status, and schedules require HTTP;
 - a direct native process refuses those operations with
   `NikaCompatibilityError`;
-- remote execution still needs a compatible local engine to capture an
-  immutable snapshot before any network admission;
+- remote execution by contained workflow name uses the resident registry;
+  explicit local paths need a compatible local engine to capture a snapshot;
 - when that capture is red the HTTP adapter returns the local engine's plain
   `nika check --json` report, so `findings[]` stays canonical and no workflow
   bytes are sent;

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -4,7 +4,9 @@
 route except public `GET /health`; bearer tokens are redacted from failures.
 A non-2xx answer typed as `{ error: { code, message } }` becomes a
 `NikaOperationError` carrying `status`, `code`, and the refused `operation`;
-any other non-2xx body is discarded and reported as a redacted
+For a check by served name, a typed 404 or 422 instead returns
+`{ clean: false, error }`; authentication and transport failures still throw.
+Any other non-2xx body is discarded and reported as a redacted
 `NikaTransportError`.
 
 | HTTP route | SDK surface | Contract |
@@ -13,8 +15,8 @@ any other non-2xx body is discarded and reported as a redacted
 | `GET /v1/openapi.json` | generation only | authenticated OpenAPI 3.1 document |
 | `GET /v1/workflows` | `listWorkflows()` | contained relative workflow names |
 | `GET /v1/workflows/{name}` | `workflow(name)` | path-free metadata, never source bytes |
-| `POST /v1/check` | `check()` | validates immutable snapshot bytes without a job |
-| `POST /v1/jobs` | `run()` | admits exact snapshot bytes with an idempotency key |
+| `POST /v1/check` | `check()` | validates a served name or immutable snapshot bytes without a job |
+| `POST /v1/jobs` | `run()` | admits a served name or exact snapshot bytes with an idempotency key |
 | `GET /v1/jobs/{id}` | internal settlement | durable job identity, outputs, receipt, settlement, or redacted error |
 | `GET /v1/jobs/{id}/status` | `status(run)` | current status only |
 | `GET /v1/jobs/{id}/events` | `events(run)` / `attachRun()` | bounded, sequenced SSE with replay |
@@ -37,6 +39,11 @@ any other non-2xx body is discarded and reported as a redacted
 - Caller-provided workflow catalog names must be contained slash-separated
   paths. Absolute paths, backslashes, empty segments, `.` and `..` are
   rejected before network I/O.
+
+A contained `.nika.yaml` name uses the resident registry without a local
+engine. Prefix a local file with `./` to capture and submit its snapshot.
+A successful by-name check returns `clean: true` and the compact resident
+acknowledgement; no local check report or exit code is fabricated.
 
 ## Settlement
 

--- a/docs/migrating-to-0.116.md
+++ b/docs/migrating-to-0.116.md
@@ -28,6 +28,8 @@ process transport; supplying `url` and `token` selects HTTP. Remote `check()`
 and `run()` also need a local Nika binary (`bin`, `NIKA_BIN`, or the exact
 optional host payload package) because
 the SDK captures and validates immutable snapshot bytes before admission.
+The current by-name HTTP path also accepts contained workflow names without a
+local engine; prefix a local file with `./` to retain snapshot capture.
 
 ```ts
 // 0.115

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,6 +16,7 @@ NIKA_BIN=/path/to/nika npm run gauntlet:projects
 NIKA_BIN=/path/to/nika npm run gauntlet:depth
 NIKA_BIN=/path/to/nika npm run gauntlet:hostile
 NIKA_BIN=/path/to/nika npm run gauntlet:recovery
+NIKA_BIN=/path/to/nika npm run gauntlet:one-door
 npm audit
 npm pack --dry-run
 ```
@@ -30,12 +31,13 @@ must remain labelled as non-gating evidence.
 
 CI adds a behavioral provenance replay. It downloads the Linux x64 asset for
 the exact root package version, verifies its GitHub attestation and published
-`SHA256SUMS` entry, then reruns all 100 deterministic workflows, the full
-14-scenario hostile suite, all five mini-SaaS projects, all five depth projects,
-and the two-process recovery scenario from a freshly packed SDK. The runner
+`SHA256SUMS` entry, then reruns all 100 deterministic workflows, the hostile suite, all five mini-SaaS projects, all five depth projects,
+the two-process recovery scenario, and five scenarios through six execution
+doors from a freshly packed SDK. The runner
 mints an ephemeral run-signing key. Its
-cancellation fixtures use the engine's in-process `nika:wait` primitive, so the
-replay needs no shell command, platform sandbox, or sandbox waiver. Cancellation
+cancellation fixtures retain the in-process `nika:wait` cases and add an
+owned loopback rendezvous for controlled task-boundary cancellation. They
+need no shell command, platform sandbox, or sandbox waiver. Cancellation
 and sealed-trace claims are exercised against the public binary. The
 cancellation fixtures cancel an execution that is observably inside its 10 s
 `nika:wait` (the durable status reads `running`, no longer `queued`, and a
@@ -123,7 +125,24 @@ tagged engine assets, starts the released Linux binary, proves the live
 OpenAPI/types pin, embeds the exact prepared commit and release version in all
 five package manifests before packing, and publishes four payloads plus the SDK
 with the repository's npm token and a Sigstore provenance attestation bound to
-the workflow identity (a version already on the registry is skipped, never
-re-published). `release-finalize.yml` refuses to create the SDK tag and GitHub
+the workflow identity. An occupied version is accepted only after its exact
+prepared tarball integrity and fetched registry bytes match; errors other than
+an explicit registry 404 refuse publication. `release-finalize.yml` refuses to create the SDK tag and GitHub
 Release until all five exact versions are publicly observable on npm and every
 published manifest carries the same prepared commit and version.
+
+## One-door parity and process supervision
+
+`gauntlet:one-door` compares CLI, raw HTTP by name and snapshot, and packed SDK
+native, by-name and snapshot execution. It checks success, failure, recovery,
+paused observation and controlled cancellation. `NIKA_ONE_DOOR_REPORT` names
+its output file; CI retains it alongside the replay results. Development mode
+uses an offline installation of the freshly packed SDK with the explicit
+`NIKA_BIN`. Public npm parity requires `NIKA_PUBLIC_SDK_VERSION` and an outer
+artifact-provenance gate; runtime agreement alone is not an attestation.
+
+All harnesses own their child processes, impose finite deadlines and await
+cleanup before emitting green evidence. The corpus runs in a fresh project and
+HOME. Changed fixtures require new measured results: old committed ledgers
+remain historical observations until a successful exact-version replay replaces
+them. Never relabel an old binary or weaken the replay comparison.

--- a/gauntlet/projects-depth/REPORT.md
+++ b/gauntlet/projects-depth/REPORT.md
@@ -27,16 +27,15 @@ remained green. The generated JSON records installed-from-pack proof, stable
 scenario facts, typed error names/codes, receipt verdicts, event observations,
 concurrency, cancellation, CAS, and restart evidence.
 
-The incident-response controller cancels its run one second after the durable
-status reads `running`, inside its 10 s stabilization wait. Engine 0.118
-answers 202 `cancellation_requested` and its execution owner records
-`execution.interrupted` once the grace expires; the evidence and its verifier
-bind that terminal to that reply. The same reply binds to an
-`execution.cancelled` or `execution.settled` terminal with status `cancelled`
-only when its settlement cause is `operator` (the request landed at a task
-boundary), and a 200 `cancelled` reply, which the resident gives a job
-cancelled before its execution starts, binds to one of those two writer kinds
-with status `cancelled`.
+The incident-response controller first executes its original workflow and
+verifies the incident plan. A separate controlled loopback fixture holds a
+task until the cancellation request is acknowledged, then releases it. The
+public 0.118.7 replay records `cancelled` with cause `operator`, one completed
+task and one dependent task that never starts. SSE, terminal result and replay
+agree; the resident shuts down without a forced kill. The ledger includes
+byte-identical source/executed app hashes and the packed SDK SHA-256.
+The hostile suite separately retains the `nika:wait` grace-expiry scenario;
+`interrupted` remains a distinct result without a fabricated settlement.
 
 An additional packed two-process recovery project runs through
 `npm run gauntlet:recovery`. Process A admits the job, persists sequence 1 and

--- a/gauntlet/projects-depth/REPORT.md
+++ b/gauntlet/projects-depth/REPORT.md
@@ -53,3 +53,9 @@ The live owning contract and engine validation define `pauseUntil` as an ISO
 calendar date (`format: date`, for example `2026-09-01`). The gauntlet exposed
 that the old README constructed a refused timestamp; the 0.116 documentation
 and exported type comment now teach the owning date contract.
+
+The committed depth baseline uses the complete Linux replay record from
+GitHub Actions run 34260625242 (candidate b688b8b7). macOS reproduced every
+behavioral field identically; its locally packed archive had a different
+SHA-256. Both original records are retained in the integration evidence.
+CI compares the exact Linux package digest as well as all behavioral fields.

--- a/gauntlet/projects-depth/incident-response-controller/app.mjs
+++ b/gauntlet/projects-depth/incident-response-controller/app.mjs
@@ -1,109 +1,174 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
-import { createServer as createNetServer } from 'node:net';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { Nika } from '@supernovae-st/nika-client';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import { CancellationRendezvous } from '../../../scripts/one-door/cancellation.mjs';
+import { cancellationFixture, compareSameJobResult, settlementFacts } from '../../../scripts/one-door/contract.mjs';
+import { OwnedProcesses } from '../../../scripts/one-door/process.mjs';
+import { bounded, cancelHeldRun, collectRunEvents } from '../../../scripts/gauntlet-cancellation.mjs';
 
-const engine = process.env.NIKA_BIN;
-assert(engine, 'NIKA_BIN is required');
-const token = 'depth-incident-token-0123456789abcdef01234567';
-const runtime = path.join(process.cwd(), '.runtime');
-await mkdir(runtime, { recursive: true });
-const tokenFile = path.join(runtime, 'serve.token');
-await writeFile(tokenFile, `${token}\n`, { mode: 0o600 });
-await chmod(tokenFile, 0o600);
-const port = await freePort();
-const url = `http://127.0.0.1:${port}`;
-const server = spawn(engine, ['serve', '--bind', `127.0.0.1:${port}`, '--workflows', '.', '--token-file', tokenFile, '--state-root', path.join(runtime, 'state'), '--plain'], { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] });
-let diagnostics = '';
-server.stderr.setEncoding('utf8');
-server.stderr.on('data', (chunk) => { diagnostics += chunk; });
+// The original incident workflow completes its ten-second stabilization wait.
+// Cancellation is proved separately at an explicitly held loopback fetch.
+export async function exerciseIncident(nika, gate, signal) {
+  const step = (promise, ms, label) => bounded(promise, ms, label, signal);
+  assert.equal((await step(nika.check('workflow.nika.yaml'), 10_000, 'incident check')).clean, true);
+  const original = await step(nika.run('workflow.nika.yaml', { idempotencyKey: 'incident-plan-1' }), 10_000, 'incident admission');
+  const projectResult = await step(original.done, 30_000, 'incident workflow completion');
+  assert.equal(projectResult.status, 'succeeded');
+  assert.equal(projectResult.outputs?.plan?.incident?.id, 'inc-2042');
+  assert.equal(projectResult.outputs?.plan?.breached, 3);
+  assert.equal(projectResult.outputs?.completion?.state, 'reassessed');
+  assert.match(projectResult.outputs?.plan_digest ?? '', /^[0-9a-f]{64}$/);
 
-try {
-  await waitForHealth(url);
-  const nika = new Nika({ url, token, allowInsecureHttp: true, bin: engine, cwd: process.cwd(), eventBufferSize: 128 });
-  assert.equal((await nika.check('workflow.nika.yaml')).clean, true);
-  const run = await nika.run('workflow.nika.yaml', { idempotencyKey: 'incident-inc-2042-controller-1' });
-  // Cancel the controller inside its stabilization window: the durable status
-  // reads `queued` at admission and `running` once the resident owns the
-  // execution, and one second later the run is inside its 10 s `nika:wait`.
-  // On engine 0.118 a cancel that lands on `running` is a 202
-  // `cancellation_requested`; the execution owner then records
-  // `execution.interrupted` once its grace expires inside the task, or
-  // `cancelled` with `cause: operator` at a task boundary. A cancel that lands
-  // on `queued` is a 200 `cancelled` with an `execution.cancelled` terminal.
-  // This consumer records the interrupted shape.
-  await untilRunning(nika, run);
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  const statusBeforeCancellation = await nika.status(run);
-  assert.equal(statusBeforeCancellation, 'running');
-  const firstCancel = nika.cancel(run);
-  assert.equal(nika.cancel(run), firstCancel);
-  const [cancellation, result] = await Promise.all([firstCancel, run.done]);
-  assert.equal(cancellation.accepted, true);
-  assert.equal(cancellation.status, 'cancellation_requested');
-  assert.equal(result.status, 'interrupted');
+  gate.arm('depth incident cancellation');
+  const run = await step(nika.run('controlled-cancel.nika.yaml', { idempotencyKey: 'incident-cancel-1' }), 10_000, 'controlled admission');
+  const { cancellation, result, rendezvous } = await cancelHeldRun(nika, run, gate, signal);
   assert(result.receipt);
-  const recovered = await nika.attachRun(run.id);
-  const events = [];
-  for await (const event of nika.events(recovered)) {
-    events.push({
-      kind: event.kind ?? 'unknown',
-      status: event.status,
-      ...(event.settlement ? { settlement_cause: event.settlement.cause } : {}),
-    });
+  const recovered = await step(nika.attachRun(run.id), 10_000, 'incident reattach');
+  const observer = new AbortController();
+  const observation = collectRunEvents(nika, recovered, observer.signal);
+  observation.catch(() => {});
+  let events;
+  try {
+    const [replayed, frames] = await step(Promise.all([recovered.done, observation]), 10_000, 'incident durable replay');
+    events = frames;
+    compareSameJobResult(replayed, result, 'incident reattach');
+    compareSameJobResult(result, events.at(-1), 'incident durable replay');
+  } finally {
+    observer.abort();
+    await bounded(observation.catch(() => {}), 2_000, 'incident replay observer cleanup');
   }
-  await recovered.done;
-  const terminal = events.at(-1);
-  assert(terminal);
-  assert.equal(terminal.kind, 'execution.interrupted');
-  assert.equal(terminal.status, result.status);
-  const remoteProof = await nika.traceVerify(result.receipt);
+  const remoteProof = await step(nika.traceVerify(result.receipt), 5_000, 'remote receipt verdict');
   assert.equal(remoteProof.verified, false);
   assert.equal(remoteProof.verdict, 'unavailable');
   assert.equal(remoteProof.reason, 'trace_journal_unavailable');
-
-  console.log(JSON.stringify({
-    project: 'incident-response-controller',
-    status: 'succeeded',
-    status_before_cancellation: statusBeforeCancellation,
+  return {
+    project: 'incident-response-controller', status: 'succeeded',
+    project_workflow_status: projectResult.status,
+    incident_plan_verified: true,
     cancelled_run_status: result.status,
     cancellation_idempotent: true,
     cancellation_status: cancellation.status,
     sse_event_kinds: [...new Set(events.map((event) => event.kind))].sort(),
-    sse_terminal: terminal,
+    sse_terminal: { kind: events.at(-1).kind, status: events.at(-1).status,
+      settlement_cause: events.at(-1).settlement?.cause },
+    settlement: settlementFacts(result),
+    same_job_terminal_and_replay_matched: true,
+    cancellation_rendezvous: rendezvous,
     remote_receipt_verdict: { verdict: remoteProof.verdict, reason: remoteProof.reason },
     deterministic_cost_cap_usd: 0,
-  }));
-} finally {
-  server.kill('SIGINT');
-  await Promise.race([new Promise((resolve) => server.once('close', resolve)), new Promise((resolve) => setTimeout(resolve, 3000))]);
-  if (server.exitCode && server.exitCode !== 130) throw new Error(`nika serve exited ${server.exitCode}: ${diagnostics.slice(-500)}`);
+  };
 }
 
-async function freePort() {
-  const server = createNetServer();
-  await new Promise((resolve, reject) => server.listen(0, '127.0.0.1', resolve).once('error', reject));
-  const address = server.address();
-  assert(address && typeof address === 'object');
-  await new Promise((resolve) => server.close(resolve));
-  return address.port;
-}
-
-async function waitForHealth(base) {
-  for (let attempt = 0; attempt < 120; attempt += 1) {
-    try { if ((await fetch(`${base}/health`)).ok) return; } catch {}
-    await new Promise((resolve) => setTimeout(resolve, 25));
+export async function waitForHealthyServer(server, {
+  timeoutMs = 10_000, fetchTimeoutMs = 750, pollMs = 25, fetchImpl = fetch, signal,
+} = {}) {
+  const deadline = performance.now() + timeoutMs;
+  const exited = server.done.then((result) => {
+    throw new Error(`incident server exited before health: ${JSON.stringify(result)}`);
+  });
+  exited.catch(() => {});
+  let lastError = 'no listening URL';
+  while (performance.now() < deadline) {
+    signal?.throwIfAborted();
+    const diagnostics = `${server.stdout}\n${server.stderr}`;
+    const url = diagnostics.match(/nika serve[^\n]*listening (http:\/\/127\.0\.0\.1:\d+)/)?.[1];
+    if (url) {
+      const request = new AbortController();
+      const limit = Math.max(1, Math.min(fetchTimeoutMs, deadline - performance.now()));
+      try {
+        const attempt = (async () => {
+          const response = await fetchImpl(`${url}/health`, { signal: request.signal, redirect: 'error' });
+          try { return response.ok; } finally { await response.body?.cancel(); }
+        })();
+        const healthy = await bounded(Promise.race([attempt, exited]), limit, 'incident health request', signal);
+        if (healthy) return url;
+        lastError = 'health returned a non-success status';
+      } catch (error) {
+        lastError = error.message;
+        if (server.child.exitCode !== null || server.child.signalCode !== null) throw error;
+      } finally {
+        request.abort();
+      }
+    }
+    await bounded(Promise.race([delay(Math.min(pollMs, Math.max(1, deadline - performance.now()))), exited]),
+      Math.max(1, deadline - performance.now()), 'incident health polling', signal);
   }
-  throw new Error('nika serve did not become healthy');
+  throw new Error(`incident health did not succeed within ${timeoutMs}ms: ${lastError}\n${server.stdout}\n${server.stderr}`);
 }
 
-async function untilRunning(client, run) {
-  for (let attempt = 0; attempt < 500; attempt += 1) {
-    const status = await client.status(run);
-    if (status !== 'queued') return status;
-    await new Promise((resolve) => setTimeout(resolve, 10));
+export async function stopIncidentServer(server, graceMs = 5_000) {
+  server.signal('SIGINT');
+  let settled = false;
+  try {
+    const result = await bounded(server.done, graceMs, 'incident server graceful shutdown');
+    settled = true;
+    assert((result.signal === null && [0, 130].includes(result.code))
+      || (result.signal === 'SIGINT' && result.code === null),
+    `incident server did not exit cleanly: ${JSON.stringify(result)}`);
+    return { exit_code: result.code, signal: result.signal, forced: false, reaped: true };
+  } finally {
+    // Even a timeout, rejected done, or unexpected signal must reap the owned
+    // process group. Escalation never turns the preceding failure green.
+    if (!settled) await server.stop();
+    await server.done.catch(() => {});
   }
-  throw new Error('the resident never took ownership of the execution');
 }
+
+async function main() {
+  const engine = process.env.NIKA_BIN;
+  assert(engine, 'NIKA_BIN is required');
+  const sdkEntry = realpathSync(fileURLToPath(import.meta.resolve('@supernovae-st/nika-client')));
+  const installedPackage = path.join(process.cwd(), 'node_modules', '@supernovae-st', 'nika-client');
+  assert(sdkEntry.startsWith(`${installedPackage}${path.sep}`), 'SDK must resolve inside this installed npm-pack consumer');
+  const { Nika } = await import('@supernovae-st/nika-client');
+  const executedAppSha256 = createHash('sha256').update(readFileSync(fileURLToPath(import.meta.url))).digest('hex');
+  const runtime = path.join(process.cwd(), '.runtime');
+  mkdirSync(runtime, { recursive: true });
+  const token = 'depth-incident-token-0123456789abcdef01234567';
+  const tokenFile = path.join(runtime, 'serve.token');
+  writeFileSync(tokenFile, `${token}\n`, { mode: 0o600 });
+  const owned = new OwnedProcesses();
+  const abort = new AbortController();
+  const handlers = new Map(['SIGINT', 'SIGTERM', 'SIGHUP'].map((signal) => [signal,
+    () => abort.abort(new Error(`incident app received ${signal}`))]));
+  for (const [signal, handler] of handlers) process.on(signal, handler);
+  const timer = setTimeout(() => abort.abort(new Error('incident app exceeded 75s')), 75_000);
+  let gate;
+  let server;
+  let report;
+  let failure;
+  try {
+    gate = await CancellationRendezvous.listen();
+    writeFileSync('controlled-cancel.nika.yaml', cancellationFixture(gate.url));
+    server = owned.start(engine, ['serve', '--bind', '127.0.0.1:0', '--workflows', '.',
+      '--token-file', tokenFile, '--state-root', path.join(runtime, 'state'), '--plain'],
+    { cwd: process.cwd(), env: process.env, timeoutMs: 85_000, maxBuffer: 64 * 1024 });
+    const url = await waitForHealthyServer(server, { signal: abort.signal });
+    const nika = new Nika({ url, token, allowInsecureHttp: true, bin: engine,
+      cwd: process.cwd(), eventBufferSize: 128 });
+    report = await exerciseIncident(nika, gate, abort.signal);
+  } catch (error) {
+    failure = error;
+  } finally {
+    abort.abort();
+    clearTimeout(timer);
+    const cleanup = await Promise.allSettled([
+      gate ? bounded(gate.close(), 2_000, 'incident rendezvous cleanup') : undefined,
+      server ? stopIncidentServer(server) : undefined,
+    ]);
+    try { await owned.close(); } catch (error) { cleanup.push({ status: 'rejected', reason: error }); }
+    for (const [signal, handler] of handlers) process.off(signal, handler);
+    const errors = cleanup.filter((result) => result.status === 'rejected').map((result) => result.reason);
+    if (server?.child.signalCode === 'SIGKILL') errors.push(new Error('incident server required SIGKILL'));
+    if (errors.length) failure = new AggregateError([...(failure ? [failure] : []), ...errors], 'incident proof or cleanup failed');
+    if (!failure) report.server_cleanup = cleanup[1].value;
+  }
+  if (failure) throw failure;
+  console.log(JSON.stringify({ ...report, executed_app_sha256: executedAppSha256,
+    sdk_entry: path.relative(process.cwd(), sdkEntry) }));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(process.argv[1])) await main();

--- a/gauntlet/projects-depth/results.json
+++ b/gauntlet/projects-depth/results.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "engine": "nika 0.118.7 (f3a31a6ee)",
   "package": "supernovae-st-nika-client-0.118.7.tgz",
+  "package_sha256": "17dcdc7a5c23be71c2cb509bcedbebc61a53bfc4021d81f7d52cf16882136ba8",
   "install_mode": "npm pack + isolated npm install --omit=optional + explicit NIKA_BIN",
   "projects": [
     {
@@ -29,7 +30,12 @@
       ],
       "receipt_verified": true,
       "deterministic_cost_cap_usd": 0,
-      "installed_from_pack": true
+      "installed_from_pack": true,
+      "app_identity": {
+        "source_sha256": "6f4d68c35a397b829b92e27e3016d9b96650747a7b93540e9aa3658fe5849efb",
+        "executed_sha256": "6f4d68c35a397b829b92e27e3016d9b96650747a7b93540e9aa3658fe5849efb",
+        "byte_identical": true
+      }
     },
     {
       "project": "evidence-provenance-pipeline",
@@ -48,29 +54,79 @@
         "workflow_started"
       ],
       "deterministic_cost_cap_usd": 0,
-      "installed_from_pack": true
+      "installed_from_pack": true,
+      "app_identity": {
+        "source_sha256": "f0c75462e0bf03cbde94df62cf8870ef05f238aa560b07d3d81d13a80d57d912",
+        "executed_sha256": "f0c75462e0bf03cbde94df62cf8870ef05f238aa560b07d3d81d13a80d57d912",
+        "byte_identical": true
+      }
     },
     {
       "project": "incident-response-controller",
       "status": "succeeded",
-      "status_before_cancellation": "running",
-      "cancelled_run_status": "interrupted",
+      "project_workflow_status": "succeeded",
+      "incident_plan_verified": true,
+      "cancelled_run_status": "cancelled",
       "cancellation_idempotent": true,
       "cancellation_status": "cancellation_requested",
       "sse_event_kinds": [
-        "execution.interrupted",
+        "execution.cancelled",
         "execution.started"
       ],
       "sse_terminal": {
-        "kind": "execution.interrupted",
-        "status": "interrupted"
+        "kind": "execution.cancelled",
+        "status": "cancelled",
+        "settlement_cause": "operator"
+      },
+      "settlement": {
+        "status": "cancelled",
+        "cause": "operator",
+        "tasks": {
+          "cancelled": 1,
+          "failed": 0,
+          "never_started": 1,
+          "ok": 1,
+          "recovered": 0,
+          "skipped": 0,
+          "total": 2
+        },
+        "spend": {
+          "priced_calls": 0,
+          "qualifier": "unmetered",
+          "unpriced_calls": 0
+        },
+        "error_code": null,
+        "error_task": null
+      },
+      "same_job_terminal_and_replay_matched": true,
+      "cancellation_rendezvous": {
+        "cancel_point": "loopback fetch held before response",
+        "release": "after cancellation request acknowledgement",
+        "requests": {
+          "hold": 1,
+          "dependent": 0
+        },
+        "dependent_unstarted": true
       },
       "remote_receipt_verdict": {
         "verdict": "unavailable",
         "reason": "trace_journal_unavailable"
       },
       "deterministic_cost_cap_usd": 0,
-      "installed_from_pack": true
+      "server_cleanup": {
+        "exit_code": 0,
+        "signal": null,
+        "forced": false,
+        "reaped": true
+      },
+      "executed_app_sha256": "91740d8068f15e7432e6750bb419be0fbfd2772962dee19ab4a650a2729b4380",
+      "sdk_entry": "node_modules/@supernovae-st/nika-client/dist/index.js",
+      "installed_from_pack": true,
+      "app_identity": {
+        "source_sha256": "91740d8068f15e7432e6750bb419be0fbfd2772962dee19ab4a650a2729b4380",
+        "executed_sha256": "91740d8068f15e7432e6750bb419be0fbfd2772962dee19ab4a650a2729b4380",
+        "byte_identical": true
+      }
     },
     {
       "project": "multi-tenant-webhook-router",
@@ -85,7 +141,12 @@
         "execution.started"
       ],
       "deterministic_cost_cap_usd": 0,
-      "installed_from_pack": true
+      "installed_from_pack": true,
+      "app_identity": {
+        "source_sha256": "141d4b3b3d32e160aed3e7872cb21beb2389221d99ed28804e11015f2439092c",
+        "executed_sha256": "141d4b3b3d32e160aed3e7872cb21beb2389221d99ed28804e11015f2439092c",
+        "byte_identical": true
+      }
     },
     {
       "project": "scheduled-research-monitor",
@@ -102,7 +163,12 @@
         2
       ],
       "deterministic_cost_cap_usd": 0,
-      "installed_from_pack": true
+      "installed_from_pack": true,
+      "app_identity": {
+        "source_sha256": "de35e211fef5f7999f8420affe598e864136b3a50ff4dcd218a11e406393d348",
+        "executed_sha256": "de35e211fef5f7999f8420affe598e864136b3a50ff4dcd218a11e406393d348",
+        "byte_identical": true
+      }
     }
   ],
   "summary": {

--- a/gauntlet/projects-depth/results.json
+++ b/gauntlet/projects-depth/results.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "engine": "nika 0.118.7 (f3a31a6ee)",
   "package": "supernovae-st-nika-client-0.118.7.tgz",
-  "package_sha256": "17dcdc7a5c23be71c2cb509bcedbebc61a53bfc4021d81f7d52cf16882136ba8",
+  "package_sha256": "f5e8c0cbc7475a944f06ec7e75ecf18a5f225e666a1a71af5a1bcfa4f23acbc4",
   "install_mode": "npm pack + isolated npm install --omit=optional + explicit NIKA_BIN",
   "projects": [
     {

--- a/gauntlet/results/hostile.json
+++ b/gauntlet/results/hostile.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-09-07T08:59:46.010Z",
+  "generated_at": "2026-09-08T17:59:23.386Z",
   "engine": "nika 0.118.7 (f3a31a6ee)",
   "scenarios": [
     {
       "name": "unsafe-http-refusal",
       "result": "green",
-      "duration_ms": 0,
+      "duration_ms": 47,
       "evidence": {
         "refusal": "NikaConfigurationError",
         "network_requests": 0
@@ -15,7 +15,7 @@
     {
       "name": "missing-engine-refusal",
       "result": "green",
-      "duration_ms": 2,
+      "duration_ms": 43,
       "evidence": {
         "error": "NikaCompatibilityError",
         "bounded": true
@@ -24,7 +24,7 @@
     {
       "name": "oversize-machine-line",
       "result": "green",
-      "duration_ms": 49,
+      "duration_ms": 939,
       "evidence": {
         "error": "NikaProtocolError",
         "limit_bytes": 1024
@@ -33,7 +33,7 @@
     {
       "name": "malformed-machine-frame",
       "result": "green",
-      "duration_ms": 56,
+      "duration_ms": 108,
       "evidence": {
         "error": "NikaProtocolError"
       }
@@ -41,7 +41,7 @@
     {
       "name": "child-crash-settlement",
       "result": "green",
-      "duration_ms": 49,
+      "duration_ms": 102,
       "evidence": {
         "status": "failed",
         "exit_code": 23
@@ -50,7 +50,7 @@
     {
       "name": "malformed-workflow-domain-report",
       "result": "green",
-      "duration_ms": 10,
+      "duration_ms": 52,
       "evidence": {
         "clean": false,
         "exit_code": 2
@@ -59,7 +59,7 @@
     {
       "name": "explicit-bin-empty-path",
       "result": "green",
-      "duration_ms": 66,
+      "duration_ms": 110,
       "evidence": {
         "check": "clean",
         "status": "succeeded"
@@ -68,7 +68,7 @@
     {
       "name": "parallel-run-load",
       "result": "green",
-      "duration_ms": 219,
+      "duration_ms": 265,
       "evidence": {
         "runs": 24,
         "succeeded": 24,
@@ -78,18 +78,57 @@
     {
       "name": "real-cancellation-race",
       "result": "green",
-      "duration_ms": 10067,
+      "duration_ms": 10209,
       "evidence": {
         "cancel_status": "cancellation_requested",
         "run_status": "cancelled",
         "exit_code": 130,
-        "settlement_cause": "operator"
+        "settlement_cause": "operator",
+        "controlled_cancellation": {
+          "cancel_status": "cancellation_requested",
+          "run_status": "cancelled",
+          "exit_code": 130,
+          "settlement": {
+            "status": "cancelled",
+            "cause": "operator",
+            "tasks": {
+              "cancelled": 1,
+              "failed": 0,
+              "never_started": 1,
+              "ok": 1,
+              "recovered": 0,
+              "skipped": 0,
+              "total": 2
+            },
+            "spend": {
+              "priced_calls": 0,
+              "qualifier": "unmetered",
+              "unpriced_calls": 0
+            },
+            "error_code": null,
+            "error_task": null
+          },
+          "same_job_terminal_matched": true,
+          "terminal": {
+            "kind": "run_settled",
+            "status": "cancelled"
+          },
+          "cancellation_rendezvous": {
+            "cancel_point": "loopback fetch held before response",
+            "release": "after cancellation request acknowledgement",
+            "requests": {
+              "hold": 1,
+              "dependent": 0
+            },
+            "dependent_unstarted": true
+          }
+        }
       }
     },
     {
       "name": "remote-durable-cancellation",
       "result": "green",
-      "duration_ms": 5414,
+      "duration_ms": 5552,
       "evidence": {
         "status_before_cancellation": "running",
         "cancel_status": "cancellation_requested",
@@ -106,13 +145,61 @@
         ],
         "durable_receipt": true,
         "trace_verdict": "unavailable",
-        "parse_fatal_clean": false
+        "parse_fatal_clean": false,
+        "controlled_cancellation": {
+          "cancel_status": "cancellation_requested",
+          "run_status": "cancelled",
+          "settlement": {
+            "status": "cancelled",
+            "cause": "operator",
+            "tasks": {
+              "cancelled": 1,
+              "failed": 0,
+              "never_started": 1,
+              "ok": 1,
+              "recovered": 0,
+              "skipped": 0,
+              "total": 2
+            },
+            "spend": {
+              "priced_calls": 0,
+              "qualifier": "unmetered",
+              "unpriced_calls": 0
+            },
+            "error_code": null,
+            "error_task": null
+          },
+          "same_job_terminal_and_replay_matched": true,
+          "cancellation_rendezvous": {
+            "cancel_point": "loopback fetch held before response",
+            "release": "after cancellation request acknowledgement",
+            "requests": {
+              "hold": 1,
+              "dependent": 0
+            },
+            "dependent_unstarted": true
+          },
+          "events": [
+            {
+              "kind": "execution.started",
+              "status": "running"
+            },
+            {
+              "kind": "execution.cancelled",
+              "status": "cancelled",
+              "settlement_cause": "operator"
+            }
+          ],
+          "durable_receipt": true,
+          "trace_verdict": "unavailable",
+          "parse_fatal_clean": false
+        }
       }
     },
     {
       "name": "trace-corruption-detection",
       "result": "green",
-      "duration_ms": 90,
+      "duration_ms": 147,
       "evidence": {
         "intact": true,
         "forged_receipt": false,
@@ -122,7 +209,7 @@
     {
       "name": "secret-canary-redaction",
       "result": "green",
-      "duration_ms": 63,
+      "duration_ms": 101,
       "evidence": {
         "result_redacted": true,
         "trace_redacted": true
@@ -131,7 +218,7 @@
     {
       "name": "slow-subscriber-overflow-isolation",
       "result": "green",
-      "duration_ms": 64,
+      "duration_ms": 101,
       "evidence": {
         "run_status": "succeeded",
         "subscriber_error": "NikaEventBufferOverflowError",
@@ -141,7 +228,7 @@
     {
       "name": "sequential-soak",
       "result": "green",
-      "duration_ms": 2333,
+      "duration_ms": 2412,
       "evidence": {
         "runs": 40,
         "succeeded": 40
@@ -152,7 +239,7 @@
     "total": 14,
     "green": 14,
     "red": 0,
-    "real_engine_runs": 70
+    "real_engine_runs": 72
   },
   "result": "green"
 }

--- a/gauntlet/results/local-execution.json
+++ b/gauntlet/results/local-execution.json
@@ -1,11 +1,9 @@
 {
-  "schema_version": 1,
   "engine": "nika 0.118.7 (f3a31a6ee)",
   "workflows": 100,
   "domains": 20,
   "recipes": 10,
   "distinct_output_hashes": 100,
-  "result": "pass",
   "rows": [
     {
       "id": "uc-001-customer-support-sla-breach-triage",
@@ -607,5 +605,7 @@
       "recipe": "emit-receipt",
       "output_sha256": "4bb2770d83713bdcb44f46591092127877e7fa929c21357d70151d89c435aaf6"
     }
-  ]
+  ],
+  "schema_version": 1,
+  "result": "green"
 }

--- a/gauntlet/results/mini-saas.json
+++ b/gauntlet/results/mini-saas.json
@@ -1,5 +1,4 @@
 {
-  "schema_version": 1,
   "engine": "nika 0.118.7 (f3a31a6ee)",
   "package": "supernovae-st-nika-client-0.118.7.tgz",
   "install_mode": "npm pack + npm install --omit=optional + explicit NIKA_BIN",
@@ -67,5 +66,6 @@
       "installed_from_pack": true
     }
   ],
+  "schema_version": 1,
   "result": "green"
 }

--- a/gauntlet/results/recovery-e2e.json
+++ b/gauntlet/results/recovery-e2e.json
@@ -1,15 +1,16 @@
 {
-  "schema_version": 1,
   "engine": "nika 0.118.7 (f3a31a6ee)",
   "package": "supernovae-st-nika-client-0.118.7.tgz",
   "process_count": 2,
   "installed_from_pack": true,
   "project": "two-process-durable-recovery",
   "status": "succeeded",
-  "job_id": "17638ce0-f4b9-41fd-8c64-6c8f544eeb1e",
+  "job_id": "63b53116-4bae-4b81-b037-3a8f55e06d0c",
   "producer_last_event_id": 1,
   "resumed_sequences": [
     2
   ],
-  "duplicate_sequences": []
+  "duplicate_sequences": [],
+  "schema_version": 1,
+  "result": "green"
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "vitest run",
+    "test": "vitest run --maxWorkers=4",
     "test:watch": "vitest",
     "check:package-surface": "node scripts/verify-packed-module-surfaces.mjs",
     "check:coverage": "node scripts/check-sdk-coverage.js",
@@ -60,6 +60,7 @@
     "gauntlet:projects": "node scripts/run-mini-saas-gauntlet.mjs",
     "gauntlet:depth": "node scripts/run-depth-projects.mjs",
     "gauntlet:recovery": "node scripts/run-recovery-e2e.mjs",
+    "gauntlet:one-door": "node scripts/run-one-door-e2e.mjs",
     "gauntlet:hostile": "node scripts/run-hostile-gauntlet.mjs",
     "generate:types": "node scripts/generate-types.js",
     "sync:native-versions": "node scripts/sync-native-versions.mjs",

--- a/scripts/corpus-project.mjs
+++ b/scripts/corpus-project.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, lstatSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+// Check and run use the same unchanged corpus in an owned project and home.
+// This is fixture isolation, not a sandbox for arbitrary hostile workflows.
+export function stageCorpus(root, scratch, env) {
+  const source = path.join(root, 'gauntlet', 'corpus');
+  const project = path.join(scratch, 'project');
+  const fixtureHome = path.join(scratch, 'home');
+  const inventoryPath = path.join(source, 'use-cases.json');
+  assert(lstatSync(inventoryPath).isFile(), 'corpus inventory must be a regular file');
+  assert(lstatSync(path.join(source, 'workflows')).isDirectory(), 'corpus workflows must be a directory');
+  const inventory = JSON.parse(readFileSync(inventoryPath, 'utf8'));
+  const workflowFiles = readdirSync(path.join(source, 'workflows'))
+    .filter((file) => file.endsWith('.nika.yaml')).sort();
+  assert(Array.isArray(inventory), 'corpus inventory must be an array');
+  assert.equal(inventory.length, 100, 'expected exactly 100 corpus cases');
+  assert.equal(workflowFiles.length, 100, 'expected exactly 100 corpus workflows');
+  const uniqueFields = ['id', 'actor', 'trigger', 'failure_oracle', 'business_outcome', 'workflow'];
+  for (const field of [...uniqueFields, 'domain', 'recipe']) {
+    assert(inventory.every((entry) => typeof entry?.[field] === 'string' && entry[field].trim().length > 0),
+      `${field} values must be non-empty strings`);
+  }
+  for (const field of uniqueFields) {
+    assert.equal(new Set(inventory.map((entry) => entry[field])).size, 100, `${field} must be unique`);
+  }
+  assert.equal(new Set(inventory.map((entry) => entry.domain)).size, 20, 'expected 20 distinct domains');
+  for (const entry of inventory) {
+    assert(typeof entry.workflow === 'string' && /^workflows\/[^/\\]+\.nika\.yaml$/.test(entry.workflow),
+      'corpus workflows must remain inside the isolated project');
+    assert(lstatSync(path.join(source, entry.workflow)).isFile(), 'corpus workflow must be a regular file');
+  }
+  assert.deepEqual(inventory.map((entry) => entry.workflow).sort(), workflowFiles.map((file) => `workflows/${file}`));
+  mkdirSync(fixtureHome, { mode: 0o700 });
+  mkdirSync(path.join(project, 'workflows'), { recursive: true, mode: 0o700 });
+  // Stop ancestor discovery without copying repository config, keys or journals.
+  writeFileSync(path.join(project, 'nika.yaml'), 'nika: sdk-corpus\n', { flag: 'wx', mode: 0o600 });
+  copyFileSync(inventoryPath, path.join(project, 'use-cases.json'));
+  for (const entry of inventory) {
+    copyFileSync(path.join(source, entry.workflow), path.join(project, entry.workflow));
+    assert(readFileSync(path.join(project, entry.workflow)).equals(readFileSync(path.join(source, entry.workflow))),
+      'staged workflow bytes must match the source corpus');
+  }
+  const engineEnv = { ...Object.fromEntries(['PATH', 'TMPDIR', 'TMP', 'TEMP', 'LANG', 'LC_ALL', 'TERM']
+    .filter((key) => env[key] !== undefined).map((key) => [key, env[key]])),
+    HOME: fixtureHome, NIKA_KEYCHAIN: 'off' };
+  return { project, engineEnv, inventory, workflowFiles };
+}

--- a/scripts/execute-gauntlet-corpus.mjs
+++ b/scripts/execute-gauntlet-corpus.mjs
@@ -1,76 +1,26 @@
-import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import path, { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { supervisedGauntlet } from './gauntlet.mjs';
+import { stageCorpus } from './corpus-project.mjs';
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const corpusRoot = join(root, "gauntlet", "corpus");
-const resultsRoot = process.env.NIKA_GAUNTLET_RESULTS_DIR
-  ? path.resolve(process.env.NIKA_GAUNTLET_RESULTS_DIR)
-  : join(root, "gauntlet", "results");
-const inventory = JSON.parse(readFileSync(join(corpusRoot, "use-cases.json"), "utf8"));
-const nikaBin = process.env.NIKA_BIN || process.env.NIKA_GAUNTLET_BIN || "nika";
-const version = spawnSync(nikaBin, ["--version"], { encoding: "utf8" });
-
-if (version.status !== 0) throw new Error(`cannot identify ${nikaBin}: ${version.stderr}`);
-
-const rows = [];
-const failures = [];
-for (const entry of inventory) {
-  const path = join(corpusRoot, entry.workflow);
-  const run = spawnSync(nikaBin, ["run", path, "--output", "json", "--max-cost-usd", "0"], {
-    cwd: root,
-    encoding: "utf8",
-    maxBuffer: 8 * 1024 * 1024,
-  });
-  if (run.status !== 0) {
-    failures.push({ id: entry.id, status: run.status, stderr: run.stderr, stdout: run.stdout });
-    continue;
+const root = path.resolve(import.meta.dirname, '..');
+await supervisedGauntlet({ name: 'local-execution', root }, async ({ scratch, nikaBin, env, run }) => {
+  const { project, engineEnv, inventory } = stageCorpus(root, scratch, env);
+  const execute = (args, timeoutMs) => run(nikaBin, args,
+    { cwd: project, env: engineEnv, timeoutMs, maxBuffer: 8 * 1024 * 1024 });
+  const engine = (await execute(['--version'], 5000)).trim();
+  await execute(['key', 'init', '--plain'], 15_000);
+  const rows = [];
+  for (const entry of inventory) {
+    const file = path.join(project, entry.workflow);
+    const output = JSON.parse(await execute(['run', file, '--output', 'json', '--max-cost-usd', '0'], 30_000));
+    rows.push({ id: entry.id, domain: entry.domain, recipe: entry.recipe,
+      output_sha256: createHash('sha256').update(JSON.stringify(output)).digest('hex') });
+    if (rows.length % 10 === 0) process.stdout.write(`executed ${rows.length}/100\n`);
   }
-  let output;
-  try {
-    output = JSON.parse(run.stdout);
-  } catch (error) {
-    failures.push({ id: entry.id, status: "invalid-json", error: String(error), stdout: run.stdout });
-    continue;
-  }
-  rows.push({
-    id: entry.id,
-    domain: entry.domain,
-    recipe: entry.recipe,
-    output_sha256: createHash("sha256").update(JSON.stringify(output)).digest("hex"),
-  });
-  if (rows.length % 10 === 0) process.stdout.write(`executed ${rows.length}/100\n`);
-}
-
-if (failures.length > 0) {
-  console.error(JSON.stringify(failures.slice(0, 10), null, 2));
-  throw new Error(`${failures.length} workflows failed execution`);
-}
-
-const distinctOutputs = new Set(rows.map((row) => row.output_sha256)).size;
-if (rows.length !== 100 || distinctOutputs < 90) {
-  throw new Error(`execution diversity failed: ${rows.length} rows, ${distinctOutputs} distinct output hashes`);
-}
-
-mkdirSync(resultsRoot, { recursive: true });
-writeFileSync(
-  join(resultsRoot, "local-execution.json"),
-  `${JSON.stringify(
-    {
-      schema_version: 1,
-      engine: version.stdout.trim(),
-      workflows: rows.length,
-      domains: new Set(rows.map((row) => row.domain)).size,
-      recipes: new Set(rows.map((row) => row.recipe)).size,
-      distinct_output_hashes: distinctOutputs,
-      result: "pass",
-      rows,
-    },
-    null,
-    2,
-  )}\n`,
-);
-
-console.log(`100/100 workflows executed; ${distinctOutputs}/100 output hashes distinct on ${version.stdout.trim()}`);
+  const distinctOutputs = new Set(rows.map((row) => row.output_sha256)).size;
+  assert(distinctOutputs >= 90, `execution diversity failed: ${distinctOutputs}/100 distinct output hashes`);
+  return { engine, workflows: rows.length, domains: new Set(rows.map((row) => row.domain)).size,
+    recipes: new Set(rows.map((row) => row.recipe)).size, distinct_output_hashes: distinctOutputs, rows };
+});

--- a/scripts/gauntlet-cancellation.mjs
+++ b/scripts/gauntlet-cancellation.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { compareControlledCancellation, compareSameJobResult } from './one-door/contract.mjs';
+
+export function bounded(promise, milliseconds, label, signal) {
+  assert(Number.isFinite(milliseconds) && milliseconds > 0, 'a finite positive deadline is required');
+  let timer;
+  let abort;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} exceeded ${milliseconds}ms`)), milliseconds);
+      abort = () => reject(signal.reason ?? new Error(`${label} aborted`));
+      if (signal?.aborted) abort();
+      else signal?.addEventListener('abort', abort, { once: true });
+    }),
+  ]).finally(() => { clearTimeout(timer); signal?.removeEventListener('abort', abort); });
+}
+
+export async function collectRunEvents(client, run, signal, { maxEvents = 256, maxBytes = 1024 * 1024 } = {}) {
+  const events = [];
+  let bytes = 0;
+  try {
+    for await (const event of client.events(run, { signal })) {
+      bytes += Buffer.byteLength(JSON.stringify(event));
+      assert(events.length < maxEvents && bytes <= maxBytes,
+        `run event output exceeded ${maxEvents} events or ${maxBytes} bytes`);
+      events.push(structuredClone(event));
+    }
+  } catch (error) {
+    if (!signal?.aborted) throw error;
+  }
+  return events;
+}
+
+// Shared by the older cancellation gates. An accepted request is only an
+// action; the actual terminal frame must agree with run.done in full.
+export async function cancelHeldRun(client, run, gate, signal) {
+  const observer = new AbortController();
+  const abort = () => observer.abort(signal.reason);
+  if (signal?.aborted) abort();
+  else signal?.addEventListener('abort', abort, { once: true });
+  const observation = collectRunEvents(client, run, observer.signal);
+  observation.catch(() => {});
+  try {
+    await bounded(Promise.race([
+      gate.arrived,
+      run.done.then(() => { throw new Error('run settled before the cancellation rendezvous'); }),
+    ]), 15_000, 'cancellation rendezvous', signal);
+    const first = client.cancel(run);
+    assert.equal(client.cancel(run), first, 'accepted cancellation must be memoized');
+    const cancellation = await bounded(first, 5_000, 'cancellation action', signal);
+    assert.equal(cancellation.accepted, true);
+    assert.equal(cancellation.status, 'cancellation_requested');
+    await bounded(gate.release(), 5_000, 'held request release', signal);
+    const [result, events] = await bounded(Promise.all([run.done, observation]), 15_000, 'actual cancellation settlement', signal);
+    compareControlledCancellation(result);
+    compareSameJobResult(result, events.at(-1), 'older gauntlet cancellation');
+    const rendezvous = gate.finish();
+    return { cancellation, result, events, rendezvous };
+  } finally {
+    signal?.removeEventListener('abort', abort);
+    observer.abort();
+    await bounded(observation.catch(() => {}), 2_000, 'cancellation observer cleanup');
+  }
+}

--- a/scripts/gauntlet.mjs
+++ b/scripts/gauntlet.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { OwnedProcesses, runOwnedProcess } from './one-door/process.mjs';
+
+// Corpus and packed application runners share process ownership and evidence commit
+// ordering. Body assertions and graceful resident shutdown must finish first.
+export async function supervisedGauntlet({ name, root, env = process.env,
+  owned = new OwnedProcesses(), timeoutMs = 300_000, persistReport = true }, exercise) {
+  assert(Number.isFinite(timeoutMs) && timeoutMs > 0);
+  assert.equal(typeof persistReport, 'boolean');
+  const resultsRoot = env.NIKA_GAUNTLET_RESULTS_DIR
+    ? path.resolve(env.NIKA_GAUNTLET_RESULTS_DIR) : path.join(root, 'gauntlet', 'results');
+  // Static corpus checks have no durable execution ledger. They still share
+  // all deadlines, signal handling and close-before-green obligations.
+  const resultsPath = persistReport ? path.join(resultsRoot, `${name}.json`) : undefined;
+  if (resultsPath) mkdirSync(resultsRoot, { recursive: true });
+  const writeReport = (report) => {
+    if (resultsPath) writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
+  };
+  writeReport({ schema_version: 1, result: 'incomplete', pid: process.pid });
+  const controller = new AbortController();
+  const stop = (reason) => {
+    controller.abort(new Error(reason));
+    void owned.close().catch(() => {});
+  };
+  const handlers = new Map(['SIGINT', 'SIGTERM', 'SIGHUP'].map((signal) => [signal, () => stop(`${name} received ${signal}`)]));
+  for (const [signal, handler] of handlers) process.on(signal, handler);
+  const timer = setTimeout(() => stop(`${name} exceeded ${timeoutMs}ms`), timeoutMs);
+  const handles = [];
+  const start = (command, args, options) => {
+    controller.signal.throwIfAborted();
+    const handle = owned.start(command, args, { env, ...options });
+    handles.push(handle);
+    return handle;
+  };
+  const run = (command, args, options) => runOwnedProcess(start, command, args, options);
+  let scratch;
+  let report;
+  const errors = [];
+  try {
+    assert(env.NIKA_BIN && path.isAbsolute(env.NIKA_BIN), 'NIKA_BIN must name an absolute engine binary under test');
+    scratch = mkdtempSync(path.join(tmpdir(), `nika-${name}-`));
+    report = await exercise({ scratch, nikaBin: env.NIKA_BIN, env, start, run, signal: controller.signal });
+  } catch (error) { errors.push(error); }
+  finally {
+    let reaped = false;
+    try { await owned.close(); reaped = true; } catch (error) { errors.push(error); }
+    for (const handle of handles) {
+      if (handle.child.signalCode !== null) errors.push(new Error(`owned process ${handle.child.pid} required ${handle.child.signalCode}`));
+      try {
+        const result = await handle.done;
+        assert([0, 130].includes(result.code), `owned process ${handle.child.pid} exited ${result.code}`);
+      } catch (error) { errors.push(error); }
+    }
+    if (controller.signal.aborted) errors.push(controller.signal.reason);
+    // Keep the deadline/interrupt handler live until cleanup itself has ended.
+    clearTimeout(timer);
+    for (const [signal, handler] of handlers) process.off(signal, handler);
+    if (scratch && reaped) {
+      try { rmSync(scratch, { recursive: true, force: true }); } catch (error) { errors.push(error); }
+    } else if (scratch) process.stderr.write(`${name} cleanup retained scratch: ${scratch}\n`);
+  }
+  if (errors.length) {
+    const failure = new AggregateError(errors, errors.map(String).join('\n'));
+    writeReport({ ...report, schema_version: 1, result: 'red', error: String(failure) });
+    throw failure;
+  }
+  const evidence = { ...report, schema_version: 1, result: 'green' };
+  writeReport(evidence);
+  process.stdout.write(`${name} green after owned cleanup${resultsPath ? ` · ${resultsPath}` : ''}\n`);
+  return evidence;
+}
+
+export async function packSdk(root, scratch, run) {
+  await run('npm', ['run', 'build'], { cwd: root, timeoutMs: 60_000 });
+  const packed = JSON.parse(await run('npm', ['pack', '--ignore-scripts', '--json', '--pack-destination', scratch],
+    { cwd: root, timeoutMs: 30_000 }));
+  assert.equal(packed.length, 1);
+  const filename = packed[0].filename;
+  assert(typeof filename === 'string' && filename === path.basename(filename), 'npm pack must return one local filename');
+  return { filename, tarball: path.join(scratch, filename) };
+}
+
+export async function installProject(source, project, tarball, run) {
+  cpSync(source, project, { recursive: true });
+  const manifestPath = path.join(project, 'package.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.dependencies = { '@supernovae-st/nika-client': `file:${tarball}` };
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await run('npm', ['install', '--ignore-scripts', '--omit=optional', '--no-audit', '--no-fund'],
+    { cwd: project, timeoutMs: 60_000 });
+}

--- a/scripts/native-release-contract.mjs
+++ b/scripts/native-release-contract.mjs
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import { createReadStream } from 'node:fs';
-import { open, readFile } from 'node:fs/promises';
+import { lstat, open, readFile } from 'node:fs/promises';
+import path from 'node:path';
 
 const TARGETS = new Map([
   ['@supernovae-st/nika-darwin-arm64', {
@@ -133,6 +135,52 @@ export function checksumForAsset(contents, asset) {
     throw new Error(`Expected exactly one SHA256SUMS entry for ${asset}, found ${matches.length}`);
   }
   return matches[0];
+}
+
+// One archive admission for CI replay, type drift and native packaging. This
+// verifies provenance, not producer honesty; callers may extract only on success.
+export async function verifyEngineArchive(archive, sums, version, expectedCommit, run = execFileSync) {
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)
+    || (expectedCommit !== undefined && !isCommit(expectedCommit))) {
+    throw new Error('archive proof requires a stable version and an exact source commit');
+  }
+  const tag = `v${version}`;
+  const asset = path.basename(archive);
+  if (![...TARGETS.keys()].some((name) => nativeTarget(name, version).asset === asset)) {
+    throw new Error('archive name is not a native release target for this version');
+  }
+  const archiveStat = await lstat(archive);
+  const sumsStat = await lstat(sums);
+  if (!archiveStat.isFile() || archiveStat.size < 1 || archiveStat.size > 128 * 1024 * 1024
+    || !sumsStat.isFile() || sumsStat.size < 1 || sumsStat.size > 1024 * 1024) {
+    throw new Error('archive proof requires bounded regular archive and checksum files');
+  }
+  const indexed = checksumForAsset(await readFile(sums, 'utf8'), asset);
+  const sha256 = await sha256File(archive);
+  if (sha256 !== indexed) throw new Error(`archive digest mismatch for ${asset}`);
+  const invoke = (args) => run('gh', args, { encoding: 'utf8', timeout: 90_000,
+    killSignal: 'SIGKILL', maxBuffer: 4 * 1024 * 1024 });
+  const release = JSON.parse(invoke(['api', `repos/supernovae-st/nika/releases/tags/${tag}`]));
+  if (release.tag_name !== tag || release.draft !== false || release.prerelease !== false
+    || typeof release.published_at !== 'string' || !Number.isFinite(Date.parse(release.published_at))) {
+    throw new Error('archive proof requires the exact published stable release');
+  }
+  const assets = release.assets?.filter((entry) => entry.name === asset);
+  if (assets?.length !== 1 || assets[0].state !== 'uploaded' || assets[0].size !== archiveStat.size
+    || assets[0].browser_download_url !== `https://github.com/supernovae-st/nika/releases/download/${tag}/${asset}`) {
+    throw new Error('archive metadata is missing, ambiguous or differs from the downloaded file');
+  }
+  const { sha: commit } = JSON.parse(invoke(['api', `repos/supernovae-st/nika/commits/${tag}`]));
+  if (!isCommit(commit) || (expectedCommit !== undefined && commit !== expectedCommit)) {
+    throw new Error('released tag differs from the expected source commit');
+  }
+  invoke(['attestation', 'verify', path.resolve(archive),
+    '--repo', 'supernovae-st/nika', '--cert-identity',
+    `https://github.com/supernovae-st/nika/.github/workflows/release.yml@refs/tags/${tag}`,
+    '--source-ref', `refs/tags/${tag}`, '--source-digest', commit,
+    '--predicate-type', 'https://slsa.dev/provenance/v1', '--deny-self-hosted-runners']);
+  if (await sha256File(archive) !== sha256) throw new Error('archive changed during provenance verification');
+  return { tag, commit, asset, sha256 };
 }
 
 export function isSha256(value) {

--- a/scripts/npm-publication.mjs
+++ b/scripts/npm-publication.mjs
@@ -1,0 +1,132 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { lstat } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { nativeTarget } from './native-release-contract.mjs';
+
+const REGISTRY = 'https://registry.npmjs.org';
+const ARCHIVE_LIMIT = 256 * 1024 * 1024;
+
+function coordinate(name, version) {
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
+    throw new Error('invalid stable npm coordinate');
+  }
+  if (name !== '@supernovae-st/nika-client') {
+    try { nativeTarget(name, version); } catch { throw new Error('invalid npm package coordinate'); }
+  }
+  return `${REGISTRY}/${encodeURIComponent(name)}/${version}`;
+}
+
+async function response(url, fetch) {
+  return fetch(url, { redirect: 'error', signal: AbortSignal.timeout(30_000) });
+}
+
+async function consume(reply, limit, accept) {
+  if (Number(reply.headers.get('content-length')) > limit) {
+    await reply.body?.cancel();
+    throw new Error('npm response exceeds byte limit');
+  }
+  if (!reply.body) throw new Error('npm response has no body');
+  let bytes = 0;
+  for await (const chunk of reply.body) {
+    bytes += chunk.length;
+    if (bytes > limit) throw new Error('npm response exceeds byte limit');
+    accept(chunk);
+  }
+  return bytes;
+}
+
+async function published(name, version, fetch) {
+  const reply = await response(coordinate(name, version), fetch);
+  if (reply.status === 404) {
+    await reply.body?.cancel();
+    return null;
+  }
+  if (reply.status !== 200) {
+    await reply.body?.cancel();
+    throw new Error(`npm registry HTTP ${reply.status}; absence is not proven`);
+  }
+  const chunks = [];
+  await consume(reply, 1024 * 1024, (chunk) => chunks.push(chunk));
+  const value = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  if (value?.name !== name || value.version !== version) {
+    throw new Error('npm registry returned a different package identity');
+  }
+  return value;
+}
+
+export async function assertAbsent(name, version, fetch = globalThis.fetch) {
+  if (await published(name, version, fetch)) throw new Error(`${name}@${version} already exists publicly`);
+}
+
+async function localIntegrity(file) {
+  const info = await lstat(file);
+  if (!info.isFile() || info.size <= 0 || info.size > ARCHIVE_LIMIT) {
+    throw new Error('npm candidate must be a bounded nonempty regular file');
+  }
+  const hash = createHash('sha512');
+  let bytes = 0;
+  for await (const chunk of createReadStream(file)) {
+    bytes += chunk.length;
+    if (bytes > ARCHIVE_LIMIT) throw new Error('npm candidate exceeds byte limit');
+    hash.update(chunk);
+  }
+  if (bytes !== info.size) throw new Error('npm candidate changed during hashing');
+  return `sha512-${hash.digest('base64')}`;
+}
+
+async function verifyBytes(value, name, version, integrity, fetch) {
+  const leaf = name.split('/')[1];
+  const expectedUrl = `${REGISTRY}/${name}/-/${leaf}-${version}.tgz`;
+  if (value.dist?.integrity !== integrity || value.dist?.tarball !== expectedUrl) {
+    throw new Error('occupied npm version differs from prepared integrity or canonical URL');
+  }
+  const reply = await response(expectedUrl, fetch);
+  if (reply.status !== 200) {
+    await reply.body?.cancel();
+    throw new Error(`npm archive HTTP ${reply.status}`);
+  }
+  const hash = createHash('sha512');
+  await consume(reply, ARCHIVE_LIMIT, (chunk) => hash.update(chunk));
+  if (`sha512-${hash.digest('base64')}` !== integrity) {
+    throw new Error('actual public npm bytes differ from the prepared archive');
+  }
+}
+
+// The prepared artifact is already pack-inspected and platform-tested upstream.
+// This boundary proves immutable byte convergence, not cross-package atomicity
+// or provenance on replay. It never adopts a version merely because it exists.
+export async function publishExact(name, version, file, { fetch = globalThis.fetch, run = execFileSync } = {}) {
+  coordinate(name, version);
+  file = path.resolve(file);
+  const integrity = await localIntegrity(file);
+  let value = await published(name, version, fetch);
+  const didPublish = value === null;
+  if (didPublish) {
+    if (await localIntegrity(file) !== integrity) throw new Error('prepared npm bytes changed before publication');
+    await run('npm', ['publish', file, '--access', 'public', '--provenance', '--ignore-scripts', `--registry=${REGISTRY}`], {
+      stdio: 'inherit', timeout: 180_000, killSignal: 'SIGKILL',
+    });
+    value = await published(name, version, fetch);
+    if (value === null) throw new Error('published npm version is not observable');
+  }
+  await verifyBytes(value, name, version, integrity, fetch);
+  if (await localIntegrity(file) !== integrity) throw new Error('prepared npm bytes changed during publication');
+  return { published: didPublish, integrity };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    const [mode, name, version, file, ...extra] = process.argv.slice(2);
+    if (extra.length || (mode === 'assert-absent' ? file !== undefined : mode !== 'publish' || !file)) {
+      throw new Error('usage: npm-publication.mjs assert-absent <package> <version> | publish <package> <version> <archive>');
+    }
+    if (mode === 'assert-absent') await assertAbsent(name, version);
+    else console.log(JSON.stringify(await publishExact(name, version, file)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/one-door/cancellation.mjs
+++ b/scripts/one-door/cancellation.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+
+// One execution at a time, held by an actual loopback tool request rather
+// than stdout buffering or an estimated sleep. Deadlines FAIL the proof;
+// they never release the fixture to manufacture a preferred settlement.
+export class CancellationRendezvous {
+  #server;
+  #active;
+  url;
+
+  static async listen() {
+    const gate = new CancellationRendezvous();
+    gate.#server = createServer((request, response) => {
+      void gate.#route(request, response).catch((error) => {
+        response.writeHead(409).end(error.message);
+      });
+    });
+    gate.#server.listen(0, '127.0.0.1');
+    await once(gate.#server, 'listening');
+    gate.url = `http://127.0.0.1:${gate.#server.address().port}`;
+    return gate;
+  }
+
+  arm(label, timeoutMs = 10_000) {
+    assert(!this.#active, 'finish the previous rendezvous first');
+    const state = { label, token: randomUUID(), requests: { hold: 0, dependent: 0 }, released: false };
+    state.arrived = new Promise((resolve, reject) => { state.resolve = resolve; state.reject = reject; });
+    state.arrived.catch(() => {});
+    state.timer = setTimeout(() => {
+      state.error = new Error(`${label}: cancellation rendezvous deadline exceeded`);
+      state.reject(state.error);
+      state.response?.destroy(state.error);
+    }, timeoutMs);
+    this.#active = state;
+    return `${this.url}/control/${state.token}`;
+  }
+
+  get arrived() {
+    assert(this.#active, 'rendezvous is not armed');
+    return this.#active.arrived;
+  }
+
+  async release() {
+    const state = this.#active;
+    assert(state?.response && !state.released, 'exactly one held task required before release');
+    if (state.error) throw state.error;
+    state.released = true;
+    state.response.writeHead(200, { 'Content-Type': 'application/json' }).end('{"held":true}');
+  }
+
+  finish() {
+    const state = this.#active;
+    assert(state, 'rendezvous is not armed');
+    if (state.error) throw state.error;
+    assert(state.released, 'held task was not explicitly released');
+    assert.equal(state.requests.hold, 1, 'exactly one in-flight task');
+    assert.equal(state.requests.dependent, 0, 'dependent task must never execute');
+    clearTimeout(state.timer);
+    this.#active = undefined;
+    return { cancel_point: 'loopback fetch held before response', release: 'after cancellation request acknowledgement',
+      requests: { ...state.requests }, dependent_unstarted: true };
+  }
+
+  async #route(request, response) {
+    const state = this.#active;
+    assert(state, 'no active execution');
+    if (request.method === 'GET' && request.url === '/hold') {
+      assert.equal(++state.requests.hold, 1, 'duplicate hold request');
+      state.response = response;
+      state.resolve();
+      return;
+    }
+    if (request.method === 'GET' && request.url === '/dependent') {
+      state.requests.dependent++;
+      response.writeHead(200, { 'Content-Type': 'application/json' }).end('{"dependent":true}');
+      return;
+    }
+    const control = `/control/${state.token}`;
+    if (request.method === 'GET' && request.url === `${control}/arrived`) {
+      await state.arrived;
+      response.writeHead(200).end('{}');
+      return;
+    }
+    if (request.method === 'POST' && request.url === `${control}/release`) {
+      await this.release();
+      response.writeHead(200).end('{}');
+      return;
+    }
+    response.writeHead(404).end();
+  }
+
+  async close() {
+    if (this.#active) {
+      clearTimeout(this.#active.timer);
+      this.#active.reject(new Error('rendezvous closed'));
+      this.#active.response?.destroy();
+    }
+    this.#server.closeAllConnections();
+    await new Promise((resolve, reject) => this.#server.close((error) => error ? reject(error) : resolve()));
+  }
+}

--- a/scripts/one-door/consumer.mjs
+++ b/scripts/one-door/consumer.mjs
@@ -1,0 +1,115 @@
+// This file is COPIED into a fresh npm consumer before execution. The bare
+// import must resolve its public exports; importing a repository dist path
+// would conceal broken package metadata and is deliberately not supported.
+import { Nika } from '@supernovae-st/nika-client';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { compareResult, compareSameJobResult, compareControlledCancellation, identity, verdict } from './contract.mjs';
+
+const config = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+const installed = createRequire(import.meta.url)('@supernovae-st/nika-client/package.json');
+assert.equal(installed.version, config.version, 'installed SDK version');
+assert.equal(process.env.NIKA_BIN, undefined, 'consumer must not inherit NIKA_BIN');
+const remote = new Nika({ url: config.url, token: config.token, allowInsecureHttp: true,
+  cwd: config.consumer, bin: config.absentBinary });
+const client = config.door === 'sdk-native'
+  ? new Nika({ cwd: config.project, ...(config.publicVersion ? {} : { bin: config.binary }) })
+  : config.door === 'sdk-snapshot'
+    ? new Nika({ url: config.url, token: config.token, allowInsecureHttp: true,
+      cwd: config.project, bin: config.binary }) : remote;
+let active;
+// Do not exit on the supervisor's TERM: let the SDK reap its native child.
+// The owning supervisor supplies a bounded KILL fallback for stuck consumers.
+process.on('SIGTERM', () => {
+  process.exitCode = 1;
+  if (active) void client.cancel(active).catch(() => {});
+});
+
+async function execute(file, options, cancel = false) {
+  const source = config.door === 'sdk-name' ? file : `./${file}`;
+  active = await client.run(source, options);
+  const run = active;
+  const frames = [];
+  let acknowledgement;
+  let terminalObserved = false;
+  let acknowledgementBeforeTerminal;
+  const request = cancel ? (async () => {
+    const arrived = await fetch(`${config.cancellationControl}/arrived`, { signal: AbortSignal.timeout(10_000) });
+    assert(arrived.ok, 'controlled in-flight task reached rendezvous');
+    await arrived.text();
+    acknowledgement = structuredClone(await client.cancel(run));
+    acknowledgementBeforeTerminal = !terminalObserved;
+    assert.equal(acknowledgement.accepted, true, 'cancel action accepted');
+    assert.equal(acknowledgement.status, 'cancellation_requested', 'pending action acknowledgement');
+    assert(acknowledgementBeforeTerminal, 'pending acknowledgement precedes terminal observation');
+    const released = await fetch(`${config.cancellationControl}/release`,
+      { method: 'POST', signal: AbortSignal.timeout(3000) });
+    assert(released.ok, 'release the held task after cancellation request');
+    await released.text();
+  })() : undefined;
+  request?.catch(() => {});
+  for await (const frame of client.events(run)) {
+    // Keep the original observation even if later SDK processing mutates it.
+    frames.push(structuredClone(frame));
+    if (frame.kind === 'run_settled' || frame.kind === 'execution.settled'
+      || (frame.kind === 'execution.cancelled' && frame.settlement)) terminalObserved = true;
+  }
+  await request;
+  const result = structuredClone(await run.done);
+  active = undefined;
+  if (cancel) {
+    compareControlledCancellation(result);
+  }
+  assert(result.receipt, 'SDK receipt');
+  compareResult(result, config.expected, `${config.door}: ${file}`);
+  const terminal = frames.findLast((frame) => frame.kind === 'run_settled' || frame.kind === 'execution.settled'
+    || (cancel && frame.kind === 'execution.cancelled' && frame.settlement));
+  assert(terminal, 'engine terminal event must be observed independently of action acknowledgement');
+  compareResult(terminal, config.expected, `${config.door} terminal event: ${file}`);
+  compareSameJobResult(result, terminal, `${config.door} event/result: ${file}`);
+  assert.deepEqual(result.outputs, terminal.outputs, 'SDK result preserves its own transport output presence and values');
+  let attachedResult;
+  if (config.door !== 'sdk-native') {
+    const cursor = frames.at(-1)?.sequence;
+    assert(Number.isInteger(cursor), 'terminal event cursor');
+    const attached = await remote.attachRun(run.id, { lastEventId: cursor });
+    attachedResult = structuredClone(await attached.done);
+    compareResult(attachedResult, config.expected, `${config.door} terminal attach: ${file}`);
+    compareSameJobResult(attachedResult, result, `${config.door} terminal attach: ${file}`);
+    assert.deepEqual(attachedResult.outputs, result.outputs, 'terminal attach preserves output presence and values');
+  }
+  return { scenario: config.name, door: config.door, ...verdict(result), ...identity(result),
+    original_result: result, terminal_event: terminal,
+    terminal_attach_result: attachedResult,
+    acknowledgement, acknowledgement_before_terminal: acknowledgementBeforeTerminal,
+    engine_boot: frames.find((frame) => frame.kind === 'boot') ?? null,
+    terminal_cursor_attach: config.door !== 'sdk-native' };
+}
+
+let report;
+if (config.action === 'catalog') {
+  const names = await remote.listWorkflows();
+  for (const name of config.names) {
+    assert(names.includes(`${name}.nika.yaml`));
+    assert.equal((await remote.check(`${name}.nika.yaml`)).clean, true, `check by name: ${name}`);
+  }
+  report = { installed_package: { name: installed.name, version: installed.version }, names };
+} else if (config.action === 'replay') {
+  active = await remote.run('clean.nika.yaml', { idempotencyKey: 'world-replay' });
+  const original = active;
+  const result = structuredClone(await original.done);
+  compareResult(result, config.expected, 'original before registry mutation');
+  writeFileSync(`${config.project}/clean.nika.yaml`, 'not valid workflow yaml\n');
+  active = await remote.run('clean.nika.yaml', { idempotencyKey: 'world-replay' });
+  assert.equal(active.id, original.id);
+  const replayedResult = await active.done;
+  compareResult(replayedResult, config.expected, 'replay before recapture');
+  compareSameJobResult(replayedResult, result, 'replay before recapture');
+  report = { replay_before_capture: true, job_id: original.id, ...identity(result),
+    original_result: result, replayed_result: replayedResult, same_job_settlement_compared: true };
+  active = undefined;
+} else {
+  report = await execute(`${config.name}.nika.yaml`, undefined, config.name === 'cancelled');
+}
+console.log(JSON.stringify(report));

--- a/scripts/one-door/contract.mjs
+++ b/scripts/one-door/contract.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+
+export const fixtures = {
+  clean: `nika: m-clean
+permits: { tools: ["nika:jq"] }
+tasks:
+  a:
+    invoke: { tool: "nika:jq", args: { input: 1, expression: "." } }
+  b:
+    with: { prev: "${'${{ tasks.a.output }}'}" }
+    invoke: { tool: "nika:jq", args: { input: 2, expression: "." } }
+outputs: { answer: "${'${{ tasks.b.output }}'}" }
+`,
+  failed: `nika: m-fail
+permits: { fs: { read: ["./missing.md"] }, tools: ["nika:read"] }
+tasks:
+  a:
+    invoke: { tool: "nika:read", args: { path: "./missing.md" } }
+`,
+  recovered: `nika: m-recover
+permits: { fs: { read: ["./missing.md"] }, tools: ["nika:read"] }
+const: { fallback: "FALLBACK" }
+tasks:
+  a:
+    invoke: { tool: "nika:read", args: { path: "./missing.md" } }
+    on_error: { recover: "${'${{ const.fallback }}'}" }
+outputs: { answer: "${'${{ tasks.a.output }}'}" }
+`,
+  paused: `nika: m-gate
+permits: { tools: ["nika:prompt"] }
+tasks:
+  gate:
+    invoke: { tool: "nika:prompt", args: { message: "ship it?" } }
+`,
+};
+
+// Shape adapted from 05-fetch-chain and 02-parallel-fanout. The harness
+// supplies only its owned loopback listener; no user input or external host.
+export function cancellationFixture(url) {
+  assert.match(url, /^http:\/\/127\.0\.0\.1:\d+$/);
+  return `nika: m-cancel
+permits: { tools: ["nika:fetch"], net: { http: ["127.0.0.1"] } }
+tasks:
+  held:
+    invoke: { tool: "nika:fetch", args: { url: "${url}/hold", mode: jq, jq: "." } }
+  dependent:
+    after: { held: success }
+    invoke: { tool: "nika:fetch", args: { url: "${url}/dependent", mode: jq, jq: "." } }
+`;
+}
+
+export function compareControlledCancellation(result) {
+  const actual = verdict(result);
+  assert.equal(actual.status, 'cancelled', 'controlled cancellation must reach the runtime boundary');
+  assert.equal(actual.cause, 'operator');
+  assert.deepEqual(actual.tasks, { total: 2, ok: 1, failed: 0, recovered: 0, skipped: 0,
+    cancelled: 1, never_started: 1 }, 'completed in-flight task and unstarted dependent');
+  assert.deepEqual(actual.outputs, {});
+  assert.equal(actual.error_code, null);
+}
+
+// Compare independent executions using stable engine facts, including the
+// complete output map and failing task. Elapsed time, IDs, and prose can differ.
+export function settlementFacts(result) {
+  assert(result, 'missing terminal result');
+  const settlement = result.settlement ?? result;
+  assert.equal(typeof settlement.cause, 'string', 'missing settlement cause');
+  assert(settlement.tasks && settlement.spend, 'missing engine tally or spend');
+  const error = result.error ?? settlement.error;
+  return { status: result.status ?? settlement.status, cause: settlement.cause,
+    tasks: settlement.tasks, spend: settlement.spend,
+    error_code: error?.code ?? null, error_task: error?.task ?? null };
+}
+
+export function verdict(result) {
+  const facts = settlementFacts(result);
+  // Failed/paused/cancelled HTTP observations may omit the optional outputs
+  // field when no workflow outputs were evaluated. This means an empty set;
+  // a dropped nonempty map still differs from the CLI oracle on every door.
+  const outputs = result.outputs === undefined && facts.status !== 'succeeded' ? {} : result.outputs;
+  assert(outputs && typeof outputs === 'object' && !Array.isArray(outputs), 'missing workflow output map');
+  return { ...facts, outputs };
+}
+
+export function compareResult(result, expected, label) {
+  try { assert.deepEqual(verdict(result), expected, label); }
+  catch (error) {
+    throw new Error(`${label ?? 'result comparison'}: ${error.message}\nactual terminal: ${JSON.stringify(result)}`, { cause: error });
+  }
+}
+
+function presentFields(object, fields) {
+  return Object.fromEntries(fields.filter((key) => Object.hasOwn(object, key))
+    .map((key) => [key, object[key]]));
+}
+
+function exactObservation(observation) {
+  assert(observation, 'missing observation');
+  const nativeEvent = observation.kind === 'run_settled';
+  const httpEvent = observation.kind === 'execution.settled' || observation.kind === 'execution.cancelled';
+  // Native flattens known settlement fields among event metadata. Project only
+  // those fields, preserving absence; HTTP already supplies the full object,
+  // including any additive fields that the proof must not normalize away.
+  const settlement = nativeEvent
+    ? presentFields(observation, ['status', 'cause', 'elapsed_ms', 'tasks', 'spend', 'error'])
+    : observation.settlement;
+  assert(settlement && typeof settlement === 'object' && !Array.isArray(settlement), 'missing settlement object');
+  // An HTTP terminal event carries the authoritative diagnostic inside its
+  // settlement. SDK results expose it separately too: check that copy as well,
+  // without falling back to the nested error and concealing a dropped copy.
+  return { ...presentFields(observation, ['status']), settlement,
+    ...presentFields(httpEvent ? settlement : observation, ['error']) };
+}
+
+export function compareSameJobResult(result, original, label = 'same-job result comparison') {
+  try { assert.deepEqual(exactObservation(result), exactObservation(original)); }
+  catch (error) {
+    throw new Error(`${label} (same-job): ${error.message}`, { cause: error });
+  }
+}
+
+export function identity(result) {
+  return { execution_id: result.execution_id ?? result.receipt?.execution_id ?? null,
+    execution: result.execution ?? null, receipt: result.receipt ?? null,
+    outputs_field_present: Object.hasOwn(result, 'outputs') };
+}

--- a/scripts/one-door/process.mjs
+++ b/scripts/one-door/process.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+// Every child gets its own POSIX process group. Native engines launched by an
+// SDK consumer inherit that group, so cleanup never selects unrelated engines.
+export class OwnedProcesses {
+  #children = new Set();
+  #closing;
+
+  start(command, args, { timeoutMs, cwd, env, maxBuffer = 4 * 1024 * 1024,
+    graceMs = 1500, killMs = 3000, onStdout, onStderr } = {}) {
+    assert(process.platform !== 'win32', 'one-door process supervision requires POSIX process groups');
+    assert(Number.isFinite(timeoutMs) && timeoutMs > 0, 'every subprocess needs a finite timeout');
+    assert(!this.#closing, 'process supervisor is closing');
+    const child = spawn(command, args, { cwd, env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    let closed = false;
+    let spawnError;
+    let failure;
+    let stopping;
+    let timer;
+    let rejectFailure;
+    const closedResult = new Promise((resolve) => {
+      child.once('error', (error) => { spawnError = error; });
+      child.once('close', (code, signal) => { closed = true; resolve({ code, signal }); });
+    });
+    const alive = () => {
+      if (!child.pid) return false;
+      try { process.kill(-child.pid, 0); return true; }
+      catch (error) { if (error.code === 'ESRCH') return false; throw error; }
+    };
+    const signal = (value) => {
+      if (!child.pid) return false;
+      try { process.kill(-child.pid, value); return true; }
+      catch (error) { if (error.code === 'ESRCH') return false; throw error; }
+    };
+    const waitGone = async (milliseconds) => {
+      const until = performance.now() + milliseconds;
+      do {
+        if (closed && !alive()) return true;
+        await delay(20);
+      } while (performance.now() < until);
+      return closed && !alive();
+    };
+    const stop = () => {
+      stopping ??= (async () => {
+        signal('SIGTERM');
+        if (await waitGone(graceMs)) return;
+        signal('SIGKILL');
+        assert(await waitGone(killMs), `owned process group ${child.pid} did not exit; retain its scratch directory`);
+        await closedResult;
+      })();
+      return stopping;
+    };
+    const fail = (error) => {
+      if (failure) return;
+      failure = error;
+      // Keep rejection immediate and supervised even when callers are still
+      // waiting for server readiness rather than awaiting this handle's done.
+      stop().then(() => rejectFailure(error), rejectFailure);
+    };
+    const handle = { child, stdout: '', stderr: '', signal, stop, done: undefined };
+    const failed = new Promise((_, reject) => { rejectFailure = reject; });
+    for (const [name, callback] of [['stdout', onStdout], ['stderr', onStderr]]) {
+      child[name].setEncoding('utf8');
+      child[name].on('data', (chunk) => {
+        if (Buffer.byteLength(handle[name]) + Buffer.byteLength(chunk) > maxBuffer) {
+          fail(new Error(`${command}: ${name} exceeded ${maxBuffer} bytes`));
+          return;
+        }
+        handle[name] += chunk;
+        try { callback?.(chunk, handle); } catch (error) { fail(error); }
+      });
+    }
+    timer = setTimeout(() => fail(new Error(`${command} timed out after ${timeoutMs}ms`)), timeoutMs);
+    handle.done = Promise.race([closedResult, failed]).then(async (result) => {
+      if (stopping) await stopping;
+      if (failure) throw failure;
+      if (spawnError) throw spawnError;
+      if (alive()) {
+        await stop();
+        throw new Error(`${command} exited with live descendants`);
+      }
+      return { ...result, stdout: handle.stdout, stderr: handle.stderr };
+    }).finally(() => {
+      clearTimeout(timer);
+      if (closed && !alive()) this.#children.delete(handle);
+    });
+    handle.done.catch(() => {});
+    this.#children.add(handle);
+    return handle;
+  }
+
+  async run(command, args, options) {
+    return runOwnedProcess(this.start.bind(this), command, args, options);
+  }
+
+  close() {
+    this.#closing ??= (async () => {
+      const results = await Promise.allSettled([...this.#children].map(async (handle) => {
+        await handle.stop();
+        await handle.done.catch(() => {});
+      }));
+      const failures = results.filter((result) => result.status === 'rejected').map((result) => result.reason);
+      if (failures.length) throw new AggregateError(failures, 'owned process cleanup failed');
+    })();
+    return this.#closing;
+  }
+}
+
+// Native engines inherit their consumer's group; a zero code alone is not a
+// successful result if supervision also observed a signal or live descendants.
+export async function runOwnedProcess(start, command, args, options) {
+  const result = await start(command, args, options).done;
+  assert.equal(result.code, 0, `${command} failed (${result.code}, ${result.signal})\n${result.stdout}\n${result.stderr}`);
+  assert.equal(result.signal, null, `${command} exited via ${result.signal}`);
+  return result.stdout;
+}

--- a/scripts/one-door/resident.mjs
+++ b/scripts/one-door/resident.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { bounded } from '../gauntlet-cancellation.mjs';
+
+export async function stopResident(server, { timeoutMs = 5_000 } = {}) {
+  if (!server) return;
+  let result;
+  try {
+    // OwnedProcesses installed done/close at spawn time, before any signal.
+    server.signal('SIGINT');
+    result = await bounded(server.done, timeoutMs, 'server shutdown');
+  } finally {
+    // A deadline remains a failure even when TERM/KILL successfully reaps it.
+    await server.stop();
+    await server.done.catch(() => {});
+  }
+  assert.equal(result.signal, null, `server exited via ${result.signal}`);
+  assert([0, 130].includes(result.code), `server exited ${result.code}: ${result.stderr.slice(-500)}`);
+}
+
+export async function waitForHealth(url, server, signal,
+  { timeoutMs = 5_000, requestMs = 500, pollMs = 25 } = {}) {
+  const deadline = performance.now() + timeoutMs;
+  const exited = server.done.then(() => { throw new Error(`server exited before readiness: ${server.stderr ?? ''}`); });
+  exited.catch(() => {});
+  while (performance.now() < deadline) {
+    signal?.throwIfAborted();
+    assert(server.child.exitCode === null && server.child.signalCode === null, 'server exited before readiness');
+    const request = new AbortController();
+    const requestSignal = signal ? AbortSignal.any([signal, request.signal]) : request.signal;
+    const remaining = Math.max(1, Math.min(requestMs, deadline - performance.now()));
+    try {
+      const healthy = await bounded(Promise.race([exited, (async () => {
+        const response = await fetch(`${url}/health`, { signal: requestSignal });
+        await response.body?.cancel();
+        return response.ok;
+      })()]), remaining, 'server health request', signal);
+      signal?.throwIfAborted();
+      if (healthy) return;
+    } catch {
+      signal?.throwIfAborted();
+      // Retry startup connection errors and nonresponsive health requests,
+      // but only inside the overall readiness deadline.
+    } finally { request.abort(); }
+    await bounded(new Promise((resolve) => setTimeout(resolve, pollMs)), pollMs + 100, 'health retry', signal);
+  }
+  throw new Error(`server did not become healthy at ${url} within ${timeoutMs}ms`);
+}

--- a/scripts/run-depth-projects.mjs
+++ b/scripts/run-depth-projects.mjs
@@ -1,75 +1,148 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawnSync } from 'node:child_process';
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { OwnedProcesses } from './one-door/process.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const projectsRoot = path.join(root, 'gauntlet', 'projects-depth');
-const resultsRoot = process.env.NIKA_GAUNTLET_RESULTS_DIR
-  ? path.resolve(process.env.NIKA_GAUNTLET_RESULTS_DIR)
-  : projectsRoot;
-const resultsPath = path.join(
-  resultsRoot,
-  process.env.NIKA_GAUNTLET_RESULTS_DIR ? 'depth-projects.json' : 'results.json',
-);
-const scratch = mkdtempSync(path.join(tmpdir(), 'nika-depth-projects-'));
-const nikaBin = process.env.NIKA_BIN;
-assert(nikaBin, 'NIKA_BIN must name the engine binary under test');
+const sha256 = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const expected = ['deployment-gate', 'evidence-provenance-pipeline', 'incident-response-controller',
+  'multi-tenant-webhook-router', 'scheduled-research-monitor'];
 
-const expected = [
-  'deployment-gate',
-  'evidence-provenance-pipeline',
-  'incident-response-controller',
-  'multi-tenant-webhook-router',
-  'scheduled-research-monitor',
-];
-
-try {
-  mkdirSync(resultsRoot, { recursive: true });
-  execFileSync('npm', ['run', 'build'], { cwd: root, stdio: 'pipe' });
-  const packed = JSON.parse(execFileSync('npm', ['pack', '--ignore-scripts', '--json', '--pack-destination', scratch], { cwd: root, encoding: 'utf8' }));
-  const tarball = path.join(scratch, packed[0].filename);
-  const names = readdirSync(projectsRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
-  assert.deepEqual(names, expected);
-  const projects = [];
-
-  for (const name of names) {
-    const source = path.join(projectsRoot, name);
-    const project = path.join(scratch, name);
-    cpSync(source, project, { recursive: true });
-    const manifestPath = path.join(project, 'package.json');
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-    manifest.dependencies = { '@supernovae-st/nika-client': `file:${tarball}` };
-    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
-    execFileSync('npm', ['install', '--ignore-scripts', '--omit=optional', '--no-audit', '--no-fund'], { cwd: project, stdio: 'pipe' });
-    const run = spawnSync(process.execPath, ['app.mjs'], {
-      cwd: project,
-      env: { ...process.env, NIKA_BIN: nikaBin },
-      encoding: 'utf8',
-      timeout: 45_000,
-    });
-    if (run.error) throw run.error;
-    if (run.status !== 0) throw new Error(`${name} failed (${run.status})\n${run.stdout}\n${run.stderr}`);
-    const line = run.stdout.trim().split('\n').at(-1);
-    const result = JSON.parse(line);
-    assert.equal(result.project, name);
-    assert.equal(result.status, 'succeeded');
-    projects.push({ ...result, installed_from_pack: true });
-    process.stdout.write(`depth ${projects.length}/${expected.length} · ${name} · succeeded\n`);
-  }
-
-  const report = {
-    schema_version: 1,
-    engine: execFileSync(nikaBin, ['--version'], { encoding: 'utf8' }).trim(),
-    package: packed[0].filename,
-    install_mode: 'npm pack + isolated npm install --omit=optional + explicit NIKA_BIN',
-    projects,
-    summary: { total: projects.length, succeeded: projects.length, result: 'green' },
-  };
-  writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
-  process.stdout.write(`${projects.length}/${expected.length} packed depth projects green · ${resultsPath}\n`);
-} finally {
-  rmSync(scratch, { recursive: true, force: true });
+export function assertAppIdentity(source, project) {
+  const committed = readFileSync(path.join(source, 'app.mjs'));
+  const executed = readFileSync(path.join(project, 'app.mjs'));
+  assert(committed.equals(executed), 'executed app must be byte-identical to the committed project app');
+  return { source_sha256: sha256(committed), executed_sha256: sha256(executed), byte_identical: true };
 }
+
+export function stageDepthProject(source, project, tarball) {
+  cpSync(source, project, { recursive: true });
+  const manifestPath = path.join(project, 'package.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.dependencies = { '@supernovae-st/nika-client': `file:${tarball}` };
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return assertAppIdentity(source, project);
+}
+
+export async function executeProjectApp(source, project, nikaBin, start) {
+  const identity = assertAppIdentity(source, project);
+  const app = path.join(project, 'app.mjs');
+  const handle = start(process.execPath, [app], {
+    cwd: project, env: { ...process.env, NIKA_BIN: nikaBin },
+    timeoutMs: 100_000, maxBuffer: 1024 * 1024, graceMs: 12_000, killMs: 3_000,
+  });
+  const run = await handle.done;
+  assert.equal(run.code, 0, `${path.basename(project)} failed (${run.code}, ${run.signal})\n${run.stdout}\n${run.stderr}`);
+  assert.equal(run.signal, null);
+  assert.deepEqual(assertAppIdentity(source, project), identity, 'the app must not change during execution');
+  return { result: JSON.parse(run.stdout.trim().split('\n').at(-1)), identity };
+}
+
+export async function runDepthProjects() {
+  const projectsRoot = path.join(root, 'gauntlet', 'projects-depth');
+  const resultsRoot = process.env.NIKA_GAUNTLET_RESULTS_DIR ? path.resolve(process.env.NIKA_GAUNTLET_RESULTS_DIR) : projectsRoot;
+  const resultsPath = path.join(resultsRoot, process.env.NIKA_GAUNTLET_RESULTS_DIR ? 'depth-projects.json' : 'results.json');
+  mkdirSync(resultsRoot, { recursive: true });
+  // Invalidate a prior green before any probe/build: an interrupted invocation
+  // is not evidence that the previous measured result still describes this run.
+  writeFileSync(resultsPath, `${JSON.stringify({ schema_version: 1,
+    summary: { result: 'incomplete' }, pid: process.pid })}\n`);
+  const nikaBin = process.env.NIKA_BIN;
+  const scratch = mkdtempSync(path.join(tmpdir(), 'nika-depth-projects-'));
+  const owned = new OwnedProcesses();
+  const handles = [];
+  const start = (...args) => { const handle = owned.start(...args); handles.push(handle); return handle; };
+  const run = async (command, args, options) => {
+    const result = await start(command, args, { env: process.env, ...options }).done;
+    assert.equal(result.code, 0, `${command} failed (${result.code}, ${result.signal})\n${result.stdout}\n${result.stderr}`);
+    assert.equal(result.signal, null);
+    return result.stdout;
+  };
+  let stopped;
+  const stop = (reason) => { stopped ??= new Error(reason); void owned.close().catch(() => {}); };
+  const handlers = new Map(['SIGINT', 'SIGTERM', 'SIGHUP'].map((signal) => [signal, () => stop(`depth runner received ${signal}`)]));
+  for (const [signal, handler] of handlers) process.on(signal, handler);
+  const timer = setTimeout(() => stop('depth runner exceeded 300s'), 300_000);
+  let report;
+  let failure;
+  try {
+    assert(nikaBin && path.isAbsolute(nikaBin), 'NIKA_BIN must name an absolute engine binary under test');
+    await run('npm', ['run', 'build'], { cwd: root, timeoutMs: 60_000 });
+    const packed = JSON.parse(await run('npm', ['pack', '--ignore-scripts', '--json', '--pack-destination', scratch],
+      { cwd: root, timeoutMs: 30_000 }));
+    const tarball = path.join(scratch, packed[0].filename);
+    // Preserve the repository-relative imports in the committed app. Only
+    // shared harness helpers are copied; no SDK source or dist is staged.
+    mkdirSync(path.join(scratch, 'scripts', 'one-door'), { recursive: true });
+    cpSync(path.join(root, 'scripts', 'gauntlet-cancellation.mjs'), path.join(scratch, 'scripts', 'gauntlet-cancellation.mjs'));
+    for (const helper of ['cancellation.mjs', 'contract.mjs', 'process.mjs']) {
+      cpSync(path.join(root, 'scripts', 'one-door', helper), path.join(scratch, 'scripts', 'one-door', helper));
+    }
+    const names = readdirSync(projectsRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+    assert.deepEqual(names, expected);
+    const projects = [];
+    for (const name of names) {
+      const source = path.join(projectsRoot, name);
+      const project = path.join(scratch, 'gauntlet', 'projects-depth', name);
+      stageDepthProject(source, project, tarball);
+      await run('npm', ['install', '--ignore-scripts', '--omit=optional', '--no-audit', '--no-fund'],
+        { cwd: project, timeoutMs: 60_000 });
+      const { result, identity } = await executeProjectApp(source, project, nikaBin, start);
+      assert.equal(result.project, name);
+      assert.equal(result.status, 'succeeded');
+      if (name === 'incident-response-controller') {
+        assert.equal(result.executed_app_sha256, identity.executed_sha256, 'the running incident app must attest the same bytes');
+        if (process.env.NIKA_GAUNTLET_RESULTS_DIR) {
+          const audit = path.join(resultsRoot, 'incident-fixtures');
+          mkdirSync(audit, { recursive: true });
+          const provenance = [];
+          for (const [label, file] of [
+            ['committed-app.mjs', path.join(source, 'app.mjs')],
+            ['executed-app.mjs', path.join(project, 'app.mjs')],
+            ['workflow.nika.yaml', path.join(project, 'workflow.nika.yaml')],
+            ['controlled-cancel.nika.yaml', path.join(project, 'controlled-cancel.nika.yaml')],
+          ]) {
+            const bytes = readFileSync(file);
+            writeFileSync(path.join(audit, label), bytes);
+            provenance.push({ file: label, sha256: sha256(bytes) });
+          }
+          writeFileSync(path.join(audit, 'sha256.json'), `${JSON.stringify(provenance, null, 2)}\n`);
+        }
+      }
+      projects.push({ ...result, installed_from_pack: true, app_identity: identity });
+      process.stdout.write(`depth ${projects.length}/${expected.length} · ${name} · succeeded\n`);
+    }
+    report = { schema_version: 1,
+      engine: (await run(nikaBin, ['--version'], { timeoutMs: 5_000 })).trim(),
+      package: packed[0].filename, package_sha256: sha256(readFileSync(tarball)),
+      install_mode: 'npm pack + isolated npm install --omit=optional + explicit NIKA_BIN',
+      projects, summary: { total: projects.length, succeeded: projects.length, result: 'green' } };
+  } catch (error) {
+    failure = error;
+  } finally {
+    clearTimeout(timer);
+    const errors = [];
+    try { await owned.close(); } catch (error) { errors.push(error); }
+    for (const handle of handles) {
+      if (handle.child.signalCode === 'SIGKILL') errors.push(new Error(`owned process ${handle.child.pid} required SIGKILL`));
+    }
+    for (const [signal, handler] of handlers) process.off(signal, handler);
+    if (stopped) errors.push(stopped);
+    if (errors.length) failure = new AggregateError([...(failure ? [failure] : []), ...errors], 'depth proof or cleanup failed');
+    // Do not delete scratch if supervision cannot establish process exit.
+    if (!errors.length) rmSync(scratch, { recursive: true, force: true });
+  }
+  if (failure) {
+    writeFileSync(resultsPath, `${JSON.stringify({ ...report, schema_version: 1,
+      summary: { ...report?.summary, result: 'red' }, error: String(failure) }, null, 2)}\n`);
+    throw failure;
+  }
+  writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`${report.projects.length}/${expected.length} packed depth projects green · ${resultsPath}\n`);
+  return report;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(process.argv[1])) await runDepthProjects();

--- a/scripts/run-hostile-gauntlet.mjs
+++ b/scripts/run-hostile-gauntlet.mjs
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawn } from 'node:child_process';
 import {
   appendFileSync,
   chmodSync,
@@ -7,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -14,96 +14,61 @@ import { tmpdir } from 'node:os';
 import { createServer } from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { cancellationTerminalMatches } from './verify-release-replay.mjs';
+import { isDurableCancellationTerminal, cancellationTerminalMatches } from './verify-release-replay.mjs';
+import { CancellationRendezvous } from './one-door/cancellation.mjs';
+import { cancellationFixture, compareSameJobResult, settlementFacts } from './one-door/contract.mjs';
+import { bounded, cancelHeldRun, collectRunEvents } from './gauntlet-cancellation.mjs';
+import { OwnedProcesses, runOwnedProcess } from './one-door/process.mjs';
+import { stopResident, waitForHealth } from './one-door/resident.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const resultsRoot = process.env.NIKA_GAUNTLET_RESULTS_DIR
-  ? path.resolve(process.env.NIKA_GAUNTLET_RESULTS_DIR)
-  : path.join(root, 'gauntlet', 'results');
-const resultsPath = path.join(resultsRoot, 'hostile.json');
-const scratch = mkdtempSync(path.join(tmpdir(), 'nika-hostile-'));
-const nikaBin = process.env.NIKA_BIN;
-const rows = [];
-let realEngineRuns = 0;
-
-if (!nikaBin) throw new Error('NIKA_BIN must name the engine binary under test');
-
-execFileSync('npm', ['run', 'build'], { cwd: root, stdio: 'pipe' });
-const { Nika, NikaError } = await import('../dist/index.js');
-
-async function scenario(name, body) {
-  const started = performance.now();
+export async function observeHostileReplay(client, run, signal,
+  { timeoutMs = 5_000, cleanupMs = 2_000, ...limits } = {}) {
+  const observer = new AbortController();
+  const abort = () => observer.abort(signal.reason);
+  if (signal?.aborted) abort();
+  else signal?.addEventListener('abort', abort, { once: true });
+  const observation = collectRunEvents(client, run, observer.signal, limits);
+  observation.catch(() => {});
   try {
-    const evidence = await body();
-    rows.push({ name, result: 'green', duration_ms: Math.round(performance.now() - started), evidence });
-    process.stdout.write(`hostile ${rows.length}/14 · ${name} · green\n`);
-  } catch (cause) {
-    rows.push({
-      name,
-      result: 'red',
-      duration_ms: Math.round(performance.now() - started),
-      error: cause instanceof Error ? `${cause.name}: ${cause.message}` : String(cause),
+    const [replayed, events] = await bounded(Promise.all([run.done, observation]), timeoutMs,
+      'cancel replay settlement', signal);
+    return { replayed, events };
+  } finally {
+    signal?.removeEventListener('abort', abort);
+    observer.abort();
+    await bounded(observation.catch(() => {}), cleanupMs, 'replay observer cleanup');
+  }
+}
+
+async function exerciseScenarios({ scratch, nikaBin, scenario, start, signal }) {
+  const { Nika, NikaError } = await import('../dist/index.js');
+  let realEngineRuns = 0;
+  function writeWorkflow(name, source) {
+    const target = path.join(scratch, name);
+    writeFileSync(target, source);
+    return target;
+  }
+
+  function receiptPath(receipt) {
+    const locator = receipt.trace_path;
+    assert.equal(typeof locator, 'string');
+    return path.isAbsolute(locator) ? locator : path.join(scratch, locator);
+  }
+
+  async function freeLoopbackPort() {
+    const server = createServer();
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
     });
-    process.stdout.write(`hostile ${rows.length}/14 · ${name} · red\n`);
+    const address = server.address();
+    assert(address && typeof address === 'object');
+    await new Promise((resolve) => server.close(resolve));
+    return address.port;
   }
-}
 
-function writeWorkflow(name, source) {
-  const target = path.join(scratch, name);
-  writeFileSync(target, source);
-  return target;
-}
-
-function bounded(promise, milliseconds, label) {
-  let timer;
-  const deadline = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} exceeded ${milliseconds}ms`)), milliseconds);
-  });
-  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
-}
-
-function receiptPath(receipt) {
-  const locator = receipt.trace_path;
-  assert.equal(typeof locator, 'string');
-  return path.isAbsolute(locator) ? locator : path.join(scratch, locator);
-}
-
-async function freeLoopbackPort() {
-  const server = createServer();
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const address = server.address();
-  assert(address && typeof address === 'object');
-  await new Promise((resolve) => server.close(resolve));
-  return address.port;
-}
-
-async function waitForHealth(url) {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    try {
-      const response = await fetch(`${url}/health`);
-      if (response.ok) return;
-    } catch {
-      // The listener is still starting.
-    }
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-  throw new Error(`server did not become healthy at ${url}`);
-}
-
-// The durable status reads `queued` at admission and `running` once the resident
-// owns the execution; the first status that is not `queued` is returned.
-async function untilRunning(client, run) {
-  for (;;) {
-    const status = await client.status(run);
-    if (status !== 'queued') return status;
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-}
-
-const deterministic = writeWorkflow('deterministic.nika.yaml', `
+  const deterministic = writeWorkflow('deterministic.nika.yaml', `
 nika: hostile-deterministic
 permits:
   tools: ["nika:hash"]
@@ -116,13 +81,13 @@ outputs:
   digest: \${{ tasks.digest.output }}
 `);
 
-const malformed = writeWorkflow('malformed.nika.yaml', `
+  const malformed = writeWorkflow('malformed.nika.yaml', `
 nika: hostile-malformed
 tasks:
   broken: [this is not a task]
 `);
 
-const cancellable = writeWorkflow('cancellable.nika.yaml', `
+  const cancellable = writeWorkflow('wait-cancellable.nika.yaml', `
 nika: hostile-cancellable
 permits:
   tools: ["nika:wait"]
@@ -133,20 +98,20 @@ tasks:
       args: { duration: "10s" }
 `);
 
-const burstTasks = Array.from({ length: 12 }, (_, index) => `
+  const burstTasks = Array.from({ length: 12 }, (_, index) => `
   digest_${index}:
     invoke:
       tool: "nika:hash"
       args: { content: "${index}", algo: sha256, encoding: hex }`).join('');
-const burst = writeWorkflow('burst.nika.yaml', `
+  const burst = writeWorkflow('burst.nika.yaml', `
 nika: hostile-burst
 permits:
   tools: ["nika:hash"]
 tasks:${burstTasks}
 `);
 
-const canaryValue = 'NIKA_CANARY_8c8901a4_DO_NOT_LEAK';
-const canary = writeWorkflow('canary.nika.yaml', `
+  const canaryValue = 'NIKA_CANARY_8c8901a4_DO_NOT_LEAK';
+  const canary = writeWorkflow('canary.nika.yaml', `
 nika: hostile-canary
 secrets:
   canary:
@@ -161,8 +126,8 @@ tasks:
       args: { content: "public", algo: sha256, encoding: hex }
 `);
 
-const fakeBin = path.join(scratch, 'fake-nika.mjs');
-writeFileSync(fakeBin, `#!/usr/bin/env node
+  const fakeBin = path.join(scratch, 'fake-nika.mjs');
+  writeFileSync(fakeBin, `#!/usr/bin/env node
 const identity = {
   engineVersion: '0.115.0',
   machineProtocolVersion: 1,
@@ -182,327 +147,458 @@ if (process.argv.includes('--sdk-identity')) {
   else process.stdout.write(JSON.stringify({ report_version: 4, clean: true }));
 }
 `);
-chmodSync(fakeBin, 0o755);
+  chmodSync(fakeBin, 0o755);
 
-await scenario('unsafe-http-refusal', async () => {
-  assert.throws(
-    () => new Nika({ url: 'http://example.test', token: 'not-a-secret' }),
-    /allowInsecureHttp/,
-  );
-  return { refusal: 'NikaConfigurationError', network_requests: 0 };
-});
-
-await scenario('missing-engine-refusal', async () => {
-  const client = new Nika({ bin: path.join(scratch, 'does-not-exist') });
-  const error = await client.check(deterministic).then(
-    () => undefined,
-    (cause) => cause,
-  );
-  assert(error instanceof NikaError);
-  return { error: error.name, bounded: true };
-});
-
-await scenario('oversize-machine-line', async () => {
-  const workflow = writeWorkflow('oversize.nika.yaml', 'nika: fake');
-  const run = await new Nika({ bin: fakeBin, machineBufferBytes: 1024 }).run(workflow);
-  const error = await bounded(run.done, 2_000, 'oversize refusal').then(
-    () => undefined,
-    (cause) => cause,
-  );
-  assert.equal(error?.name, 'NikaProtocolError');
-  return { error: error.name, limit_bytes: 1024 };
-});
-
-await scenario('malformed-machine-frame', async () => {
-  const workflow = writeWorkflow('malformed-machine.nika.yaml', 'nika: fake');
-  const run = await new Nika({ bin: fakeBin }).run(workflow);
-  const error = await bounded(run.done, 2_000, 'malformed frame refusal').then(
-    () => undefined,
-    (cause) => cause,
-  );
-  assert.equal(error?.name, 'NikaProtocolError');
-  return { error: error.name };
-});
-
-await scenario('child-crash-settlement', async () => {
-  const workflow = writeWorkflow('crash.nika.yaml', 'nika: fake');
-  const run = await new Nika({ bin: fakeBin }).run(workflow);
-  const result = await bounded(run.done, 2_000, 'crash settlement');
-  assert.equal(result.status, 'failed');
-  assert.equal(result.exitCode, 23);
-  return { status: result.status, exit_code: result.exitCode };
-});
-
-await scenario('malformed-workflow-domain-report', async () => {
-  const report = await new Nika({ bin: nikaBin, cwd: scratch }).check(malformed);
-  assert.equal(report.clean, false);
-  assert.notEqual(report.exitCode, 0);
-  return { clean: report.clean, exit_code: report.exitCode };
-});
-
-await scenario('explicit-bin-empty-path', async () => {
-  const previous = process.env.PATH;
-  process.env.PATH = '';
-  try {
-    const client = new Nika({ bin: nikaBin, cwd: scratch });
-    const report = await client.check(deterministic, { nativeStrict: true });
-    const run = await client.run(deterministic, { maxCostUsd: 0 });
-    const result = await run.done;
-    assert.equal(report.clean, true);
-    assert.equal(result.status, 'succeeded');
-    realEngineRuns += 1;
-    return { check: 'clean', status: result.status };
-  } finally {
-    process.env.PATH = previous;
-  }
-});
-
-await scenario('parallel-run-load', async () => {
-  const client = new Nika({ bin: nikaBin, cwd: scratch });
-  const runs = await Promise.all(Array.from({ length: 24 }, () => client.run(deterministic, { maxCostUsd: 0 })));
-  const results = await bounded(Promise.all(runs.map((run) => run.done)), 20_000, 'parallel runs');
-  assert.equal(results.filter((result) => result.status === 'succeeded').length, 24);
-  assert.equal(new Set(results.map((result) => result.id)).size, 24);
-  realEngineRuns += results.filter((result) => result.status === 'succeeded').length;
-  return { runs: 24, succeeded: 24, unique_run_ids: 24 };
-});
-
-await scenario('real-cancellation-race', async () => {
-  const client = new Nika({ bin: nikaBin, cwd: scratch });
-  const run = await client.run(cancellable, { maxCostUsd: 0 });
-  let terminalBeforeRequest;
-  let terminalAt;
-  void run.done.then((result) => {
-    terminalBeforeRequest = result;
-    terminalAt = performance.now();
+  await scenario('unsafe-http-refusal', async () => {
+    assert.throws(
+      () => new Nika({ url: 'http://example.test', token: 'not-a-secret' }),
+      /allowInsecureHttp/,
+    );
+    return { refusal: 'NikaConfigurationError', network_requests: 0 };
   });
-  await new Promise((resolve) => setTimeout(resolve, 150));
-  const requestedAt = performance.now();
-  const first = client.cancel(run);
-  assert.equal(client.cancel(run), first);
-  // The native engine lets the in-flight `nika:wait` run out before it settles
-  // the cancelled run with `cause: operator` and exit 130 (measured on 0.118.7:
-  // ~10 s for this fixture), so the bound covers the whole wait.
-  const [cancelled, result] = await bounded(Promise.all([first, run.done]), 20_000, 'cancellation');
-  assert.equal(cancelled.accepted, true, JSON.stringify({
-    cancelled,
-    terminal_before_request: terminalAt !== undefined && terminalAt <= requestedAt,
-    terminal: terminalBeforeRequest,
-    result,
-  }));
-  assert.equal(cancelled.status, 'cancellation_requested', JSON.stringify(cancelled));
-  assert.equal(result.status, 'cancelled', JSON.stringify({ cancelled, result }));
-  assert.equal(result.settlement?.cause, 'operator', JSON.stringify(result.settlement ?? null));
-  realEngineRuns += 1;
-  return {
-    cancel_status: cancelled.status,
-    run_status: result.status,
-    exit_code: result.exitCode,
-    settlement_cause: result.settlement.cause,
-  };
-});
 
-await scenario('remote-durable-cancellation', async () => {
-  const remote = path.join(scratch, 'remote-cancel');
-  mkdirSync(remote);
-  writeFileSync(path.join(remote, 'nika.yaml'), 'nika: hostile-remote\n');
-  writeFileSync(path.join(remote, 'slow.nika.yaml'), readFileSync(cancellable, 'utf8'));
-  writeFileSync(path.join(remote, 'broken.nika.yaml'), readFileSync(malformed, 'utf8'));
-  const token = 'hostile-remote-token-0123456789abcdef0123456789';
-  const tokenFile = path.join(remote, 'serve.token');
-  writeFileSync(tokenFile, `${token}\n`);
-  chmodSync(tokenFile, 0o600);
-  const port = await freeLoopbackPort();
-  const url = `http://127.0.0.1:${port}`;
-  const server = spawn(nikaBin, [
-    'serve', '--bind', `127.0.0.1:${port}`, '--workflows', remote,
-    '--token-file', tokenFile, '--state-root', path.join(remote, 'state'), '--plain',
-  ], { cwd: remote, stdio: ['ignore', 'pipe', 'pipe'] });
-  let diagnostics = '';
-  server.stderr.setEncoding('utf8');
-  server.stderr.on('data', (chunk) => { diagnostics += chunk; });
-  try {
-    await waitForHealth(url);
-    const client = new Nika({
-      url,
-      token,
-      allowInsecureHttp: true,
-      bin: nikaBin,
-      cwd: remote,
+  await scenario('missing-engine-refusal', async () => {
+    const client = new Nika({ bin: path.join(scratch, 'does-not-exist') });
+    const error = await client.check(deterministic).then(
+      () => undefined,
+      (cause) => cause,
+    );
+    assert(error instanceof NikaError);
+    return { error: error.name, bounded: true };
+  });
+
+  await scenario('oversize-machine-line', async () => {
+    const workflow = writeWorkflow('oversize.nika.yaml', 'nika: fake');
+    const run = await new Nika({ bin: fakeBin, machineBufferBytes: 1024 }).run(workflow);
+    const error = await bounded(run.done, 2_000, 'oversize refusal').then(
+      () => undefined,
+      (cause) => cause,
+    );
+    assert.equal(error?.name, 'NikaProtocolError');
+    return { error: error.name, limit_bytes: 1024 };
+  });
+
+  await scenario('malformed-machine-frame', async () => {
+    const workflow = writeWorkflow('malformed-machine.nika.yaml', 'nika: fake');
+    const run = await new Nika({ bin: fakeBin }).run(workflow);
+    const error = await bounded(run.done, 2_000, 'malformed frame refusal').then(
+      () => undefined,
+      (cause) => cause,
+    );
+    assert.equal(error?.name, 'NikaProtocolError');
+    return { error: error.name };
+  });
+
+  await scenario('child-crash-settlement', async () => {
+    const workflow = writeWorkflow('crash.nika.yaml', 'nika: fake');
+    const run = await new Nika({ bin: fakeBin }).run(workflow);
+    const result = await bounded(run.done, 2_000, 'crash settlement');
+    assert.equal(result.status, 'failed');
+    assert.equal(result.exitCode, 23);
+    return { status: result.status, exit_code: result.exitCode };
+  });
+
+  await scenario('malformed-workflow-domain-report', async () => {
+    const report = await new Nika({ bin: nikaBin, cwd: scratch }).check(malformed);
+    assert.equal(report.clean, false);
+    assert.notEqual(report.exitCode, 0);
+    return { clean: report.clean, exit_code: report.exitCode };
+  });
+
+  await scenario('explicit-bin-empty-path', async () => {
+    const previous = process.env.PATH;
+    process.env.PATH = '';
+    try {
+      const client = new Nika({ bin: nikaBin, cwd: scratch });
+      const report = await client.check(deterministic, { nativeStrict: true });
+      const run = await client.run(deterministic, { maxCostUsd: 0 });
+      const result = await run.done;
+      assert.equal(report.clean, true);
+      assert.equal(result.status, 'succeeded');
+      realEngineRuns += 1;
+      return { check: 'clean', status: result.status };
+    } finally {
+      process.env.PATH = previous;
+    }
+  });
+
+  await scenario('parallel-run-load', async () => {
+    const client = new Nika({ bin: nikaBin, cwd: scratch });
+    const runs = await Promise.all(Array.from({ length: 24 }, () => client.run(deterministic, { maxCostUsd: 0 })));
+    const results = await bounded(Promise.all(runs.map((run) => run.done)), 20_000, 'parallel runs');
+    assert.equal(results.filter((result) => result.status === 'succeeded').length, 24);
+    assert.equal(new Set(results.map((result) => result.id)).size, 24);
+    realEngineRuns += results.filter((result) => result.status === 'succeeded').length;
+    return { runs: 24, succeeded: 24, unique_run_ids: 24 };
+  });
+
+  await scenario('real-cancellation-race', async () => {
+    const controlled = await (async () => {
+      const gate = await CancellationRendezvous.listen();
+      try {
+        const workflow = writeWorkflow('cancellable.nika.yaml', cancellationFixture(gate.url));
+        gate.arm('hostile native cancellation');
+        const client = new Nika({ bin: nikaBin, cwd: scratch });
+        const run = await client.run(workflow, { maxCostUsd: 0 });
+        const { cancellation, result, events, rendezvous } = await cancelHeldRun(client, run, gate);
+        realEngineRuns += 1;
+        return { cancel_status: cancellation.status, run_status: result.status, exit_code: result.exitCode,
+          settlement: settlementFacts(result), same_job_terminal_matched: true,
+          terminal: { kind: events.at(-1).kind, status: events.at(-1).status }, cancellation_rendezvous: rendezvous };
+      } finally {
+        await bounded(gate.close(), 2_000, 'native rendezvous cleanup');
+      }
+    })();
+    const client = new Nika({ bin: nikaBin, cwd: scratch });
+    const run = await client.run(cancellable, { maxCostUsd: 0 });
+    let terminalBeforeRequest;
+    let terminalAt;
+    void run.done.then((result) => {
+      terminalBeforeRequest = result;
+      terminalAt = performance.now();
     });
-    const parseFatal = await client.check('broken.nika.yaml');
-    assert.equal(parseFatal.clean, false);
-    assert.notEqual(parseFatal.exitCode, 0);
-    const run = await client.run('slow.nika.yaml', { idempotencyKey: 'hostile-cancel-1' });
-    // Cancel an execution that is observably inside its only task, the 10 s
-    // wait. On engine 0.118 a cancel that lands on a `running` job is a 202
-    // `cancellation_requested`; the execution owner then records
-    // `execution.interrupted` once its grace expires inside the task (~5 s,
-    // measured), or `cancelled` with `cause: operator` at a task boundary. A
-    // cancel that lands on `queued` is a 200 `cancelled` before execution.
-    // This fixture records the interrupted shape: it waits for `running`, then
-    // a further 250 ms, so the request lands inside the wait, never at its
-    // boundary and never before execution.
-    await bounded(untilRunning(client, run), 5_000, 'execution start');
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    const statusBeforeCancellation = await client.status(run);
-    assert.equal(statusBeforeCancellation, 'running');
-    const cancellation = await client.cancel(run);
-    const result = await bounded(run.done, 15_000, 'remote cancellation');
-    assert.equal(cancellation.accepted, true, JSON.stringify({
-      cancellation,
-      status_before_cancellation: statusBeforeCancellation,
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const requestedAt = performance.now();
+    const first = client.cancel(run);
+    assert.equal(client.cancel(run), first);
+    // The native engine lets the in-flight `nika:wait` run out before it settles
+    // the cancelled run with `cause: operator` and exit 130 (measured on 0.118.7:
+    // ~10 s for this fixture), so the bound covers the whole wait.
+    const [cancelled, result] = await bounded(Promise.all([first, run.done]), 20_000, 'cancellation');
+    assert.equal(cancelled.accepted, true, JSON.stringify({
+      cancelled,
+      terminal_before_request: terminalAt !== undefined && terminalAt <= requestedAt,
+      terminal: terminalBeforeRequest,
       result,
     }));
-    assert.equal(cancellation.status, 'cancellation_requested', JSON.stringify(cancellation));
-    assert.equal(result.status, 'interrupted', JSON.stringify({ cancellation, result }));
+    assert.equal(cancelled.status, 'cancellation_requested', JSON.stringify(cancelled));
+    assert.equal(result.status, 'cancelled', JSON.stringify({ cancelled, result }));
+    assert.equal(result.settlement?.cause, 'operator', JSON.stringify(result.settlement ?? null));
     realEngineRuns += 1;
-    assert(result.receipt);
-    const recovered = await client.attachRun(run.id);
-    const events = [];
-    for await (const event of client.events(recovered)) {
-      events.push({
-        kind: event.kind,
-        status: event.status,
-        ...(event.settlement ? { settlement_cause: event.settlement.cause } : {}),
-      });
-    }
-    await bounded(recovered.done, 5_000, 'cancel replay settlement');
-    // The durable replay ends on a terminal the cancel reply may lead to: after
-    // a 202 `cancellation_requested`, `execution.interrupted`/`interrupted`
-    // (grace expired inside a task, no settlement) or `execution.cancelled` /
-    // `execution.settled` with status `cancelled` and `cause: operator` (a task
-    // boundary); after a 200 `cancelled`, one of those two writer kinds with
-    // status `cancelled`. The verifier refuses every other pairing.
-    assert.equal(
-      cancellationTerminalMatches(cancellation.status, events.at(-1)),
-      true,
-      `cancel replay events: ${JSON.stringify(events)}`,
-    );
-    const trace = await client.traceVerify(result.receipt);
-    assert.equal(trace.verified, false);
-    assert.equal(trace.verdict, 'unavailable');
-    assert.equal(trace.reason, 'trace_journal_unavailable');
     return {
-      status_before_cancellation: statusBeforeCancellation,
-      cancel_status: cancellation.status,
+      cancel_status: cancelled.status,
       run_status: result.status,
-      events,
-      durable_receipt: true,
-      trace_verdict: trace.verdict,
-      parse_fatal_clean: parseFatal.clean,
+      exit_code: result.exitCode,
+      settlement_cause: result.settlement.cause,
+      controlled_cancellation: controlled,
     };
-  } finally {
-    server.kill('SIGINT');
-    await bounded(new Promise((resolve) => server.once('close', resolve)), 5_000, 'server shutdown')
-      .catch(() => server.kill('SIGTERM'));
-    if (server.exitCode && server.exitCode !== 130) {
-      throw new Error(`server exited ${server.exitCode}: ${diagnostics.slice(-500)}`);
-    }
-  }
-});
-
-await scenario('trace-corruption-detection', async () => {
-  const client = new Nika({ bin: nikaBin, cwd: scratch });
-  const run = await client.run(deterministic, { maxCostUsd: 0 });
-  const result = await run.done;
-  realEngineRuns += 1;
-  assert(result.receipt);
-  const intact = await client.traceVerify(result.receipt);
-  assert.equal(intact.verified, true);
-  const forged = await client.traceVerify({
-    ...result.receipt,
-    trace_id: 'forged-trace-id',
-    snapshot_digest: '0'.repeat(64),
-    chain_head: '0'.repeat(64),
-    chain_len: 999_999,
-    sealed: false,
   });
-  assert.equal(forged.verified, false);
-  const source = receiptPath(result.receipt);
-  const corrupted = path.join(scratch, 'corrupted-trace.ndjson');
-  copyFileSync(source, corrupted);
-  appendFileSync(corrupted, '{"tampered":true}\n');
-  const broken = await client.traceVerify({ ...result.receipt, trace_path: corrupted });
-  assert.equal(broken.verified, false);
-  return {
-    intact: intact.verified,
-    forged_receipt: forged.verified,
-    corrupted_trace: broken.verified,
-  };
-});
 
-await scenario('secret-canary-redaction', async () => {
-  const previous = process.env.NIKA_HOSTILE_SECRET_CANARY;
-  process.env.NIKA_HOSTILE_SECRET_CANARY = canaryValue;
-  try {
+  await scenario('remote-durable-cancellation', async () => {
+    const gate = await CancellationRendezvous.listen();
+    const remoteAbort = new AbortController();
+    const remoteSignal = signal ? AbortSignal.any([signal, remoteAbort.signal]) : remoteAbort.signal;
+    let server;
+    try {
+      const remote = path.join(scratch, 'remote-cancel');
+      mkdirSync(remote);
+      writeFileSync(path.join(remote, 'nika.yaml'), 'nika: hostile-remote\n');
+      writeFileSync(path.join(remote, 'slow.nika.yaml'), cancellationFixture(gate.url));
+      writeFileSync(path.join(remote, 'wait-cancel.nika.yaml'), readFileSync(cancellable));
+      writeFileSync(path.join(remote, 'broken.nika.yaml'), readFileSync(malformed, 'utf8'));
+      const token = 'hostile-remote-token-0123456789abcdef0123456789';
+      const tokenFile = path.join(remote, 'serve.token');
+      writeFileSync(tokenFile, `${token}\n`);
+      chmodSync(tokenFile, 0o600);
+      const port = await freeLoopbackPort();
+      const url = `http://127.0.0.1:${port}`;
+      server = start(nikaBin, [
+        'serve', '--bind', `127.0.0.1:${port}`, '--workflows', remote,
+        '--token-file', tokenFile, '--state-root', path.join(remote, 'state'), '--plain',
+      ], { cwd: remote, env: process.env, timeoutMs: 60_000, maxBuffer: 1024 * 1024 });
+      await waitForHealth(url, server, remoteSignal);
+      const client = new Nika({
+        url,
+        token,
+        allowInsecureHttp: true,
+        bin: nikaBin,
+        cwd: remote,
+        requestTimeout: 5_000,
+        fetch: (input, init) => fetch(input, { ...init,
+          signal: AbortSignal.any([remoteSignal, ...(init?.signal ? [init.signal] : [])]) }),
+      });
+      const parseFatal = await bounded(client.check('./broken.nika.yaml', { signal: remoteSignal }), 5_000, 'remote check', remoteSignal);
+      assert.equal(parseFatal.clean, false);
+      assert.notEqual(parseFatal.exitCode, 0);
+      gate.arm('hostile remote cancellation');
+      const run = await bounded(client.run('slow.nika.yaml', { idempotencyKey: 'hostile-cancel-1' }),
+        5_000, 'remote admission', remoteSignal);
+      const { cancellation, result, rendezvous } = await cancelHeldRun(client, run, gate, remoteSignal);
+      realEngineRuns += 1;
+      assert(result.receipt);
+      const recovered = await bounded(client.attachRun(run.id), 5_000, 'remote attach', remoteSignal);
+      const { replayed, events } = await observeHostileReplay(client, recovered, remoteSignal);
+      compareSameJobResult(replayed, result, 'hostile cancellation reattach');
+      compareSameJobResult(result, events.at(-1), 'hostile cancellation durable replay');
+      // The durable terminal must retain the engine's actual cancellation,
+      // including its cause, task tally, spend and additive settlement fields.
+      assert.equal(
+        isDurableCancellationTerminal(events.at(-1)),
+        true,
+        `cancel replay events: ${JSON.stringify(events)}`,
+      );
+      const trace = await bounded(client.traceVerify(result.receipt, { signal: remoteSignal }),
+        5_000, 'remote trace verification', remoteSignal);
+      assert.equal(trace.verified, false);
+      assert.equal(trace.verdict, 'unavailable');
+      assert.equal(trace.reason, 'trace_journal_unavailable');
+      const controlled = {
+        cancel_status: cancellation.status,
+        run_status: result.status,
+        settlement: settlementFacts(result),
+        same_job_terminal_and_replay_matched: true,
+        cancellation_rendezvous: rendezvous,
+        events: events.map(({ kind, status, settlement }) => ({ kind, status,
+          ...(settlement ? { settlement_cause: settlement.cause } : {}) })),
+        durable_receipt: true,
+        trace_verdict: trace.verdict,
+        parse_fatal_clean: parseFatal.clean,
+      };
+      // Preserve main's separate grace-expiry scenario: its actual interrupted
+      // observation is not replaced by the controlled task-boundary fixture.
+      const waitRun = await bounded(client.run('./wait-cancel.nika.yaml',
+        { idempotencyKey: 'hostile-wait-cancel-1' }), 5_000, 'wait admission', remoteSignal);
+      await bounded((async () => {
+        for (;;) {
+          remoteSignal.throwIfAborted();
+          if (await client.status(waitRun) !== 'queued') return;
+          await bounded(new Promise((resolve) => setTimeout(resolve, 10)), 100, 'status delay', remoteSignal);
+        }
+      })(), 5_000, 'wait execution start', remoteSignal);
+      await bounded(new Promise((resolve) => setTimeout(resolve, 250)), 1_000, 'in-task wait', remoteSignal);
+      const statusBeforeCancellation = await client.status(waitRun);
+      assert.equal(statusBeforeCancellation, 'running');
+      const waitCancellation = await bounded(client.cancel(waitRun), 5_000, 'wait cancellation action', remoteSignal);
+      assert.equal(waitCancellation.accepted, true);
+      assert.equal(waitCancellation.status, 'cancellation_requested');
+      const waitResult = await bounded(waitRun.done, 15_000, 'wait cancellation result', remoteSignal);
+      assert.equal(waitResult.status, 'interrupted');
+      assert(waitResult.receipt);
+      realEngineRuns += 1;
+      const waitReplay = await bounded(client.attachRun(waitRun.id), 5_000, 'wait reattach', remoteSignal);
+      const { replayed: waitReplayed, events: waitEvents } = await observeHostileReplay(client, waitReplay, remoteSignal);
+      assert.equal(waitReplayed.status, waitResult.status);
+      const waitTerminal = waitEvents.at(-1);
+      assert.equal(waitTerminal?.kind, 'execution.interrupted');
+      assert.equal(waitTerminal?.status, waitResult.status);
+      assert.equal(cancellationTerminalMatches(waitCancellation.status, waitTerminal), true);
+      const waitTrace = await bounded(client.traceVerify(waitResult.receipt, { signal: remoteSignal }),
+        5_000, 'wait receipt verdict', remoteSignal);
+      assert.equal(waitTrace.verified, false);
+      assert.equal(waitTrace.verdict, 'unavailable');
+      assert.equal(waitTrace.reason, 'trace_journal_unavailable');
+      return {
+        status_before_cancellation: statusBeforeCancellation,
+        cancel_status: waitCancellation.status, run_status: waitResult.status,
+        events: waitEvents.map(({ kind, status, settlement }) => ({ kind, status,
+          ...(settlement ? { settlement_cause: settlement.cause } : {}) })),
+        durable_receipt: true, trace_verdict: waitTrace.verdict, parse_fatal_clean: parseFatal.clean,
+        controlled_cancellation: controlled,
+      };
+    } finally {
+      remoteAbort.abort();
+      try { await bounded(gate.close(), 2_000, 'remote rendezvous cleanup'); }
+      finally { await stopResident(server); }
+    }
+  });
+
+  await scenario('trace-corruption-detection', async () => {
     const client = new Nika({ bin: nikaBin, cwd: scratch });
-    const run = await client.run(canary, { maxCostUsd: 0 });
-    const result = await run.done;
-    assert.equal(result.status, 'succeeded');
-    realEngineRuns += 1;
-    assert(!JSON.stringify(result).includes(canaryValue));
-    assert(result.receipt);
-    const tracePath = receiptPath(result.receipt);
-    assert(!readFileSync(tracePath, 'utf8').includes(canaryValue));
-    return { result_redacted: true, trace_redacted: true };
-  } finally {
-    if (previous === undefined) delete process.env.NIKA_HOSTILE_SECRET_CANARY;
-    else process.env.NIKA_HOSTILE_SECRET_CANARY = previous;
-  }
-});
-
-await scenario('slow-subscriber-overflow-isolation', async () => {
-  const client = new Nika({ bin: nikaBin, cwd: scratch, eventBufferSize: 4 });
-  const run = await client.run(burst, { maxCostUsd: 0 });
-  const iterator = client.events(run, { bufferSize: 2 })[Symbol.asyncIterator]();
-  const result = await run.done;
-  assert.equal(result.status, 'succeeded');
-  realEngineRuns += 1;
-  const error = await iterator.next().then(
-    () => undefined,
-    (cause) => cause,
-  );
-  assert.equal(error?.name, 'NikaEventBufferOverflowError');
-  return { run_status: result.status, subscriber_error: error.name, subscriber_limit: 2 };
-});
-
-await scenario('sequential-soak', async () => {
-  const client = new Nika({ bin: nikaBin, cwd: scratch });
-  let succeeded = 0;
-  for (let index = 0; index < 40; index += 1) {
     const run = await client.run(deterministic, { maxCostUsd: 0 });
     const result = await run.done;
-    assert.equal(result.status, 'succeeded');
-    succeeded += 1;
     realEngineRuns += 1;
-  }
-  return { runs: succeeded, succeeded };
-});
+    assert(result.receipt);
+    const intact = await client.traceVerify(result.receipt);
+    assert.equal(intact.verified, true);
+    const forged = await client.traceVerify({
+      ...result.receipt,
+      trace_id: 'forged-trace-id',
+      snapshot_digest: '0'.repeat(64),
+      chain_head: '0'.repeat(64),
+      chain_len: 999_999,
+      sealed: false,
+    });
+    assert.equal(forged.verified, false);
+    const source = receiptPath(result.receipt);
+    const corrupted = path.join(scratch, 'corrupted-trace.ndjson');
+    copyFileSync(source, corrupted);
+    appendFileSync(corrupted, '{"tampered":true}\n');
+    const broken = await client.traceVerify({ ...result.receipt, trace_path: corrupted });
+    assert.equal(broken.verified, false);
+    return {
+      intact: intact.verified,
+      forged_receipt: forged.verified,
+      corrupted_trace: broken.verified,
+    };
+  });
 
-const report = {
-  schema_version: 1,
-  generated_at: new Date().toISOString(),
-  engine: execFileSync(nikaBin, ['--version'], { encoding: 'utf8' }).trim(),
-  scenarios: rows,
-  summary: {
-    total: rows.length,
-    green: rows.filter((row) => row.result === 'green').length,
-    red: rows.filter((row) => row.result === 'red').length,
-    real_engine_runs: realEngineRuns,
-  },
-  result: rows.every((row) => row.result === 'green') ? 'green' : 'red',
-};
-mkdirSync(resultsRoot, { recursive: true });
-writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
-rmSync(scratch, { recursive: true, force: true });
+  await scenario('secret-canary-redaction', async () => {
+    const previous = process.env.NIKA_HOSTILE_SECRET_CANARY;
+    process.env.NIKA_HOSTILE_SECRET_CANARY = canaryValue;
+    try {
+      const client = new Nika({ bin: nikaBin, cwd: scratch });
+      const run = await client.run(canary, { maxCostUsd: 0 });
+      const result = await run.done;
+      assert.equal(result.status, 'succeeded');
+      realEngineRuns += 1;
+      assert(!JSON.stringify(result).includes(canaryValue));
+      assert(result.receipt);
+      const tracePath = receiptPath(result.receipt);
+      assert(!readFileSync(tracePath, 'utf8').includes(canaryValue));
+      return { result_redacted: true, trace_redacted: true };
+    } finally {
+      if (previous === undefined) delete process.env.NIKA_HOSTILE_SECRET_CANARY;
+      else process.env.NIKA_HOSTILE_SECRET_CANARY = previous;
+    }
+  });
 
-if (report.result !== 'green') {
-  for (const row of rows.filter((entry) => entry.result === 'red')) {
-    process.stderr.write(`${row.name} · ${row.error}\n`);
+  await scenario('slow-subscriber-overflow-isolation', async () => {
+    const client = new Nika({ bin: nikaBin, cwd: scratch, eventBufferSize: 4 });
+    const run = await client.run(burst, { maxCostUsd: 0 });
+    const observer = new AbortController();
+    let iterator;
+    try {
+      iterator = client.events(run, { bufferSize: 2, signal: observer.signal })[Symbol.asyncIterator]();
+      const result = await run.done;
+      assert.equal(result.status, 'succeeded');
+      realEngineRuns += 1;
+      const error = await iterator.next().then(
+        () => undefined,
+        (cause) => cause,
+      );
+      assert.equal(error?.name, 'NikaEventBufferOverflowError');
+      return { run_status: result.status, subscriber_error: error.name, subscriber_limit: 2 };
+    } finally {
+      observer.abort();
+      await bounded(Promise.resolve(iterator?.return?.()), 2_000, 'slow subscriber cleanup');
+    }
+  });
+
+  await scenario('sequential-soak', async () => {
+    const client = new Nika({ bin: nikaBin, cwd: scratch });
+    let succeeded = 0;
+    for (let index = 0; index < 40; index += 1) {
+      const run = await client.run(deterministic, { maxCostUsd: 0 });
+      const result = await run.done;
+      assert.equal(result.status, 'succeeded');
+      succeeded += 1;
+      realEngineRuns += 1;
+    }
+    return { runs: succeeded, succeeded };
+  });
+
+  return realEngineRuns;
+}
+
+export async function runHostileGauntlet() {
+  const resultsRoot = process.env.NIKA_GAUNTLET_RESULTS_DIR
+    ? path.resolve(process.env.NIKA_GAUNTLET_RESULTS_DIR) : path.join(root, 'gauntlet', 'results');
+  const resultsPath = path.join(resultsRoot, 'hostile.json');
+  mkdirSync(resultsRoot, { recursive: true });
+  // An interrupted invocation must not leave a previous green authoritative.
+  writeFileSync(resultsPath, `${JSON.stringify({ result: 'incomplete', pid: process.pid })}\n`);
+  const nikaBin = process.env.NIKA_BIN;
+  assert(nikaBin && path.isAbsolute(nikaBin), 'NIKA_BIN must name an absolute engine binary under test');
+  const scratch = mkdtempSync(path.join(tmpdir(), 'nika-hostile-'));
+  const owned = new OwnedProcesses();
+  const handles = [];
+  const abort = new AbortController();
+  const start = (...args) => {
+    abort.signal.throwIfAborted();
+    const handle = owned.start(...args);
+    handles.push(handle);
+    return handle;
+  };
+  const stop = (reason) => { abort.abort(new Error(reason)); void owned.close().catch(() => {}); };
+  const handlers = new Map(['SIGINT', 'SIGTERM', 'SIGHUP'].map((signal) => [signal, () => stop(`hostile runner received ${signal}`)]));
+  for (const [signal, handler] of handlers) process.on(signal, handler);
+  const deadline = setTimeout(() => stop('hostile runner exceeded 180s'), 180_000);
+  const rows = [];
+  let realEngineRuns = 0;
+  let engine;
+  let failure;
+  try {
+    await runOwnedProcess(start, 'npm', ['run', 'build'], { cwd: root, env: process.env, timeoutMs: 60_000 });
+    engine = (await runOwnedProcess(start, nikaBin, ['--version'], { timeoutMs: 5_000 })).trim();
+    const directRuns = await exerciseScenarios({ scratch, nikaBin, start, signal: abort.signal,
+      scenario: async (name, body) => {
+        const started = performance.now();
+        try {
+          abort.signal.throwIfAborted();
+          let evidence;
+          if (name === 'remote-durable-cancellation') evidence = await body();
+          else {
+            const output = await runOwnedProcess(start, process.execPath,
+              [fileURLToPath(import.meta.url), '--native-scenario', name, scratch],
+              { cwd: root, env: process.env, timeoutMs: name === 'sequential-soak' ? 120_000 : 60_000,
+                maxBuffer: 1024 * 1024 });
+            const result = JSON.parse(output);
+            assert.equal(result.name, name);
+            realEngineRuns += result.realEngineRuns;
+            if (result.error) throw new Error(result.error);
+            evidence = result.evidence;
+          }
+          rows.push({ name, result: 'green', duration_ms: Math.round(performance.now() - started), evidence });
+        } catch (cause) {
+          rows.push({ name, result: 'red', duration_ms: Math.round(performance.now() - started),
+            error: cause instanceof Error ? `${cause.name}: ${cause.message}` : String(cause) });
+        }
+        process.stdout.write(`hostile ${rows.length}/14 · ${name} · ${rows.at(-1).result}\n`);
+      },
+    });
+    realEngineRuns += directRuns;
+  } catch (error) { failure = error; }
+  finally {
+    clearTimeout(deadline);
+    const errors = [];
+    try { await owned.close(); } catch (error) { errors.push(error); }
+    for (const handle of handles) {
+      if (handle.child.signalCode === 'SIGKILL') errors.push(new Error(`owned process ${handle.child.pid} required SIGKILL`));
+    }
+    for (const [signal, handler] of handlers) process.off(signal, handler);
+    if (abort.signal.aborted) errors.push(abort.signal.reason);
+    if (errors.length) failure = new AggregateError([...(failure ? [failure] : []), ...errors],
+      `hostile proof or cleanup failed: ${errors.map((error) => error.message).join('; ')}`);
+    // Retain scratch if cleanup could not establish bounded, unforced exit.
+    if (!errors.length) rmSync(scratch, { recursive: true, force: true });
+    else process.stderr.write(`hostile cleanup retained scratch: ${scratch}\n`);
   }
-  process.stderr.write(`${report.summary.red}/${report.summary.total} hostile scenarios red · ${resultsPath}\n`);
-  process.exitCode = 1;
-} else {
-  process.stdout.write(`${report.summary.green}/${report.summary.total} hostile scenarios green · ${resultsPath}\n`);
+  const report = {
+    schema_version: 1, generated_at: new Date().toISOString(), engine, scenarios: rows,
+    summary: { total: rows.length, green: rows.filter((row) => row.result === 'green').length,
+      red: rows.filter((row) => row.result === 'red').length, real_engine_runs: realEngineRuns },
+    ...(failure ? { supervision_error: String(failure) } : {}),
+    result: !failure && rows.length === 14 && rows.every((row) => row.result === 'green') ? 'green' : 'red',
+  };
+  writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
+  if (report.result !== 'green') {
+    for (const row of rows.filter((entry) => entry.result === 'red')) process.stderr.write(`${row.name} · ${row.error}\n`);
+    if (failure) process.stderr.write(`${failure}\n`);
+    process.stderr.write(`hostile proof red · ${resultsPath}\n`);
+    process.exitCode = 1;
+  } else process.stdout.write(`${report.summary.green}/${report.summary.total} hostile scenarios green · ${resultsPath}\n`);
+  return report;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(process.argv[1])) {
+  if (process.argv[2] === '--native-scenario') {
+    const name = process.argv[3];
+    assert(name !== 'remote-durable-cancellation', 'resident must stay directly owned by the parent supervisor');
+    let evidence;
+    let error;
+    let matched = false;
+    const realEngineRuns = await exerciseScenarios({ scratch: process.argv[4], nikaBin: process.env.NIKA_BIN,
+      scenario: async (candidate, body) => {
+        if (candidate === name) {
+          matched = true;
+          try { evidence = await body(); }
+          catch (cause) { error = cause instanceof Error ? `${cause.name}: ${cause.message}` : String(cause); }
+        }
+      },
+    });
+    assert(matched, `unknown hostile scenario: ${name}`);
+    // Even a failed assertion must retain the count of actual engine runs.
+    // The parent rejects error before it can record this scenario as green.
+    process.stdout.write(`${JSON.stringify({ name, evidence, error, realEngineRuns })}\n`);
+  } else await runHostileGauntlet();
 }

--- a/scripts/run-mini-saas-gauntlet.mjs
+++ b/scripts/run-mini-saas-gauntlet.mjs
@@ -1,73 +1,34 @@
-import { execFileSync, spawnSync } from 'node:child_process';
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import assert from 'node:assert/strict';
+import { readdirSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { installProject, supervisedGauntlet, packSdk } from './gauntlet.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const projectsRoot = path.join(root, 'gauntlet', 'projects');
-const resultsRoot = process.env.NIKA_GAUNTLET_RESULTS_DIR
-  ? path.resolve(process.env.NIKA_GAUNTLET_RESULTS_DIR)
-  : path.join(root, 'gauntlet', 'results');
-const resultsPath = path.join(resultsRoot, 'mini-saas.json');
-const scratch = mkdtempSync(path.join(tmpdir(), 'nika-mini-saas-'));
-const nikaBin = process.env.NIKA_BIN;
 
-if (!nikaBin) throw new Error('NIKA_BIN must name the engine binary under test');
-
-try {
-  mkdirSync(resultsRoot, { recursive: true });
-  execFileSync('npm', ['run', 'build'], { cwd: root, stdio: 'pipe' });
-  const packed = JSON.parse(execFileSync(
-    'npm',
-    ['pack', '--ignore-scripts', '--json', '--pack-destination', scratch],
-    { cwd: root, encoding: 'utf8' },
-  ));
-  const tarball = path.join(scratch, packed[0].filename);
-  const rows = [];
-
-  for (const name of readdirSync(projectsRoot).sort()) {
-    const source = path.join(projectsRoot, name);
-    const project = path.join(scratch, name);
-    cpSync(source, project, { recursive: true });
-    const manifestPath = path.join(project, 'package.json');
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-    manifest.dependencies = { '@supernovae-st/nika-client': `file:${tarball}` };
-    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
-    execFileSync(
-      'npm',
-      ['install', '--ignore-scripts', '--omit=optional', '--no-audit', '--no-fund'],
-      { cwd: project, stdio: 'pipe' },
-    );
-    const run = spawnSync(process.execPath, ['app.mjs'], {
-      cwd: project,
-      env: { ...process.env, NIKA_BIN: nikaBin },
-      encoding: 'utf8',
-      timeout: 30_000,
-    });
-    if (run.status !== 0) {
-      throw new Error(`${name} failed (${run.status})\n${run.stdout}\n${run.stderr}`);
+export async function runMiniSaasGauntlet() {
+  return supervisedGauntlet({ name: 'mini-saas', root }, async ({ scratch, nikaBin, run }) => {
+    const { filename, tarball } = await packSdk(root, scratch, run);
+    const projectsRoot = path.join(root, 'gauntlet', 'projects');
+    const rows = [];
+    for (const name of readdirSync(projectsRoot).sort()) {
+      const project = path.join(scratch, name);
+      await installProject(path.join(projectsRoot, name), project, tarball, run);
+      const stdout = await run(process.execPath, ['app.mjs'], { cwd: project, timeoutMs: 30_000 });
+      const result = JSON.parse(stdout.trim().split('\n').at(-1));
+      assert.equal(result.project, name);
+      assert.equal(result.status, 'succeeded');
+      rows.push({ name, ...result, installed_from_pack: true });
+      process.stdout.write(`mini-saas ${rows.length}/5 · ${name} · ${result.status}\n`);
     }
-    const lines = run.stdout.trim().split('\n');
-    const result = JSON.parse(lines.at(-1));
-    if (result.project !== name || result.status !== 'succeeded') {
-      throw new Error(`${name} returned an invalid settlement: ${lines.at(-1)}`);
-    }
-    rows.push({ name, ...result, installed_from_pack: true });
-    process.stdout.write(`mini-saas ${rows.length}/5 · ${name} · ${result.status}\n`);
-  }
-
-  if (rows.length !== 5) throw new Error(`expected 5 mini-SaaS projects, received ${rows.length}`);
-  const report = {
-    schema_version: 1,
-    engine: execFileSync(nikaBin, ['--version'], { encoding: 'utf8' }).trim(),
-    package: packed[0].filename,
-    install_mode: 'npm pack + npm install --omit=optional + explicit NIKA_BIN',
-    projects: rows,
-    result: 'green',
-  };
-  writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
-  process.stdout.write(`5/5 packed mini-SaaS projects green · ${resultsPath}\n`);
-} finally {
-  rmSync(scratch, { recursive: true, force: true });
+    assert.equal(rows.length, 5, 'expected 5 mini-SaaS projects');
+    return {
+      engine: (await run(nikaBin, ['--version'], { timeoutMs: 5_000 })).trim(),
+      package: filename,
+      install_mode: 'npm pack + npm install --omit=optional + explicit NIKA_BIN',
+      projects: rows,
+    };
+  });
 }
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(process.argv[1])) await runMiniSaasGauntlet();

--- a/scripts/run-one-door-e2e.mjs
+++ b/scripts/run-one-door-e2e.mjs
@@ -1,0 +1,360 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { copyFileSync, createReadStream, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { OwnedProcesses } from './one-door/process.mjs';
+import { stopResident } from './one-door/resident.mjs';
+import { CancellationRendezvous } from './one-door/cancellation.mjs';
+import { compareResult, compareSameJobResult, compareControlledCancellation, cancellationFixture, fixtures, identity, settlementFacts, verdict } from './one-door/contract.mjs';
+
+// Public npm mode installs its native payload and resolves the package's bare
+// export inside a fresh consumer. Artifact provenance is an OUTER gate, not a
+// conclusion obtainable from this runtime parity exercise.
+const root = path.resolve(import.meta.dirname, '..');
+const reportPath = process.env.NIKA_ONE_DOOR_REPORT;
+// Invalidate a prior green before validation or installation can fail.
+if (reportPath) writeFileSync(reportPath, `${JSON.stringify({ result: 'incomplete', pid: process.pid })}\n`);
+const binary = process.env.NIKA_BIN;
+assert(binary && path.isAbsolute(binary), 'NIKA_BIN must be an absolute CLI/resident engine path');
+const version = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8')).version;
+const publicVersion = process.env.NIKA_PUBLIC_SDK_VERSION;
+const scratch = mkdtempSync(path.join(tmpdir(), 'nika-one-door-e2e-'));
+const project = path.join(scratch, 'project');
+const consumer = path.join(scratch, 'consumer');
+const absentBinary = path.join(scratch, 'deliberately-absent-nika');
+const token = 'one-door-public-contract-test-token-0123456789';
+// No inherited provider credentials, proxy configuration, engine config,
+// or signing keys. Public npm mode needs no login either.
+const env = { ...Object.fromEntries(['PATH', 'TMPDIR', 'TMP', 'TEMP', 'LANG', 'LC_ALL', 'TERM']
+  .filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]])),
+  HOME: path.join(scratch, 'home'), NIKA_KEYCHAIN: 'off' };
+const consumerEnv = { ...env };
+delete consumerEnv.NIKA_BIN;
+const owned = new OwnedProcesses();
+const abort = new AbortController();
+let cleanupError;
+function stopProof(reason) {
+  abort.abort(new Error(reason));
+  void owned.close().catch((error) => { cleanupError = error; });
+}
+const signalHandlers = new Map(['SIGINT', 'SIGTERM', 'SIGHUP'].map((signal) => [signal, () => stopProof(`one-door received ${signal}`)]));
+for (const [signal, handler] of signalHandlers) process.on(signal, handler);
+const deadline = setTimeout(() => stopProof('one-door overall deadline exceeded (180s)'), 180_000);
+let url;
+let server;
+let configSequence = 0;
+let report;
+let cancellationGate;
+const rows = [];
+const traces = [];
+
+try {
+  mkdirSync(project);
+  mkdirSync(consumer);
+  mkdirSync(env.HOME);
+  cancellationGate = await CancellationRendezvous.listen();
+  const workflows = { ...fixtures, cancelled: cancellationFixture(cancellationGate.url) };
+  writeFileSync(path.join(project, 'nika.yaml'), 'nika: one-door-e2e\n');
+  for (const [name, yaml] of Object.entries(workflows)) writeFileSync(path.join(project, `${name}.nika.yaml`), yaml);
+  writeFileSync(path.join(scratch, 'token'), `${token}\n`, { mode: 0o600 });
+  const engine = await probe(binary, env);
+  engine.binary_sha256 = await sha256(binary);
+  assert.equal(engine.sdk_identity.engineVersion, version, 'CLI/resident release train');
+  if (publicVersion) {
+    assert.equal(publicVersion, version, 'public SDK and repository release train');
+    assert.match(engine.version, new RegExp(`^nika ${version.replaceAll('.', '\\.')} \\([0-9a-f]+\\)$`));
+  }
+  let dependency = `@supernovae-st/nika-client@${publicVersion}`;
+  if (!publicVersion) {
+    await owned.run('npm', ['run', 'build'], { cwd: root, env, timeoutMs: 60_000 });
+    const [packed] = JSON.parse(await owned.run('npm', [
+      'pack', '--ignore-scripts', '--json', '--pack-destination', scratch,
+    ], { cwd: root, env, timeoutMs: 30_000 }));
+    dependency = path.join(scratch, packed.filename);
+  }
+  writeFileSync(path.join(consumer, 'package.json'), '{"private":true,"type":"module"}\n');
+  await owned.run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund',
+    ...(publicVersion ? [] : ['--omit=optional', '--offline']), dependency,
+  ], { cwd: consumer, env: consumerEnv, timeoutMs: 60_000 });
+  for (const file of ['consumer.mjs', 'contract.mjs']) {
+    copyFileSync(path.join(root, 'scripts/one-door', file), path.join(consumer, file));
+  }
+  // This public bin shim resolves the same packaged engine as native Nika().
+  // It receives no override in npm mode, and cannot fall back to the repo binary.
+  const nativeEngine = publicVersion
+    ? await probe(path.join(consumer, 'node_modules/.bin/nika'), consumerEnv)
+    : engine;
+  const nativePackage = `@supernovae-st/nika-${process.platform}-${process.arch}`;
+  const nativeBinary = publicVersion ? path.join(consumer, 'node_modules', nativePackage, 'bin/nika') : binary;
+  if (publicVersion) {
+    nativeEngine.native_package = nativePackage;
+    nativeEngine.binary_path = nativeBinary;
+    nativeEngine.binary_sha256 = await sha256(nativeBinary);
+  }
+  assert.equal(nativeEngine.sdk_identity.engineVersion, version, 'native payload release train');
+  assert.deepEqual(nativeEngine.sdk_identity, engine.sdk_identity, 'native payload and CLI/resident identity vector');
+  if (publicVersion) {
+    assert.equal(nativeEngine.binary_sha256, engine.binary_sha256,
+      'public npm native payload must be the exact same-platform released CLI binary');
+  }
+  const installedLock = JSON.parse(readFileSync(path.join(consumer, 'package-lock.json'), 'utf8'));
+  const installedPackages = Object.entries(installedLock.packages)
+    .filter(([key]) => key.startsWith('node_modules/@supernovae-st/nika-') && existsSync(path.join(consumer, key)))
+    .map(([key, value]) => ({ path: key, version: value.version, resolved: value.resolved,
+      integrity: value.integrity ?? null }));
+
+  server = owned.start(binary, ['serve', '--bind', '127.0.0.1:0', '--workflows', project,
+    '--token-file', path.join(scratch, 'token'), '--state-root', path.join(scratch, 'state'), '--plain'],
+  { cwd: project, env, timeoutMs: 180_000 });
+  let healthy = false;
+  const listenerDeadline = performance.now() + 10_000;
+  while (performance.now() < listenerDeadline) {
+    abort.signal.throwIfAborted();
+    assert.equal(server.child.exitCode, null, `resident exited: ${server.stdout}\n${server.stderr}`);
+    url = `${server.stdout}\n${server.stderr}`.match(/nika serve[^\n]*listening (http:\/\/127\.0\.0\.1:\d+)/)?.[1];
+    if (url) {
+      try { healthy = (await request('/health', {}, 1000)).ok; }
+      catch (error) { abort.signal.throwIfAborted(); }
+      if (healthy) break;
+    }
+    await delay(25);
+  }
+  assert(healthy, `resident listener/health unavailable: ${server.stdout}\n${server.stderr}`);
+  assert(!existsSync(absentBinary));
+  for (const name of Object.keys(workflows)) assert(!existsSync(path.join(consumer, `${name}.nika.yaml`)));
+  const catalog = await sdk({ action: 'catalog', names: Object.keys(workflows), door: 'sdk-name' });
+  const expectations = {};
+  for (const [name, expectedStatus, expectedExit] of [
+    ['clean', 'succeeded', 0], ['failed', 'failed', 1], ['recovered', 'succeeded', 0],
+    ['paused', 'paused', 4], ['cancelled', 'cancelled', 130],
+  ]) {
+    process.stderr.write(`one-door scenario: ${name}\n`);
+    const file = `${name}.nika.yaml`;
+    const ordinary = await cli(['check', file, '--json'], 0);
+    assert.equal(ordinary.execution_snapshot, undefined, 'snapshot export must stay opt-in');
+    const captured = await cli(['check', file, '--json', '--sdk-snapshot'], 0);
+    assert.equal(typeof captured.execution_snapshot, 'string');
+    let cancellationSent = false;
+    if (name === 'cancelled') cancellationGate.arm('cli');
+    const cliRun = await cli(['run', file, '--json', '--max-cost-usd', '0.01'], expectedExit, true,
+      name === 'cancelled' ? async (handle) => {
+        await cancellationGate.arrived;
+        cancellationSent = handle.signal('SIGTERM');
+        assert(cancellationSent, 'CLI signal accepted while task held');
+        await cancellationGate.release();
+      } : undefined);
+    const settled = cliRun.find((frame) => frame.kind === 'run_settled');
+    const expected = verdict(settled);
+    expectations[name] = expected;
+    assert.equal(expected.status, expectedStatus);
+    if (name === 'failed') assert.equal(expected.error_task, 'a', 'named failed task');
+    if (name === 'clean' || name === 'recovered') assert(Object.keys(expected.outputs).length > 0, 'nonempty workflow outputs');
+    if (name === 'cancelled') compareControlledCancellation(settled);
+    rows.push({ scenario: name, door: 'cli', ...expected, ...identity(settled),
+      original_terminal: settled,
+      ...(cancellationSent ? { acknowledgement: { signal_sent: true }, cancellation: cancellationGate.finish() } : {}) });
+    const trace = await cli(['trace', 'outputs', settled.receipt.trace_path, '--json'], 0);
+    compareSameJobResult({ kind: 'execution.settled', status: trace.settlement.status,
+      settlement: trace.settlement }, settled, `same-execution trace settlement: ${name}`);
+    traces.push({ scenario: name, door: 'cli', settlement: settlementFacts(trace.settlement),
+      exact_settlement: trace.settlement, same_job_settlement_compared: true,
+      workflow_outputs_compared: false, reason: 'trace outputs exposes per-task data, not workflow outputs' });
+    for (const [door, body] of [
+      ['http-name', JSON.stringify({ workflow: file })], ['http-snapshot', captured.execution_snapshot],
+    ]) {
+      if (name === 'cancelled') cancellationGate.arm(door);
+      const response = await request('/v1/jobs', {
+        method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `${name}-${door}` }, body,
+      });
+      assert(response.ok, `${door} admission: ${await response.clone().text()}`);
+      const job = await response.json();
+      const { terminal, acknowledgement } = await httpEvents(job.id, name === 'cancelled', `${door}: ${name}`);
+      compareResult(terminal, expected, `${door}: ${name}`);
+      const durable = await compareDurable(job.id, terminal, `${door}: ${name}`);
+      if (name === 'cancelled') {
+        compareControlledCancellation(terminal);
+        await compareTrace(name, door, terminal);
+      }
+      rows.push({ scenario: name, door, ...verdict(terminal), ...identity(terminal), acknowledgement,
+        original_terminal: terminal, durable_job: durable, same_job_get_compared: true,
+        ...(name === 'cancelled' ? { cancellation: cancellationGate.finish() } : {}) });
+    }
+    for (const door of ['sdk-native', 'sdk-name', 'sdk-snapshot']) {
+      const cancellationControl = name === 'cancelled' ? cancellationGate.arm(door) : undefined;
+      const row = await sdk({ action: 'run', name, door, expected, cancellationControl });
+      if (door !== 'sdk-native') {
+        row.durable_job = await compareDurable(row.original_result.id, row.terminal_event, `${door}: ${name}`);
+        row.same_job_get_compared = true;
+      }
+      if (name === 'cancelled') {
+        await compareTrace(name, door, row.original_result);
+        row.cancellation = cancellationGate.finish();
+      }
+      rows.push(row);
+    }
+  }
+  const replay = await sdk({ action: 'replay', door: 'sdk-name', expected: expectations.clean });
+  assert.equal(await sha256(binary), engine.binary_sha256, 'CLI/resident artifact changed during proof');
+  assert.equal(await sha256(nativeBinary), nativeEngine.binary_sha256, 'native artifact changed during proof');
+  abort.signal.throwIfAborted();
+  report = { result: 'green', evidence_kind: publicVersion ? 'installed public npm runtime parity' : 'development npm-pack parity',
+    provenance: 'not attested by this script; public provenance requires the root outer gate',
+    cli_resident_engine: engine, sdk_native_engine: nativeEngine,
+    native_resolution: publicVersion ? 'installed public package, no NIKA_BIN override' : 'explicit development binary',
+    installed_package: catalog.installed_package, installed_packages: installedPackages, rows, traces, replay,
+    cancellation_fixture: { source: workflows.cancelled,
+      sha256: createHash('sha256').update(workflows.cancelled).digest('hex'),
+      deadline_ms: 10_000, timeout_behavior: 'fail; never release on a timer',
+      network: 'owned loopback HTTP only; development npm install uses --offline',
+      credentials: 'fresh HOME, NIKA_KEYCHAIN=off, no inherited provider or proxy environment' },
+    coverage: { execution_doors: 6, scenarios: 5, terminal_cursor_attach: true,
+      cancellation: 'controlled loopback fetch rendezvous on all six doors; cancellation requested while held, then release; exact cancelled/operator tally requires one completed task and one unstarted dependent',
+      cancellation_race: 'success racing a request remains valid engine behavior; this controlled fixture must cancel, and mutation tests reject fabricating cancellation or losing an actual settlement',
+      same_job: 'full settlements: CLI event/trace on all scenarios; SDK event/result on all scenarios and terminal attach on HTTP; raw GET/event on all HTTP jobs; event/result/trace across all six controlled cancellation executions',
+      outputs: 'complete maps; absent optional outputs equal an empty set only for non-success states, with presence recorded',
+      paused: 'terminal observation only; resumability is not asserted' } };
+} catch (error) {
+  if (server) process.stderr.write(`resident diagnostics:\n${server.stdout}\n${server.stderr}\n`);
+  throw error;
+} finally {
+  clearTimeout(deadline);
+  try {
+    try {
+      try { await stopResident(server); }
+      finally { await owned.close(); }
+    } finally { await cancellationGate?.close(); }
+    if (cleanupError) throw cleanupError;
+    rmSync(scratch, { recursive: true, force: true });
+    for (const [signal, handler] of signalHandlers) process.off(signal, handler);
+  } catch (error) {
+    process.stderr.write(`cleanup incomplete; retained owned scratch directory ${scratch}\n`);
+    throw error;
+  }
+}
+// A green artifact is only emitted AFTER owned processes (including native
+// descendants) are gone and their scratch directory has been removed.
+abort.signal.throwIfAborted();
+if (reportPath) writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(`one-door green: 5 scenarios, 6 execution doors; ${report.evidence_kind} (${report.cli_resident_engine.version})`);
+
+async function sha256(file) {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(file)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function probe(command, childEnv) {
+  const options = { cwd: consumer, env: childEnv, timeoutMs: 15_000 };
+  return { command, version: (await owned.run(command, ['--version'], options)).trim(),
+    sdk_identity: JSON.parse(await owned.run(command, ['--sdk-identity'], options)) };
+}
+
+async function sdk(config) {
+  abort.signal.throwIfAborted();
+  const configPath = path.join(consumer, `request-${configSequence++}.json`);
+  writeFileSync(configPath, JSON.stringify({ version, publicVersion, url, token, project,
+    consumer, binary, absentBinary, ...config }));
+  return JSON.parse(await owned.run(process.execPath, [path.join(consumer, 'consumer.mjs'), configPath],
+    { cwd: consumer, env: consumerEnv, timeoutMs: 25_000 }));
+}
+
+async function cli(args, expectedExit, ndjson = false, onStarted) {
+  abort.signal.throwIfAborted();
+  const handle = owned.start(binary, [...args, '--plain'], { cwd: project, env, timeoutMs: 20_000 });
+  const [result] = await Promise.all([handle.done, onStarted?.(handle)]);
+  assert.equal(result.code, expectedExit, `${args.join(' ')}\n${result.stdout}\n${result.stderr}`);
+  return ndjson ? result.stdout.trim().split('\n').map((line) => JSON.parse(line)) : JSON.parse(result.stdout);
+}
+
+function request(route, options = {}, timeout = 15_000) {
+  return fetch(`${url}${route}`, { ...options, headers: { Authorization: `Bearer ${token}`, ...options.headers },
+    signal: AbortSignal.any([abort.signal, AbortSignal.timeout(timeout)]) });
+}
+
+async function httpEvents(id, cancel, label) {
+  const events = await request(`/v1/jobs/${id}/events`);
+  assert(events.ok && events.body, 'HTTP event stream');
+  const reader = events.body.getReader();
+  const decoder = new TextDecoder();
+  let pending = '';
+  let terminal;
+  let acknowledgement;
+  const cancellation = cancel ? (async () => {
+    await cancellationGate.arrived;
+    assert(!terminal, 'cancel while the runtime task is held');
+    const response = await request(`/v1/jobs/${id}/cancel`, { method: 'POST' });
+    assert.equal(response.status, 202, 'controlled fixture must exercise pending HTTP cancellation');
+    acknowledgement = { http_status: response.status, body: await response.json() };
+    assert.equal(acknowledgement.body.status, 'running', 'pending acknowledgement is not a settlement');
+    assert.equal(acknowledgement.body.settlement, undefined, 'pending acknowledgement has no settlement');
+    assert(!terminal, 'pending acknowledgement precedes terminal observation');
+    await cancellationGate.release();
+  })() : undefined;
+  cancellation?.catch(() => {});
+  let bytes = 0;
+  const observed = [];
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      assert(bytes < 4 * 1024 * 1024, 'bounded HTTP event stream');
+      pending += decoder.decode(value, { stream: true });
+      const lines = pending.split('\n');
+      pending = lines.pop();
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue;
+        const frame = JSON.parse(line.slice(5));
+        observed.push(frame);
+        if (frame.kind === 'execution.settled'
+          || (cancel && frame.kind === 'execution.cancelled' && frame.settlement)) terminal = frame;
+      }
+      if (terminal) break;
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+  assert(terminal, `${label}: HTTP must emit its own terminal settlement: ${JSON.stringify(observed)}`);
+  await cancellation;
+  if (cancel) assert(acknowledgement, 'observed HTTP cancellation acknowledgement');
+  return { terminal, acknowledgement };
+}
+
+async function compareDurable(id, terminal, label) {
+  const response = await request(`/v1/jobs/${id}`);
+  assert.equal(response.status, 200);
+  const durable = await response.json();
+  assert.equal(durable.id, id);
+  // GET's legacy top-level error is a code/message summary. As with SSE,
+  // its full authoritative diagnostic lives inside the settlement object.
+  compareSameJobResult({ ...durable, kind: 'execution.settled' }, terminal, `${label} GET/event`);
+  assert.deepEqual(durable.outputs, terminal.outputs, `${label} GET output presence and values`);
+  assert.deepEqual(durable.receipt, terminal.receipt, `${label} GET receipt`);
+  return durable;
+}
+
+async function compareTrace(scenario, door, original) {
+  const receipt = original.receipt;
+  assert(receipt?.execution_id && receipt?.trace_id, 'trace comparison requires the original receipt');
+  const directory = path.join(project, '.nika/traces');
+  // This is a supervisor read of its own scratch journal, not a remote SDK
+  // capability. Bind by full execution identity, never the four-digit name.
+  const matches = readdirSync(directory).filter((file) => file.endsWith('.ndjson'))
+    .map((file) => path.join(directory, file))
+    .filter((file) => readFileSync(file, 'utf8').trim().split('\n')
+      .some((line) => JSON.parse(line).execution?.uuid === receipt.execution_id.slice(4)));
+  assert.equal(matches.length, 1, `${door}: exactly one journal for the full execution identity`);
+  const trace = await cli(['trace', 'outputs', matches[0], '--json'], 0);
+  compareSameJobResult({ kind: 'execution.settled', status: trace.settlement?.status,
+    settlement: trace.settlement }, original, `${door} same-execution trace settlement`);
+  assert.equal(trace.tasks.find((task) => task.id === 'held')?.status, 'ok');
+  const dependent = trace.tasks.find((task) => task.id === 'dependent');
+  assert.equal(dependent?.status, 'cancelled');
+  assert.equal(dependent.verb, null, 'trace has no start verb for the unstarted dependent');
+  traces.push({ scenario, door, execution_id: receipt.execution_id, trace_id: receipt.trace_id,
+    exact_settlement: trace.settlement, tasks: trace.tasks, same_job_settlement_compared: true,
+    workflow_outputs_compared: false, reason: 'trace outputs exposes per-task data, not workflow outputs' });
+}

--- a/scripts/run-recovery-e2e.mjs
+++ b/scripts/run-recovery-e2e.mjs
@@ -1,134 +1,66 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawn, spawnSync } from 'node:child_process';
-import {
-  chmodSync,
-  cpSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { createServer as createNetServer } from 'node:net';
-import { tmpdir } from 'node:os';
+import { chmodSync, realpathSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { bounded } from './gauntlet-cancellation.mjs';
+import { installProject, supervisedGauntlet, packSdk } from './gauntlet.mjs';
+import { stopResident, waitForHealth } from './one-door/resident.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const source = path.join(root, 'gauntlet', 'recovery-e2e');
-const resultsRoot = process.env.NIKA_GAUNTLET_RESULTS_DIR
-  ? path.resolve(process.env.NIKA_GAUNTLET_RESULTS_DIR)
-  : path.join(root, 'gauntlet', 'results');
-const resultPath = path.join(resultsRoot, 'recovery-e2e.json');
-const nikaBin = process.env.NIKA_BIN;
-assert(nikaBin, 'NIKA_BIN must name the engine binary under test');
-const scratch = mkdtempSync(path.join(tmpdir(), 'nika-recovery-e2e-'));
-let server;
 
-try {
-  mkdirSync(resultsRoot, { recursive: true });
-  execFileSync('npm', ['run', 'build'], { cwd: root, stdio: 'pipe' });
-  const packed = JSON.parse(execFileSync(
-    'npm',
-    ['pack', '--ignore-scripts', '--json', '--pack-destination', scratch],
-    { cwd: root, encoding: 'utf8' },
-  ));
-  const tarball = path.join(scratch, packed[0].filename);
-  const project = path.join(scratch, 'project');
-  cpSync(source, project, { recursive: true });
-  const manifestPath = path.join(project, 'package.json');
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  manifest.dependencies = { '@supernovae-st/nika-client': `file:${tarball}` };
-  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
-  execFileSync(
-    'npm',
-    ['install', '--ignore-scripts', '--omit=optional', '--no-audit', '--no-fund'],
-    { cwd: project, stdio: 'pipe' },
-  );
-
-  const token = 'recovery-e2e-token-0123456789abcdef0123456789';
-  const tokenFile = path.join(scratch, 'serve.token');
-  writeFileSync(tokenFile, `${token}\n`, { mode: 0o600 });
-  chmodSync(tokenFile, 0o600);
-  const port = await freePort();
-  const url = `http://127.0.0.1:${port}`;
-  server = spawn(nikaBin, [
-    'serve',
-    '--bind', `127.0.0.1:${port}`,
-    '--workflows', project,
-    '--token-file', tokenFile,
-    '--state-root', path.join(scratch, 'state'),
-    '--plain',
-  ], { cwd: project, stdio: ['ignore', 'pipe', 'pipe'] });
-  let diagnostics = '';
-  server.stderr.setEncoding('utf8');
-  server.stderr.on('data', (chunk) => { diagnostics += chunk; });
-  await waitForHealth(url);
-
-  const env = {
-    ...process.env,
-    NIKA_BIN: nikaBin,
-    NIKA_URL: url,
-    NIKA_TOKEN: token,
-  };
-  const producer = spawnSync(process.execPath, ['client.mjs', 'producer'], {
-    cwd: project,
-    env,
-    encoding: 'utf8',
-    timeout: 30_000,
-  });
-  assert.equal(producer.status, 0, producer.stderr);
-  const recoveryState = producer.stdout.trim().split('\n').at(-1);
-  assert(recoveryState, 'producer did not persist a recovery state');
-  const consumer = spawnSync(process.execPath, ['client.mjs', 'consumer'], {
-    cwd: project,
-    env: { ...env, NIKA_RECOVERY_STATE: recoveryState },
-    encoding: 'utf8',
-    timeout: 30_000,
-  });
-  assert.equal(consumer.status, 0, consumer.stderr);
-  const result = JSON.parse(consumer.stdout.trim().split('\n').at(-1));
-  const evidence = {
-    schema_version: 1,
-    engine: execFileSync(nikaBin, ['--version'], { encoding: 'utf8' }).trim(),
-    package: packed[0].filename,
-    process_count: 2,
-    installed_from_pack: true,
-    ...result,
-  };
-  writeFileSync(resultPath, `${JSON.stringify(evidence, null, 2)}\n`);
-  process.stdout.write(`two-process recovery green · ${resultPath}\n`);
-
-  server.kill('SIGINT');
-  await Promise.race([
-    new Promise((resolve) => server.once('close', resolve)),
-    new Promise((resolve) => setTimeout(resolve, 3_000)),
-  ]);
-  if (server.exitCode && server.exitCode !== 130) {
-    throw new Error(`nika serve exited ${server.exitCode}: ${diagnostics.slice(-500)}`);
-  }
-} finally {
-  if (server?.exitCode === null) server.kill('SIGTERM');
-  rmSync(scratch, { recursive: true, force: true });
-}
-
-async function freePort() {
-  const probe = createNetServer();
-  await new Promise((resolve, reject) => {
-    probe.listen(0, '127.0.0.1', resolve).once('error', reject);
-  });
-  const address = probe.address();
-  assert(address && typeof address === 'object');
-  await new Promise((resolve) => probe.close(resolve));
-  return address.port;
-}
-
-async function waitForHealth(base) {
-  for (let attempt = 0; attempt < 120; attempt += 1) {
+export async function runRecoveryE2e() {
+  return supervisedGauntlet({ name: 'recovery-e2e', root }, async ({ scratch, nikaBin, env, start, run, signal }) => {
+    const { filename, tarball } = await packSdk(root, scratch, run);
+    const project = path.join(scratch, 'project');
+    await installProject(path.join(root, 'gauntlet', 'recovery-e2e'), project, tarball, run);
+    const token = 'recovery-e2e-token-0123456789abcdef0123456789';
+    const tokenFile = path.join(scratch, 'serve.token');
+    writeFileSync(tokenFile, `${token}\n`, { mode: 0o600 });
+    chmodSync(tokenFile, 0o600);
+    const port = await freePort(signal);
+    const url = `http://127.0.0.1:${port}`;
+    const server = start(nikaBin, [
+      'serve', '--bind', `127.0.0.1:${port}`, '--workflows', project,
+      '--token-file', tokenFile, '--state-root', path.join(scratch, 'state'), '--plain',
+    ], { cwd: project, timeoutMs: 90_000, maxBuffer: 1024 * 1024 });
     try {
-      if ((await fetch(`${base}/health`)).ok) return;
-    } catch {}
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-  throw new Error('nika serve did not become healthy');
+      await waitForHealth(url, server, signal, { timeoutMs: 3_000 });
+      const clientEnv = { ...env, NIKA_URL: url, NIKA_TOKEN: token };
+      const producer = await run(process.execPath, ['client.mjs', 'producer'],
+        { cwd: project, env: clientEnv, timeoutMs: 30_000 });
+      const recoveryState = producer.trim().split('\n').at(-1);
+      assert(recoveryState, 'producer did not persist a recovery state');
+      const consumer = await run(process.execPath, ['client.mjs', 'consumer'],
+        { cwd: project, env: { ...clientEnv, NIKA_RECOVERY_STATE: recoveryState }, timeoutMs: 30_000 });
+      const result = JSON.parse(consumer.trim().split('\n').at(-1));
+      assert.equal(result.project, 'two-process-durable-recovery');
+      assert.equal(result.status, 'succeeded');
+      return {
+        engine: (await run(nikaBin, ['--version'], { timeoutMs: 5_000 })).trim(),
+        package: filename, process_count: 2, installed_from_pack: true, ...result,
+      };
+    } finally {
+      // Keep the original 3s shutdown obligation. TERM/KILL cleanup cannot
+      // turn a missed graceful deadline into a successful recovery proof.
+      await stopResident(server, { timeoutMs: 3_000 });
+    }
+  });
 }
+
+async function freePort(signal) {
+  const probe = createServer();
+  try {
+    await bounded(new Promise((resolve, reject) => {
+      probe.once('error', reject);
+      probe.listen({ port: 0, host: '127.0.0.1', signal }, resolve);
+    }), 3_000, 'loopback port reservation', signal);
+    const address = probe.address();
+    assert(address && typeof address === 'object');
+    return address.port;
+  } finally {
+    await bounded(new Promise((resolve) => probe.close(resolve)), 1_000, 'port reservation cleanup');
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(process.argv[1])) await runRecoveryE2e();

--- a/scripts/verify-engine-archive.mjs
+++ b/scripts/verify-engine-archive.mjs
@@ -1,0 +1,7 @@
+import { verifyEngineArchive } from './native-release-contract.mjs';
+
+const [archive, sums, version, expectedCommit, ...extra] = process.argv.slice(2);
+if (!archive || !sums || !version || extra.length) {
+  throw new Error('usage: verify-engine-archive.mjs <archive> <SHA256SUMS> <version> [expected-engine-commit]');
+}
+console.log(JSON.stringify(await verifyEngineArchive(archive, sums, version, expectedCommit)));

--- a/scripts/verify-gauntlet-corpus.mjs
+++ b/scripts/verify-gauntlet-corpus.mjs
@@ -1,48 +1,18 @@
-import { spawnSync } from "node:child_process";
-import { readFileSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { supervisedGauntlet } from './gauntlet.mjs';
+import { stageCorpus } from './corpus-project.mjs';
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const corpusRoot = join(root, "gauntlet", "corpus");
-const workflowsRoot = join(corpusRoot, "workflows");
-const inventory = JSON.parse(readFileSync(join(corpusRoot, "use-cases.json"), "utf8"));
-const workflowFiles = readdirSync(workflowsRoot).filter((name) => name.endsWith(".nika.yaml")).sort();
-const requiredUniqueFields = ["id", "actor", "trigger", "failure_oracle", "business_outcome", "workflow"];
-
-if (inventory.length !== 100 || workflowFiles.length !== 100) {
-  throw new Error(`expected 100 inventory rows and workflows; got ${inventory.length} and ${workflowFiles.length}`);
-}
-for (const field of requiredUniqueFields) {
-  const count = new Set(inventory.map((entry) => entry[field])).size;
-  if (count !== 100) throw new Error(`${field} is not unique: ${count}/100`);
-}
-if (new Set(inventory.map((entry) => entry.domain)).size !== 20) {
-  throw new Error("expected 20 distinct domains");
-}
-
-const nikaBin = process.env.NIKA_BIN || process.env.NIKA_GAUNTLET_BIN || "nika";
-const failures = [];
-for (const [index, file] of workflowFiles.entries()) {
-  const path = join(workflowsRoot, file);
-  const check = spawnSync(nikaBin, ["check", "--json", "--native-strict", path], {
-    encoding: "utf8",
-    maxBuffer: 8 * 1024 * 1024,
+const root = path.resolve(import.meta.dirname, '..');
+await supervisedGauntlet({ name: 'corpus-check', root, persistReport: false },
+  async ({ scratch, nikaBin, env, run }) => {
+    const { project, engineEnv, workflowFiles } = stageCorpus(root, scratch, env);
+    for (const [index, file] of workflowFiles.entries()) {
+      const stdout = await run(nikaBin, ['check', '--json', '--native-strict', path.join(project, 'workflows', file)],
+        { cwd: project, env: engineEnv, timeoutMs: 30_000, maxBuffer: 8 * 1024 * 1024 });
+      const report = JSON.parse(stdout);
+      assert(report?.clean === true && report?.paid_ready === true, `${file}: check is not clean and paid-ready`);
+      if ((index + 1) % 10 === 0) process.stdout.write(`checked ${index + 1}/100\n`);
+    }
+    return { checked: workflowFiles.length, domains: 20, unique_identity_fields: 6 };
   });
-  if (check.status !== 0) {
-    failures.push({ file, stage: "check", status: check.status, stderr: check.stderr, stdout: check.stdout });
-    continue;
-  }
-  const report = JSON.parse(check.stdout);
-  if (report.clean !== true || report.paid_ready !== true) {
-    failures.push({ file, stage: "readiness", clean: report.clean, paid_ready: report.paid_ready, next: report.next });
-  }
-  if ((index + 1) % 10 === 0) process.stdout.write(`checked ${index + 1}/100\n`);
-}
-
-if (failures.length > 0) {
-  console.error(JSON.stringify(failures.slice(0, 10), null, 2));
-  throw new Error(`${failures.length} workflows failed corpus verification`);
-}
-
-console.log("100/100 workflows clean, native-strict, paid-ready; 20 domains and six semantic identity fields unique");

--- a/src/lib/http-transport.ts
+++ b/src/lib/http-transport.ts
@@ -62,6 +62,13 @@ interface SnapshotIdentity {
   units: number;
 }
 
+interface SnapshotAck {
+  status: 'accepted';
+  snapshot_digest: string;
+  root: string;
+  units: number;
+}
+
 interface ObservationState {
   lastSequence: number;
   lastData?: string;
@@ -92,6 +99,14 @@ interface ObservationSettlement {
   settle: (source: NikaEvent | DurableJob) => void;
 }
 
+interface JsonRefusal {
+  operation: NikaOperation;
+  status: number;
+  refusal: { code: string; message?: string };
+}
+
+type JsonOutcome = { object: Record<string, unknown>; status: number } | JsonRefusal;
+
 const JOB_STATUSES = new Set([
   'queued',
   'running',
@@ -115,6 +130,8 @@ const RETRY_BASE_MILLISECONDS = 100;
 const RETRY_MIN_MILLISECONDS = 25;
 const RETRY_MAX_MILLISECONDS = 5_000;
 
+const WORKFLOW_REFUSAL_STATUSES = new Set([404, 422]);
+
 export class HttpTransport implements Transport {
   readonly kind = 'http' as const;
   private serverIdentity?: Promise<NikaEngineIdentity>;
@@ -128,26 +145,24 @@ export class HttpTransport implements Transport {
     if (options.model !== undefined || options.nativeStrict === true) {
       throw this.gap(
         'checkOptions',
-        'Remote snapshot capture does not support model or nativeStrict overrides',
+        'nika serve admission has no request envelope for model or nativeStrict overrides',
       );
     }
+    if (isContainedWorkflowName(workflow)) return this.checkByName(workflow, options.signal);
     const captured = await this.captureSnapshot(workflow, options.signal, true);
     if (captured.bytes === undefined) return captured.report;
     const snapshot = captured.identity;
     if (!snapshot) {
       throw this.gap('executionSnapshot', 'Local engine omitted execution snapshot identity');
     }
-    const acknowledged = await this.json('/v1/check', {
+    const acknowledged = snapshotAck(await this.json('/v1/check', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: captured.bytes,
       signal: options.signal,
-    }, true, [200], 'check');
+    }, true, [200], 'check'));
     if (
-      Object.keys(acknowledged).some((key) => ![
-        'status', 'snapshot_digest', 'root', 'units',
-      ].includes(key))
-      || acknowledged.status !== 'accepted'
+      !acknowledged
       || acknowledged.snapshot_digest !== snapshot.digest
       || acknowledged.root !== snapshot.root
       || acknowledged.units !== snapshot.units
@@ -165,12 +180,20 @@ export class HttpTransport implements Transport {
     ) {
       throw this.gap(
         'runOptions',
-        'nika serve snapshot admission has no request envelope for vars, model, or maxCostUsd',
+        'nika serve admission has no request envelope for vars, model, or maxCostUsd',
       );
     }
     const idempotencyKey = options.idempotencyKey ?? randomUUID();
     if (Buffer.byteLength(idempotencyKey) < 1 || Buffer.byteLength(idempotencyKey) > 255) {
       throw new NikaTransportError(this.kind, 'Idempotency-Key must be 1-255 bytes');
+    }
+    if (isContainedWorkflowName(workflow)) {
+      // The by-name form (ADR-131): the resident captures the world of a
+      // workflow its registry lists and computes the digest its receipt
+      // carries. No local engine is spawned and no digest is expected here.
+      await this.ensureServerIdentity();
+      const job = await this.admitJob(JSON.stringify({ workflow }), idempotencyKey);
+      return this.httpRun(job.id as NikaRunId, 0, job);
     }
     const captured = await this.captureSnapshot(workflow);
     if (captured.bytes === undefined) {
@@ -179,24 +202,52 @@ export class HttpTransport implements Transport {
     if (!captured.identity) {
       throw this.gap('executionSnapshot', 'Local engine omitted execution snapshot identity');
     }
+    const job = await this.admitJob(captured.bytes, idempotencyKey);
+    return this.httpRun(job.id as NikaRunId, 0, job, captured.identity.digest);
+  }
+
+  /**
+   * The by-name form of `POST /v1/check` (ADR-131): the resident captures
+   * the world of a workflow its registry lists and answers the compact
+   * acknowledgement; nothing is hashed or spawned here. A refusal that
+   * judges the workflow is a red result, as it is on the native transport:
+   * 404 (the name is not served) and 422 (the capture or admission refused
+   * it). Authorization, deadline, envelope and availability refusals still
+   * throw, because they judge the request, not the workflow.
+   */
+  private async checkByName(workflow: string, signal?: AbortSignal): Promise<NikaCheckResult> {
+    await this.ensureServerIdentity();
+    const outcome = await this.jsonOutcome('/v1/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workflow }),
+      signal,
+    }, true, [200], 'check', true);
+    if ('refusal' in outcome) {
+      if (!WORKFLOW_REFUSAL_STATUSES.has(outcome.status)) throw this.refused('/v1/check', outcome);
+      return { clean: false, error: outcome.refusal };
+    }
+    const acknowledged = snapshotAck(outcome.object);
+    if (!acknowledged) {
+      throw new NikaProtocolError(this.kind, 'Check admission did not acknowledge the workflow');
+    }
+    return { clean: true, ...acknowledged };
+  }
+
+  private async admitJob(body: string, idempotencyKey: string): Promise<DurableJob> {
     const admitted = await this.json('/v1/jobs', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Idempotency-Key': idempotencyKey,
       },
-      body: captured.bytes,
+      body,
     }, true, [200, 202], 'run');
-    const id = typeof admitted.id === 'string' ? admitted.id as NikaRunId : undefined;
+    const id = typeof admitted.id === 'string' ? admitted.id : undefined;
     if (!id) {
       throw new NikaProtocolError(this.kind, 'Job admission response omitted its id');
     }
-    return this.httpRun(
-      id,
-      0,
-      durableJob(admitted, id, this.kind),
-      captured.identity.digest,
-    );
+    return durableJob(admitted, id, this.kind);
   }
 
   async attachRun(id: string, options: NikaAttachRunOptions): Promise<TransportRun> {
@@ -392,7 +443,7 @@ export class HttpTransport implements Transport {
         ...(settlement ? { settlement } : {}),
       });
     };
-    if (attachedState && isTerminal(attachedState.status)) settle(attachedState);
+    if (attachedState && isObservationEnded(attachedState)) settle(attachedState);
 
     const events: AsyncIterable<NikaEvent> = {
       [Symbol.asyncIterator]: async function* (this: HttpTransport) {
@@ -447,7 +498,7 @@ export class HttpTransport implements Transport {
         );
         const durable = durableJob(object, id, this.kind);
         if (status === 202) {
-          if (isTerminal(durable.status)) {
+          if (isExecutionTerminal(durable.status)) {
             throw new NikaProtocolError(this.kind, 'Pending cancellation returned a terminal job');
           }
           return {
@@ -458,7 +509,7 @@ export class HttpTransport implements Transport {
           };
         }
         // A pause ends this observation while leaving the job resumable.
-        if (durable.status !== 'paused' && !isTerminal(durable.status)) {
+        if (durable.status !== 'paused' && !isExecutionTerminal(durable.status)) {
           throw new NikaProtocolError(this.kind, 'Cancellation did not return an ended observation');
         }
         settle(durable);
@@ -512,7 +563,7 @@ export class HttpTransport implements Transport {
           await this.retryObservation(state, signal, durable, settlement);
           continue;
         }
-        if (isTerminal(durable.status)) {
+        if (isObservationEnded(durable)) {
           state.terminalObserved = true;
           settle(durable);
           return;
@@ -563,7 +614,7 @@ export class HttpTransport implements Transport {
           state.lastSequence = sequence;
           state.lastData = frame.data;
           state.attempt = 0;
-          if (isTerminal(event.status)) {
+          if (isObservationEnded(event)) {
             state.terminalObserved = true;
             settle(event);
           }
@@ -584,7 +635,7 @@ export class HttpTransport implements Transport {
         await this.retryObservation(state, signal, durable, settlement);
         continue;
       }
-      if (isTerminal(durable.status)) {
+      if (isObservationEnded(durable)) {
         state.terminalObserved = true;
         settle(durable);
         return;
@@ -853,7 +904,7 @@ export class HttpTransport implements Transport {
         settlement.id,
         signal,
       );
-      if (!isRetryObservation(durable) && isTerminal(durable.status)) {
+      if (!isRetryObservation(durable) && isObservationEnded(durable)) {
         state.terminalObserved = true;
         settlement.settle(durable);
         return;
@@ -1068,6 +1119,19 @@ export class HttpTransport implements Transport {
     acceptedStatuses: readonly number[],
     operation: NikaOperation | undefined,
   ): Promise<{ object: Record<string, unknown>; status: number }> {
+    const outcome = await this.jsonOutcome(path, init, authenticated, acceptedStatuses, operation);
+    if ('refusal' in outcome) throw this.refused(path, outcome);
+    return outcome;
+  }
+
+  private async jsonOutcome(
+    path: string,
+    init: RequestInit,
+    authenticated: boolean,
+    acceptedStatuses: readonly number[],
+    operation: NikaOperation | undefined,
+    strictRefusal = false,
+  ): Promise<JsonOutcome> {
     const response = await this.fetchResponse(path, init, true, authenticated, false);
     if (!acceptedStatuses.includes(response.status)) {
       if (response.ok) {
@@ -1077,21 +1141,11 @@ export class HttpTransport implements Transport {
           `HTTP ${path} returned non-contract status ${response.status}`,
         );
       }
-      // A refusal the server typed as `{ error: { code, message } }` keeps its
-      // code. The message is engine-owned and already path-free; the bearer
-      // token is redacted defensively in case a hostile server echoes it.
       const refusal = operation === undefined
         ? undefined
-        : await this.readRefusal(response, path);
+        : await this.readRefusal(response, path, strictRefusal);
       if (operation !== undefined && refusal) {
-        throw new NikaOperationError(
-          operation,
-          this.kind,
-          refusal.code,
-          `HTTP ${response.status} for ${path}: ${refusal.code}`
-          + (refusal.message ? ` (${refusal.message})` : ''),
-          { status: response.status, machineCode: refusal.code },
-        );
+        return { operation, status: response.status, refusal };
       }
       await discardResponse(response);
       throw new NikaTransportError(
@@ -1114,6 +1168,17 @@ export class HttpTransport implements Transport {
     };
   }
 
+  private refused(path: string, outcome: JsonRefusal): NikaOperationError {
+    const { code, message } = outcome.refusal;
+    return new NikaOperationError(
+      outcome.operation,
+      this.kind,
+      code,
+      `HTTP ${outcome.status} for ${path}: ${code}` + (message ? ` (${message})` : ''),
+      { status: outcome.status, machineCode: code },
+    );
+  }
+
   /**
    * Read a non-2xx body only when the server typed it as an engine refusal.
    * Anything else (plain text, oversized, malformed, a code that is not a
@@ -1123,6 +1188,7 @@ export class HttpTransport implements Transport {
   private async readRefusal(
     response: Response,
     path: string,
+    strict = false,
   ): Promise<{ code: string; message?: string } | undefined> {
     const contentType = response.headers
       .get('Content-Type')
@@ -1140,6 +1206,13 @@ export class HttpTransport implements Transport {
       return undefined;
     }
     const error = machineObject(object.error);
+    // A by-name check may return a normal red workflow result only for the
+    // exact Error envelope owned by OpenAPI, never a malformed response.
+    if (strict && (
+      Object.keys(object).some((key) => key !== 'error')
+      || !error || Object.keys(error).some((key) => key !== 'code' && key !== 'message')
+      || typeof error.message !== 'string'
+    )) return undefined;
     const code = error?.code;
     if (
       typeof code !== 'string'
@@ -1151,7 +1224,7 @@ export class HttpTransport implements Transport {
     const message = typeof error?.message === 'string' && error.message.length > 0
       ? this.redact(error.message)
       : undefined;
-    return { code, ...(message ? { message } : {}) };
+    return { code, ...(strict ? { message: this.redact(error?.message as string) } : message ? { message } : {}) };
   }
 
   /** Engine messages are already path-free; a reflected bearer token never survives. */
@@ -1394,7 +1467,15 @@ function pathForOperation(operation: NikaOperation): string {
   return operation;
 }
 
-function isTerminal(status: unknown): status is string {
+function isObservationEnded(source: { status?: unknown; settlement?: unknown }): boolean {
+  // A bare paused status can be an attachment waiting beyond its cursor.
+  // Only the explicit settlement closes that observation leg. Cancel's 200
+  // response supplies its own ended-observation authority, handled separately.
+  return isExecutionTerminal(source.status)
+    || (source.status === 'paused' && machineObject(source.settlement)?.status === 'paused');
+}
+
+function isExecutionTerminal(status: unknown): status is string {
   return status === 'succeeded'
     || status === 'failed'
     || status === 'interrupted'
@@ -1567,6 +1648,29 @@ function assertReceiptIdentity(
   ) {
     throw new NikaProtocolError(transport, 'Receipt snapshot digest did not match its admission');
   }
+}
+
+function snapshotAck(value: Record<string, unknown>): SnapshotAck | undefined {
+  const allowed = new Set(['status', 'snapshot_digest', 'root', 'units']);
+  if (
+    Object.keys(value).some((key) => !allowed.has(key))
+    || value.status !== 'accepted'
+    || typeof value.snapshot_digest !== 'string'
+    || !/^[0-9a-f]{64}$/.test(value.snapshot_digest)
+    || typeof value.root !== 'string'
+    || value.root.length === 0
+    || typeof value.units !== 'number'
+    || !Number.isSafeInteger(value.units)
+    || value.units < 1
+  ) {
+    return undefined;
+  }
+  return {
+    status: 'accepted',
+    snapshot_digest: value.snapshot_digest,
+    root: value.root,
+    units: value.units,
+  };
 }
 
 function snapshotIdentity(bytes: string, transport: 'http'): SnapshotIdentity {

--- a/src/lib/machine.ts
+++ b/src/lib/machine.ts
@@ -45,8 +45,8 @@ export function eventStatus(event: NikaEvent | undefined): NikaRunStatus | undef
  * The settlement a terminal frame carries (engine 0.118+ · ADR-128): the
  * native `run_settled` flattens it (`cause` · `elapsed_ms` · `tasks` ·
  * `spend`), the resident's `execution.settled` nests it whole under
- * `settlement`, `status` and the named `error` included. A nested settlement
- * is read through `readSettlement`, so a malformed known fact is a protocol
+ * `settlement`, `status` and the named `error` included. Both projections
+ * are read through `readSettlement`, so a malformed known fact is a protocol
  * fault and an additive field rides through. Absent on older engines; never
  * invented from an exit code.
  */
@@ -59,18 +59,11 @@ export function eventSettlement(
   if (record.settlement !== undefined) {
     return readSettlement(record.settlement, transport, eventStatus(event));
   }
-  const source = record;
-  const cause = typeof source.cause === 'string' ? source.cause : undefined;
-  const elapsed = typeof source.elapsed_ms === 'number' ? source.elapsed_ms : undefined;
-  const tasks = machineObject(source.tasks);
-  const spend = machineObject(source.spend);
-  if (cause === undefined && elapsed === undefined && !tasks && !spend) return undefined;
-  return {
-    ...(cause !== undefined ? { cause } : {}),
-    ...(elapsed !== undefined ? { elapsed_ms: elapsed } : {}),
-    ...(tasks ? { tasks } : {}),
-    ...(spend ? { spend } : {}),
-  };
+  if (['cause', 'elapsed_ms', 'tasks', 'spend'].every((key) => record[key] === undefined)) return undefined;
+  const fields = ['status', 'cause', 'elapsed_ms', 'tasks', 'spend', 'error'];
+  return readSettlement(Object.fromEntries(fields
+    .filter((key) => record[key] !== undefined)
+    .map((key) => [key, record[key]])), transport, eventStatus(event));
 }
 
 export function eventReceipt(event: NikaEvent | undefined): NikaReceipt | undefined {

--- a/src/lib/native-process-transport.ts
+++ b/src/lib/native-process-transport.ts
@@ -258,8 +258,9 @@ export class NativeProcessTransport implements Transport {
               lastEvent = event;
               receipt = eventReceipt(event) ?? receipt;
               outputs = eventOutputs(event) ?? outputs;
-              machineError = eventError(event) ?? machineError;
-              settlement = eventSettlement(event, kind) ?? settlement;
+              const currentSettlement = eventSettlement(event, kind);
+              machineError = currentSettlement ? eventError(event) : eventError(event) ?? machineError;
+              settlement = currentSettlement ?? settlement;
               yield event;
             }
             if (Buffer.byteLength(buffer) > machineBufferBytes) {
@@ -276,8 +277,9 @@ export class NativeProcessTransport implements Transport {
               lastEvent = event;
               receipt = eventReceipt(event) ?? receipt;
               outputs = eventOutputs(event) ?? outputs;
-              machineError = eventError(event) ?? machineError;
-              settlement = eventSettlement(event, kind) ?? settlement;
+              const currentSettlement = eventSettlement(event, kind);
+              machineError = currentSettlement ? eventError(event) : eventError(event) ?? machineError;
+              settlement = currentSettlement ?? settlement;
               yield event;
             }
           }

--- a/src/lib/run-session.ts
+++ b/src/lib/run-session.ts
@@ -61,7 +61,12 @@ export class RunSession {
   }
 
   cancel(): Promise<NikaCancelResult> {
-    this.cancelPromise ??= this.cancelAndSettle();
+    this.cancelPromise ??= this.requestCancel().catch((error) => {
+      // A refused or lost action response is retryable. Only an accepted
+      // request is memoized; observation and its actual result stay alive.
+      this.cancelPromise = undefined;
+      throw error;
+    });
     return this.cancelPromise;
   }
 
@@ -69,8 +74,11 @@ export class RunSession {
     return this.source.status();
   }
 
-  private async cancelAndSettle(): Promise<NikaCancelResult> {
+  private async requestCancel(): Promise<NikaCancelResult> {
     const cancellation = await this.source.cancel();
+    // An accepted signal is not an execution result. Observation continues
+    // independently; callers await run.done for the engine's actual verdict.
+    if (cancellation.status === 'cancellation_requested') return cancellation;
     const result = await this.source.done;
     // An active observer owns the terminal event boundary. Let the transport
     // pump deliver that persisted frame before it closes the subscription.

--- a/test/canonical-incident.test.mjs
+++ b/test/canonical-incident.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { OwnedProcesses } from '../scripts/one-door/process.mjs';
+import { bounded, collectRunEvents } from '../scripts/gauntlet-cancellation.mjs';
+import { assertAppIdentity, executeProjectApp, stageDepthProject } from '../scripts/run-depth-projects.mjs';
+import { exerciseIncident, stopIncidentServer, waitForHealthyServer } from '../gauntlet/projects-depth/incident-response-controller/app.mjs';
+
+test('depth runner does not substitute a second incident application', () => {
+  const runner = readFileSync(new URL('../scripts/run-depth-projects.mjs', import.meta.url), 'utf8');
+  assert(!runner.includes('gauntlet-depth-incident.mjs'), 'execute the committed app, not a replacement');
+});
+
+test('a failed depth invocation invalidates its previous green report', async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'depth-failure-proof-'));
+  const owned = new OwnedProcesses();
+  const report = path.join(scratch, 'depth-projects.json');
+  try {
+    writeFileSync(report, JSON.stringify({ summary: { result: 'green' } }));
+    writeFileSync(path.join(scratch, 'npm'), `#!${process.execPath}\nprocess.exitCode = 13;\n`, { mode: 0o755 });
+    const result = await owned.start(process.execPath,
+      [new URL('../scripts/run-depth-projects.mjs', import.meta.url).pathname],
+      { timeoutMs: 3000, env: { PATH: scratch, HOME: scratch, NIKA_KEYCHAIN: 'off',
+        NIKA_BIN: process.execPath, NIKA_GAUNTLET_RESULTS_DIR: scratch } }).done;
+    assert.equal(result.code, 1);
+    assert.equal(result.signal, null);
+    const failed = JSON.parse(readFileSync(report, 'utf8'));
+    assert.equal(failed.summary.result, 'red');
+    assert.match(failed.error, /npm failed \(13/);
+  } finally {
+    await owned.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test('the committed incident app uses the shared controlled cancellation primitive', () => {
+  const app = readFileSync(new URL('../gauntlet/projects-depth/incident-response-controller/app.mjs', import.meta.url), 'utf8');
+  assert(app.includes('../../../scripts/gauntlet-cancellation.mjs'));
+  assert(!app.includes('setTimeout(resolve, 250)'));
+});
+
+test('the executed file independently reports the same bytes as its source and provenance', async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'canonical-incident-identity-'));
+  const owned = new OwnedProcesses();
+  try {
+    const source = path.join(scratch, 'source');
+    const project = path.join(scratch, 'gauntlet', 'projects-depth', 'fixture');
+    mkdirSync(source);
+    const app = `import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+console.log(JSON.stringify({ actual_sha256: createHash('sha256').update(readFileSync(new URL(import.meta.url))).digest('hex') }));
+`;
+    writeFileSync(path.join(source, 'app.mjs'), app);
+    writeFileSync(path.join(source, 'package.json'), '{"type":"module"}');
+    const identity = stageDepthProject(source, project, path.join(scratch, 'fixture.tgz'));
+    const { result, identity: executed } = await executeProjectApp(source, project, '/unused-test-engine', owned.start.bind(owned));
+    assert.equal(result.actual_sha256, createHash('sha256').update(app).digest('hex'));
+    assert.deepEqual(executed, identity);
+    assert.equal(executed.source_sha256, result.actual_sha256);
+    assert.equal(executed.executed_sha256, result.actual_sha256);
+    writeFileSync(path.join(project, 'app.mjs'), `${app}\n// hidden substitution\n`);
+    assert.throws(() => assertAppIdentity(source, project), /byte-identical/);
+    let launched = false;
+    await assert.rejects(executeProjectApp(source, project, '/unused', () => { launched = true; }), /byte-identical/);
+    assert.equal(launched, false);
+  } finally {
+    await owned.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+const fakeServer = () => ({
+  stdout: 'nika serve: listening http://127.0.0.1:12345\n', stderr: '',
+  child: { exitCode: null, signalCode: null }, done: new Promise(() => {}),
+});
+
+test('a listening URL with perpetually unhealthy responses never passes readiness', async () => {
+  let attempts = 0;
+  let cancelledBodies = 0;
+  await assert.rejects(waitForHealthyServer(fakeServer(), {
+    timeoutMs: 60, pollMs: 5, fetchTimeoutMs: 10,
+    fetchImpl: async () => { attempts++; return { ok: false, body: { cancel: async () => { cancelledBodies++; } } }; },
+  }), /health/);
+  assert(attempts > 0);
+  assert.equal(cancelledBodies, attempts);
+});
+
+test('a stalled health fetch is bounded and its request is aborted', async () => {
+  const signals = [];
+  await assert.rejects(waitForHealthyServer(fakeServer(), {
+    timeoutMs: 60, pollMs: 5, fetchTimeoutMs: 10,
+    fetchImpl: (_url, { signal }) => { signals.push(signal); return new Promise(() => {}); },
+  }), /health/);
+  assert(signals.length > 0);
+  assert(signals.every((signal) => signal.aborted));
+});
+
+test('readiness requires a successful health response and consumes its body', async () => {
+  let attempts = 0;
+  let bodies = 0;
+  const url = await waitForHealthyServer(fakeServer(), { timeoutMs: 500, pollMs: 1,
+    fetchImpl: async (_url, options) => {
+      assert.equal(options.redirect, 'error');
+      return { ok: ++attempts === 2, body: { cancel: async () => { bodies++; } } };
+    },
+  });
+  assert.equal(url, 'http://127.0.0.1:12345');
+  assert.equal(attempts, 2);
+  assert.equal(bodies, 2);
+});
+
+test('readiness fails immediately when the owned server exits', async () => {
+  const server = fakeServer();
+  server.done = Promise.resolve({ code: 1, signal: null, stdout: '', stderr: 'failed' });
+  server.child.exitCode = 1;
+  await assert.rejects(waitForHealthyServer(server, { fetchImpl: async () => new Promise(() => {}) }), /exited before health/);
+});
+
+test('a SIGKILL result cannot count as healthy server cleanup', async () => {
+  const signals = [];
+  await assert.rejects(stopIncidentServer({ signal: (signal) => signals.push(signal),
+    done: Promise.resolve({ code: null, signal: 'SIGKILL' }), stop: async () => {} }), /did not exit cleanly/);
+  assert.deepEqual(signals, ['SIGINT']);
+});
+
+test('failed graceful cleanup escalates and reaps an uncooperative owned process, then rejects', { timeout: 5000 }, async () => {
+  const owned = new OwnedProcesses();
+  let ready;
+  const started = new Promise((resolve) => { ready = resolve; });
+  const server = owned.start(process.execPath, ['-e',
+    "process.on('SIGINT', () => {}); process.on('SIGTERM', () => {}); console.log('ready'); setInterval(() => {}, 1000)"],
+  { timeoutMs: 3000, graceMs: 30, killMs: 1000, onStdout: () => ready() });
+  try {
+    await bounded(started, 1000, 'test child ready');
+    await assert.rejects(stopIncidentServer(server, 30), /graceful shutdown/);
+    assert.equal(server.child.signalCode, 'SIGKILL');
+    assert.throws(() => process.kill(server.child.pid, 0), (error) => error.code === 'ESRCH');
+  } finally { await owned.close(); }
+});
+
+test('shared event collection bounds both count and serialized output', async () => {
+  const client = { async *events() { for (let index = 0; index < 4; index++) yield { value: 'abc' }; } };
+  await assert.rejects(collectRunEvents(client, {}, undefined, { maxEvents: 3 }), /event output exceeded/);
+  await assert.rejects(collectRunEvents(client, {}, undefined, { maxBytes: 10 }), /event output exceeded/);
+});
+
+test.each([
+  (result) => { result.status = 'failed'; },
+  (result) => { result.outputs.plan.incident.id = 'different'; },
+  (result) => { result.outputs.plan.breached = 2; },
+  (result) => { result.outputs.completion.state = 'unfinished'; },
+  (result) => { result.outputs.plan_digest = 'not-a-digest'; },
+])('the original incident workflow output checks must pass before controlled cancellation', async (mutate) => {
+  const result = { status: 'succeeded', outputs: { plan: { incident: { id: 'inc-2042' }, breached: 3 },
+    completion: { state: 'reassessed' }, plan_digest: 'a'.repeat(64) } };
+  mutate(result);
+  const workflows = [];
+  const client = { check: async () => ({ clean: true }), run: async (workflow) => {
+    workflows.push(workflow); return { done: Promise.resolve(result) };
+  } };
+  await assert.rejects(exerciseIncident(client, { arm() { assert.fail('cancellation must not start'); } }));
+  assert.deepEqual(workflows, ['workflow.nika.yaml']);
+});

--- a/test/corpus-check-supervision.test.mjs
+++ b/test/corpus-check-supervision.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { OwnedProcesses } from '../scripts/one-door/process.mjs';
+
+const runner = new URL('../scripts/verify-gauntlet-corpus.mjs', import.meta.url).pathname;
+const repo = path.resolve(new URL('..', import.meta.url).pathname);
+
+for (const mode of ['success', 'invalid-json', 'not-ready', 'interrupted']) {
+  test(`corpus check is an isolated, supervised observation: ${mode}`, { timeout: 15_000 }, async () => {
+    const scratch = mkdtempSync(path.join(tmpdir(), 'corpus-check-owner-test-'));
+    const owned = new OwnedProcesses();
+    const marker = path.join(scratch, 'started.json');
+    const binary = path.join(scratch, 'nika');
+    const results = path.join(scratch, 'must-not-record-execution');
+    writeFileSync(binary, `#!${process.execPath}
+      const fs = require('node:fs');
+      if (process.argv[2] !== 'check') process.exit(21);
+      fs.writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ pid: process.pid,
+        cwd: process.cwd(), home: process.env.HOME, secret: process.env.NIKA_TEST_SECRET,
+        project: fs.existsSync(require('node:path').join(process.cwd(), 'nika.yaml')) }));
+      if (${JSON.stringify(mode)} === 'interrupted') {
+        process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);
+      } else if (${JSON.stringify(mode)} === 'invalid-json') console.log('{');
+      else console.log(JSON.stringify({ clean: true, paid_ready: ${mode !== 'not-ready'} }));
+    `, { mode: 0o755 });
+    try {
+      const handle = owned.start(process.execPath, [runner], { cwd: repo, timeoutMs: 10_000, graceMs: 3000,
+        env: { PATH: scratch, HOME: scratch, NIKA_BIN: binary,
+          NIKA_GAUNTLET_RESULTS_DIR: results, NIKA_TEST_SECRET: 'not-for-engine' } });
+      if (mode === 'interrupted') {
+        const until = performance.now() + 3000;
+        while (!existsSync(marker) && performance.now() < until) await new Promise((resolve) => setTimeout(resolve, 10));
+        assert(existsSync(marker));
+        handle.signal('SIGINT');
+      }
+      const result = await handle.done;
+      assert.equal(result.signal, null);
+      assert.equal(result.code, mode === 'success' ? 0 : 1, result.stderr);
+      assert.equal(result.stdout.includes('corpus-check green after owned cleanup'), mode === 'success');
+      const observation = JSON.parse(readFileSync(marker, 'utf8'));
+      assert.equal(observation.project, true, 'an explicit project root must stop ancestor discovery');
+      assert.notEqual(observation.cwd, repo);
+      assert.notEqual(observation.home, scratch);
+      assert.equal(observation.secret, undefined);
+      assert.equal(existsSync(observation.cwd), false);
+      assert.equal(existsSync(observation.home), false);
+      assert.throws(() => process.kill(observation.pid, 0), { code: 'ESRCH' });
+      assert.equal(existsSync(results), false, 'static checks must not manufacture execution evidence');
+    } finally {
+      await owned.close();
+      rmSync(scratch, { recursive: true });
+    }
+  });
+}

--- a/test/corpus-project.test.mjs
+++ b/test/corpus-project.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { stageCorpus } from '../scripts/corpus-project.mjs';
+
+const repo = path.resolve(new URL('..', import.meta.url).pathname);
+
+for (const mode of ['clean', 'undeclared-file', 'symlink-workflow']) {
+  test(`corpus staging admits only the declared regular workflows: ${mode}`, () => {
+    const scratch = mkdtempSync(path.join(tmpdir(), 'corpus-project-test-'));
+    const sourceRoot = path.join(scratch, 'source');
+    const source = path.join(sourceRoot, 'gauntlet', 'corpus');
+    cpSync(path.join(repo, 'gauntlet', 'corpus'), source, { recursive: true });
+    const first = JSON.parse(readFileSync(path.join(source, 'use-cases.json'), 'utf8'))[0].workflow;
+    try {
+      if (mode === 'undeclared-file') writeFileSync(path.join(source, 'unrelated-secret'), 'not a fixture');
+      if (mode === 'symlink-workflow') {
+        const file = path.join(source, first);
+        rmSync(file);
+        symlinkSync(path.join(repo, 'gauntlet', 'corpus', first), file);
+        assert.throws(() => stageCorpus(sourceRoot, scratch, {}), /regular file/);
+        return;
+      }
+      const staged = stageCorpus(sourceRoot, scratch, { PATH: '/test/bin', NIKA_TEST_SECRET: 'synthetic' });
+      assert.equal(readFileSync(path.join(staged.project, 'nika.yaml'), 'utf8'), 'nika: sdk-corpus\n');
+      assert.deepEqual(readdirSync(staged.project).sort(), ['nika.yaml', 'use-cases.json', 'workflows']);
+      assert.equal(existsSync(path.join(staged.project, 'unrelated-secret')), false);
+      assert.equal(staged.engineEnv.NIKA_TEST_SECRET, undefined);
+      assert.equal(staged.engineEnv.PATH, '/test/bin');
+      for (const entry of staged.inventory) {
+        assert(readFileSync(path.join(staged.project, entry.workflow)).equals(readFileSync(path.join(source, entry.workflow))));
+      }
+    } finally { rmSync(scratch, { recursive: true }); }
+  });
+}
+
+for (const [name, mutate] of [
+  ['missing-id', (rows) => { delete rows[0].id; }],
+  ['empty-actor', (rows) => { rows[0].actor = '  '; }],
+  ['numeric-trigger', (rows) => { rows[0].trigger = 7; }],
+  ['missing-domain', (rows) => {
+    const domain = rows[0].domain;
+    for (const row of rows) if (row.domain === domain) delete row.domain;
+  }],
+  ['missing-recipe', (rows) => { delete rows[0].recipe; }],
+]) {
+  test(`corpus metadata is present before any project is staged: ${name}`, () => {
+    const scratch = mkdtempSync(path.join(tmpdir(), 'corpus-metadata-test-'));
+    const sourceRoot = path.join(scratch, 'source');
+    const source = path.join(sourceRoot, 'gauntlet', 'corpus');
+    try {
+      cpSync(path.join(repo, 'gauntlet', 'corpus'), source, { recursive: true });
+      const inventoryPath = path.join(source, 'use-cases.json');
+      const rows = JSON.parse(readFileSync(inventoryPath, 'utf8'));
+      mutate(rows);
+      writeFileSync(inventoryPath, JSON.stringify(rows));
+      assert.throws(() => stageCorpus(sourceRoot, scratch, {}), /non-empty strings/);
+      assert.equal(existsSync(path.join(scratch, 'project')), false);
+      assert.equal(existsSync(path.join(scratch, 'home')), false);
+    } finally { rmSync(scratch, { recursive: true }); }
+  });
+}

--- a/test/corpus-supervision.test.mjs
+++ b/test/corpus-supervision.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { OwnedProcesses } from '../scripts/one-door/process.mjs';
+
+const runner = new URL('../scripts/execute-gauntlet-corpus.mjs', import.meta.url).pathname;
+const repo = path.resolve(new URL('..', import.meta.url).pathname);
+
+for (const mode of ['missing', 'version-failed', 'run-failed', 'invalid-json', 'success', 'interrupted']) {
+  test(`corpus owns its isolated execution and replaces stale evidence: ${mode}`, { timeout: 20_000 }, async () => {
+    const scratch = mkdtempSync(path.join(tmpdir(), 'corpus-owner-test-'));
+    const owned = new OwnedProcesses();
+    const reportPath = path.join(scratch, 'local-execution.json');
+    const marker = path.join(scratch, 'started.json');
+    const binary = path.join(scratch, 'nika');
+    writeFileSync(reportPath, '{"result":"green","old":true}');
+    writeFileSync(binary, `#!${process.execPath}
+      const fs = require('node:fs');
+      if (process.argv.includes('--version')) {
+        console.log('nika 0.118.3 (8375f17e8)');
+        process.exit(${mode === 'version-failed' ? 9 : 0});
+      }
+      if (process.argv[2] === 'key') process.exit(0);
+      fs.writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ pid: process.pid,
+        cwd: process.cwd(), home: process.env.HOME, secret: process.env.NIKA_TEST_SECRET,
+        file: process.argv[3] }));
+      if (${JSON.stringify(mode)} === 'interrupted') {
+        process.on('SIGTERM', () => {});
+        setInterval(() => {}, 1000);
+      } else if (${JSON.stringify(mode)} === 'run-failed') process.exit(17);
+      else if (${JSON.stringify(mode)} === 'invalid-json') console.log('{');
+      else console.log(JSON.stringify({ file: process.argv[3] }));
+    `, { mode: 0o755 });
+    try {
+      const handle = owned.start(process.execPath, [runner], { cwd: repo,
+        env: { PATH: scratch, HOME: scratch, NIKA_TEST_SECRET: 'must-not-reach-engine',
+          ...(mode === 'missing' ? {} : { NIKA_BIN: binary }), NIKA_GAUNTLET_RESULTS_DIR: scratch },
+        timeoutMs: 15_000, graceMs: 3000 });
+      if (mode === 'interrupted') {
+        const until = performance.now() + 4000;
+        while (!existsSync(marker) && performance.now() < until) await new Promise((resolve) => setTimeout(resolve, 10));
+        assert(existsSync(marker));
+        assert.equal(JSON.parse(readFileSync(reportPath, 'utf8')).result, 'incomplete');
+        handle.signal('SIGINT');
+      }
+      const result = await handle.done;
+      assert.equal(result.signal, null);
+      assert.equal(result.code, mode === 'success' ? 0 : 1, result.stderr);
+      const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+      assert.equal(report.result, mode === 'success' ? 'green' : 'red');
+      assert.equal(report.old, undefined);
+      if (existsSync(marker)) {
+        const observation = JSON.parse(readFileSync(marker, 'utf8'));
+        assert.notEqual(observation.cwd, repo);
+        assert.notEqual(observation.home, scratch);
+        assert.equal(observation.secret, undefined);
+        assert.equal(existsSync(observation.cwd), false, 'owned project is removed after process exit');
+        assert.equal(existsSync(observation.home), false, 'owned signing home is removed');
+        assert.throws(() => process.kill(observation.pid, 0), { code: 'ESRCH' });
+      }
+      if (mode === 'success') {
+        assert.equal(report.workflows, 100);
+        assert.equal(report.distinct_output_hashes, 100);
+      }
+    } finally {
+      await owned.close();
+      rmSync(scratch, { recursive: true });
+    }
+  });
+}

--- a/test/engine-artifact-provenance.test.mjs
+++ b/test/engine-artifact-provenance.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, truncateSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { verifyEngineArchive } from '../scripts/native-release-contract.mjs';
+
+const commit = 'a'.repeat(40);
+const asset = 'nika-macos-arm64-0.118.7.tar.gz';
+const tag = 'v0.118.7';
+
+async function fixture(body) {
+  const root = mkdtempSync(path.join(tmpdir(), 'nika-artifact-proof-'));
+  const archive = path.join(root, asset);
+  const sums = path.join(root, 'SHA256SUMS');
+  const bytes = Buffer.from('not executable: verifier tests never extract or run it');
+  const hash = createHash('sha256').update(bytes).digest('hex');
+  writeFileSync(archive, bytes);
+  writeFileSync(sums, `${hash}  ${asset}\n`);
+  const release = { tag_name: tag, draft: false, prerelease: false, published_at: '2026-09-04T20:00:00Z',
+    assets: [{ name: asset, state: 'uploaded', size: bytes.length,
+      browser_download_url: `https://github.com/supernovae-st/nika/releases/download/${tag}/${asset}` }] };
+  const calls = [];
+  const run = (command, args, options) => {
+    calls.push({ command, args, options });
+    if (args[0] === 'api') return JSON.stringify(args[1].includes('/commits/') ? { sha: commit } : release);
+    return '';
+  };
+  try { await body({ root, archive, sums, release, calls, run, hash }); }
+  finally { rmSync(root, { recursive: true, force: true }); }
+}
+
+test('native archive proof binds bytes to the exact hosted workflow, tag and source commit', async () => {
+  await fixture(async ({ archive, sums, calls, run, hash }) => {
+    assert.deepEqual(await verifyEngineArchive(archive, sums, '0.118.7', commit, run),
+      { tag, commit, asset, sha256: hash });
+    assert.deepEqual(calls.at(-1).args, ['attestation', 'verify', archive,
+      '--repo', 'supernovae-st/nika', '--cert-identity',
+      `https://github.com/supernovae-st/nika/.github/workflows/release.yml@refs/tags/${tag}`,
+      '--source-ref', `refs/tags/${tag}`, '--source-digest', commit,
+      '--predicate-type', 'https://slsa.dev/provenance/v1', '--deny-self-hosted-runners']);
+    assert(calls.every(({ command, options }) => command === 'gh' && options.timeout === 90_000));
+  });
+});
+
+test.each(['draft', 'prerelease', 'unpublished', 'wrong-tag', 'duplicate', 'size', 'source'])('archive proof refuses %s metadata before attestation', async (kind) => {
+  await fixture(async ({ archive, sums, release, run, calls }) => {
+    if (kind === 'draft') release.draft = true;
+    if (kind === 'prerelease') release.prerelease = true;
+    if (kind === 'unpublished') release.published_at = null;
+    if (kind === 'wrong-tag') release.tag_name = 'v0.118.0';
+    if (kind === 'duplicate') release.assets.push(release.assets[0]);
+    if (kind === 'size') release.assets[0].size++;
+    await assert.rejects(verifyEngineArchive(archive, sums, '0.118.7', kind === 'source' ? 'b'.repeat(40) : commit, run));
+    assert(!calls.some(({ args }) => args[0] === 'attestation'));
+  });
+});
+
+test('changed bytes, ambiguous checksums and invalid coordinates cannot reach attestation', async () => {
+  await fixture(async ({ archive, sums, run, calls, hash }) => {
+    await assert.rejects(verifyEngineArchive(archive, sums, '0.118.7+dirty', commit, run));
+    writeFileSync(sums, `${hash}  ${asset}\n${hash}  ${asset}\n`);
+    await assert.rejects(verifyEngineArchive(archive, sums, '0.118.7', commit, run), /exactly one/);
+    writeFileSync(sums, `${'b'.repeat(64)}  ${asset}\n`);
+    await assert.rejects(verifyEngineArchive(archive, sums, '0.118.7', commit, run), /digest mismatch/);
+    assert.equal(calls.length, 0);
+  });
+});
+
+test('a failed attestation is a failed proof, never an executable fallback', async () => {
+  await fixture(async ({ archive, sums, run }) => {
+    await assert.rejects(verifyEngineArchive(archive, sums, '0.118.7', commit, (command, args, options) => {
+      if (args[0] === 'attestation') throw new Error('untrusted signer');
+      return run(command, args, options);
+    }), /untrusted signer/);
+  });
+});
+
+test('oversized archives are refused before reading or invoking the verifier', async () => {
+  await fixture(async ({ archive, sums, run, calls }) => {
+    truncateSync(archive, 128 * 1024 * 1024 + 1);
+    await assert.rejects(verifyEngineArchive(archive, sums, '0.118.7', commit, run), /bounded regular/);
+    assert.equal(calls.length, 0);
+  });
+});
+
+test('a concurrent archive replacement cannot retain the earlier checksum claim', async () => {
+  await fixture(async ({ archive, sums, run }) => {
+    await assert.rejects(verifyEngineArchive(archive, sums, '0.118.7', commit, (command, args, options) => {
+      if (args[0] === 'attestation') writeFileSync(archive, 'replacement bytes');
+      return run(command, args, options);
+    }), /changed during provenance verification/);
+  });
+});
+
+test('both CI consumers and release packaging use the one strict archive verifier', () => {
+  const ci = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8');
+  const release = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
+  assert.equal(ci.match(/scripts\/verify-engine-archive\.mjs/g)?.length, 2);
+  assert.equal(release.match(/scripts\/verify-engine-archive\.mjs/g)?.length, 1);
+  assert(!`${ci}\n${release}`.includes('gh attestation verify "$asset" --repo supernovae-st/nika'));
+});

--- a/test/fixtures/fake-nika.mjs
+++ b/test/fixtures/fake-nika.mjs
@@ -147,6 +147,12 @@ if (command === 'run' && argv.includes('--json')) {
       emit({ kind: 'task_completed', sequence: index + 1, value: index });
     }
     if (workflow.includes('settled')) {
+      if (workflow.includes('recovered')) {
+        emit({ kind: 'task_failed', fields: [
+          { key: 'task', value: 'recovered' },
+          { key: 'detail', value: 'NIKA-EXEC-001 · recovered by the workflow' },
+        ] });
+      }
       // The 0.118 engine's terminal shape (ADR-128): the settlement rides
       // run_settled flattened · status · cause · elapsed_ms · tasks · spend.
       emit({

--- a/test/gauntlet-binary.test.mjs
+++ b/test/gauntlet-binary.test.mjs
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+let scratch;
+let fixture;
+let environment;
+
+beforeEach(() => {
+  scratch = mkdtempSync(path.join(tmpdir(), 'nika-gauntlet-selection-'));
+  fixture = path.join(scratch, 'nika');
+  mkdirSync(path.join(scratch, 'home'));
+  writeFileSync(fixture, `#!${process.execPath}
+import { appendFileSync } from 'node:fs';
+appendFileSync(${JSON.stringify(path.join(scratch, 'calls'))}, 'called\\n');
+if (process.argv.includes('--version')) process.stdout.write('fixture');
+else if (process.argv.includes('check')) process.stdout.write(JSON.stringify({ clean: true, paid_ready: true }));
+else process.stdout.write(JSON.stringify({ file: process.argv[3] }));
+`);
+  chmodSync(fixture, 0o755);
+  environment = { PATH: scratch, HOME: path.join(scratch, 'home'), NIKA_KEYCHAIN: 'off',
+    NIKA_TEST_MARKER: path.join(scratch, 'calls'), NIKA_GAUNTLET_RESULTS_DIR: path.join(scratch, 'results') };
+});
+
+afterEach(() => { rmSync(scratch, { recursive: true }); });
+
+describe.each(['verify-gauntlet-corpus.mjs', 'execute-gauntlet-corpus.mjs'])('%s engine selection', (script) => {
+  it.each(['legacy-only', 'path-only', 'relative', 'empty'])('refuses %s before spawning any engine', (mode) => {
+    if (mode !== 'path-only') environment.NIKA_GAUNTLET_BIN = fixture;
+    if (mode === 'relative') environment.NIKA_BIN = 'nika';
+    if (mode === 'empty') environment.NIKA_BIN = '';
+    const result = spawnSync(process.execPath, [path.join(root, 'scripts', script)], {
+      cwd: root, env: environment, encoding: 'utf8', timeout: 5000,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stderr).toContain('NIKA_BIN must name an absolute engine binary under test');
+    expect(existsSync(environment.NIKA_TEST_MARKER)).toBe(false);
+    if (script.startsWith('execute-')) {
+      const report = JSON.parse(readFileSync(path.join(environment.NIKA_GAUNTLET_RESULTS_DIR, 'local-execution.json'), 'utf8'));
+      expect(report.result).toBe('red');
+    } else expect(existsSync(environment.NIKA_GAUNTLET_RESULTS_DIR)).toBe(false);
+  });
+
+  it('uses only the explicit binary for the complete corpus', () => {
+    environment.NIKA_BIN = fixture;
+    environment.NIKA_GAUNTLET_BIN = path.join(scratch, 'retired-must-not-run');
+    const result = spawnSync(process.execPath, [path.join(root, 'scripts', script)], {
+      cwd: root, env: environment, encoding: 'utf8', timeout: 15000,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status, result.stderr).toBe(0);
+    const expected = script.startsWith('verify-') ? 100 : 102;
+    expect(readFileSync(environment.NIKA_TEST_MARKER, 'utf8').trim().split('\n')).toHaveLength(expected);
+  }, 20000);
+});

--- a/test/gauntlet-composition.test.mjs
+++ b/test/gauntlet-composition.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { exerciseIncident } from '../gauntlet/projects-depth/incident-response-controller/app.mjs';
+import { stableDepthEvidence, stableHostileEvidence } from '../scripts/verify-release-replay.mjs';
+
+test('controlled incident output satisfies the current replay judge without changing its cancellation contract', async () => {
+  const settlement = { status: 'cancelled', cause: 'operator', elapsed_ms: 9,
+    tasks: { total: 2, ok: 1, failed: 0, recovered: 0, skipped: 0, cancelled: 1, never_started: 1 },
+    spend: { pricing_as_of: null, total_cost_usd: null, qualifier: 'unmetered' } };
+  const result = { id: 'controlled-job', status: 'cancelled', settlement, receipt: { trace_id: 'controlled-trace' } };
+  const event = { kind: 'execution.settled', status: 'cancelled', settlement, receipt: result.receipt };
+  const action = Promise.resolve({ accepted: true, status: 'cancellation_requested' });
+  let release;
+  const held = new Promise((resolve) => { release = () => resolve(result); });
+  const controlled = { id: result.id, done: held };
+  const workflows = [];
+  const client = {
+    check: async () => ({ clean: true }),
+    run: async (workflow) => {
+      workflows.push(workflow);
+      if (workflow === 'controlled-cancel.nika.yaml') return controlled;
+      assert.equal(workflow, 'workflow.nika.yaml');
+      return { done: Promise.resolve({ status: 'succeeded', outputs: {
+        plan: { incident: { id: 'inc-2042' }, breached: 3 },
+        completion: { state: 'reassessed' }, plan_digest: 'a'.repeat(64),
+      } }) };
+    },
+    cancel: () => action,
+    async *events(run) { await run.done; yield structuredClone(event); },
+    attachRun: async (id) => { assert.equal(id, result.id); return controlled; },
+    traceVerify: async () => ({ verified: false, verdict: 'unavailable', reason: 'trace_journal_unavailable' }),
+  };
+  const gate = { arm() {}, arrived: Promise.resolve(), release: async () => release(),
+    finish: () => ({ requests: { hold: 1, dependent: 0 } }) };
+  const project = await exerciseIncident(client, gate);
+  assert.deepEqual(workflows, ['workflow.nika.yaml', 'controlled-cancel.nika.yaml']);
+  assert.equal(project.sse_terminal.settlement_cause, 'operator');
+  assert.equal(project.settlement.spend.pricing_as_of, null);
+  assert.doesNotThrow(() => stableDepthEvidence({ projects: [project] }));
+  const missingCause = structuredClone(project);
+  delete missingCause.sse_terminal.settlement_cause;
+  assert.throws(() => stableDepthEvidence({ projects: [missingCause] }), /exact cancellation terminal/);
+});
+
+test('main interruption evidence stays valid independently of supplementary controlled cancellation', () => {
+  const report = { schema_version: 1, engine: 'synthetic-fixture', summary: {}, result: 'green',
+    scenarios: [{ name: 'remote-durable-cancellation', result: 'green', evidence: {
+      cancel_status: 'cancellation_requested', run_status: 'interrupted',
+      events: [{ kind: 'execution.interrupted', status: 'interrupted' }],
+      controlled_cancellation: { run_status: 'cancelled', settlement: { cause: 'operator' } },
+    } }] };
+  assert.doesNotThrow(() => stableHostileEvidence(report));
+  const falseSettlement = structuredClone(report);
+  falseSettlement.scenarios[0].evidence.events[0].settlement_cause = 'operator';
+  assert.throws(() => stableHostileEvidence(falseSettlement), /exact terminal frame/);
+});

--- a/test/hostile-supervision.test.mjs
+++ b/test/hostile-supervision.test.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { OwnedProcesses, runOwnedProcess } from '../scripts/one-door/process.mjs';
+import { bounded } from '../scripts/gauntlet-cancellation.mjs';
+import { observeHostileReplay } from '../scripts/run-hostile-gauntlet.mjs';
+import { stopResident, waitForHealth } from '../scripts/one-door/resident.mjs';
+
+const never = () => new Promise(() => {});
+const gone = (pid) => assert.throws(() => process.kill(pid, 0), { code: 'ESRCH' });
+
+function replay({ events = [], done = Promise.resolve({ status: 'cancelled' }), hang = false } = {}) {
+  let closed = false;
+  let observedSignal;
+  const client = {
+    async *events(_run, { signal }) {
+      observedSignal = signal;
+      try {
+        for (const event of events) yield event;
+        if (hang && !signal.aborted) await new Promise((resolve) => signal.addEventListener('abort', resolve, { once: true }));
+      } finally { closed = true; }
+    },
+  };
+  return { client, run: { done }, get closed() { return closed; }, get signal() { return observedSignal; } };
+}
+
+test('hostile replay drains and clones bounded events on success', async () => {
+  const event = { kind: 'execution.settled', settlement: { status: 'cancelled' } };
+  const f = replay({ events: [event] });
+  const proof = await observeHostileReplay(f.client, f.run);
+  event.settlement.status = 'failed';
+  assert.equal(proof.events[0].settlement.status, 'cancelled');
+  assert.equal(proof.replayed.status, 'cancelled');
+  assert(f.closed && f.signal.aborted);
+});
+
+test('hostile replay deadline aborts and awaits a never-ending subscriber', async () => {
+  const f = replay({ hang: true, done: never() });
+  await assert.rejects(observeHostileReplay(f.client, f.run, undefined, { timeoutMs: 30 }), /cancel replay settlement exceeded/);
+  assert(f.closed && f.signal.aborted);
+});
+
+test.each([{ maxEvents: 1 }, { maxBytes: 1 }])('hostile replay caps event output and closes the observer (%j)', async (limits) => {
+  const f = replay({ events: [{ kind: 'one' }, { kind: 'two' }], hang: true, done: never() });
+  await assert.rejects(observeHostileReplay(f.client, f.run, undefined, { timeoutMs: 200, ...limits }), /run event output exceeded/);
+  assert(f.closed && f.signal.aborted);
+});
+
+test('hostile replay settlement failure aborts and awaits its subscriber', async () => {
+  const f = replay({ hang: true, done: Promise.reject(new Error('actual settlement failed')) });
+  await assert.rejects(observeHostileReplay(f.client, f.run), /actual settlement failed/);
+  assert(f.closed && f.signal.aborted);
+});
+
+test('hostile replay propagates runner abort and awaits the subscriber', async () => {
+  const abort = new AbortController();
+  const f = replay({ hang: true, done: never() });
+  const observed = observeHostileReplay(f.client, f.run, abort.signal);
+  abort.abort(new Error('runner stopped'));
+  await assert.rejects(observed, /runner stopped/);
+  assert(f.closed && f.signal.aborted);
+});
+
+test('hostile replay refuses an observer that ignores abort within a cleanup deadline', async () => {
+  const client = { events: () => ({ [Symbol.asyncIterator]: () => ({ next: never }) }) };
+  await assert.rejects(observeHostileReplay(client, { done: never() }, undefined,
+    { timeoutMs: 20, cleanupMs: 20 }), /replay observer cleanup exceeded/);
+});
+
+test.each(['hang', 'unhealthy', 'healthy'])('hostile readiness requires successful bounded health (%s)', async (mode) => {
+  let requests = 0;
+  let connection;
+  const http = createServer((_request, response) => {
+    requests++;
+    if (mode === 'unhealthy') response.writeHead(503).end('not ready');
+    if (mode === 'healthy') response.writeHead(200).end('ok');
+  });
+  http.on('connection', (socket) => { connection = socket; });
+  http.listen(0, '127.0.0.1');
+  await once(http, 'listening');
+  const handle = { child: { exitCode: null, signalCode: null }, done: never() };
+  try {
+    const check = waitForHealth(`http://127.0.0.1:${http.address().port}`, handle, undefined,
+      { timeoutMs: 100, requestMs: 25, pollMs: 5 });
+    if (mode === 'healthy') await check;
+    else await assert.rejects(check, /did not become healthy/);
+    assert(requests > 0);
+  } finally {
+    http.closeAllConnections();
+    await new Promise((resolve) => http.close(resolve));
+    assert(!connection || connection.destroyed);
+  }
+});
+
+test('hostile readiness notices an already exited server', async () => {
+  const handle = { child: { exitCode: 0, signalCode: null }, done: Promise.resolve({ code: 0 }) };
+  await assert.rejects(waitForHealth('http://127.0.0.1:1', handle), /server exited/);
+});
+
+test('hostile server close is observed even when it preceded shutdown', async () => {
+  const owned = new OwnedProcesses();
+  const handle = owned.start(process.execPath, ['-e', ''], { timeoutMs: 1000 });
+  try {
+    await handle.done;
+    await stopResident(handle, { timeoutMs: 50 });
+    gone(handle.child.pid);
+  } finally { await owned.close(); }
+});
+
+test.each([false, true])('hostile shutdown awaits TERM/KILL fallback and never greens a deadline (ignore TERM: %s)', async (ignoreTerm) => {
+  const owned = new OwnedProcesses();
+  let ready;
+  const started = new Promise((resolve) => { ready = resolve; });
+  const handle = owned.start(process.execPath, ['-e', `
+    process.on('SIGINT', () => {});
+    ${ignoreTerm ? "process.on('SIGTERM', () => {});" : ''}
+    console.log('ready'); setInterval(() => {}, 1000);
+  `], { timeoutMs: 2000, graceMs: 50, killMs: 1000, onStdout: ready });
+  try {
+    await started;
+    await assert.rejects(stopResident(handle, { timeoutMs: 30 }), /server shutdown exceeded/);
+    gone(handle.child.pid);
+    assert.equal(handle.child.signalCode, ignoreTerm ? 'SIGKILL' : 'SIGTERM');
+  } finally { await owned.close(); }
+});
+
+test('hostile owned consumer timeout reaps native-like descendants', async () => {
+  const owned = new OwnedProcesses();
+  let pids;
+  try {
+    await assert.rejects(runOwnedProcess(owned.start.bind(owned), process.execPath, ['-e', `
+      const { spawn } = require('node:child_process');
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+      process.on('SIGTERM', () => {});
+      child.on('close', () => process.exit(0));
+      console.log(JSON.stringify({ parent: process.pid, child: child.pid }));
+    `], { timeoutMs: 300, graceMs: 1000, killMs: 1000, onStdout: (chunk) => { pids = JSON.parse(chunk); } }), /timed out/);
+    gone(pids.parent);
+    gone(pids.child);
+  } finally { await owned.close(); }
+});
+
+test('hostile owned process cannot green a signal exit or excessive output', async () => {
+  const owned = new OwnedProcesses();
+  try {
+    await assert.rejects(runOwnedProcess(owned.start.bind(owned), process.execPath,
+      ['-e', "process.kill(process.pid, 'SIGKILL')"], { timeoutMs: 1000 }), /SIGKILL/);
+    await assert.rejects(runOwnedProcess(owned.start.bind(owned), process.execPath,
+      ['-e', "console.log('x'.repeat(10000))"], { timeoutMs: 1000, maxBuffer: 100 }), /exceeded/);
+  } finally { await owned.close(); }
+});
+
+test('runner interruption reaps an uncooperative build and replaces stale green with a failed proof', { timeout: 10_000 }, async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'hostile-runner-test-'));
+  const owned = new OwnedProcesses();
+  const report = path.join(scratch, 'hostile.json');
+  const marker = path.join(scratch, 'build.pid');
+  mkdirSync(path.join(scratch, 'home'));
+  writeFileSync(report, '{"result":"green"}');
+  writeFileSync(path.join(scratch, 'npm'), `#!${process.execPath}
+    import { writeFileSync } from 'node:fs';
+    process.on('SIGTERM', () => {});
+    writeFileSync(${JSON.stringify(marker)}, String(process.pid));
+    setInterval(() => {}, 1000);
+  `, { mode: 0o755 });
+  // Make the executable extensionless JavaScript unambiguously ESM.
+  writeFileSync(path.join(scratch, 'package.json'), '{"type":"module"}');
+  let retained;
+  try {
+    const handle = owned.start(process.execPath, [new URL('../scripts/run-hostile-gauntlet.mjs', import.meta.url).pathname],
+      { timeoutMs: 7000, graceMs: 2500, env: { PATH: scratch, HOME: path.join(scratch, 'home'),
+        NIKA_BIN: process.execPath, NIKA_KEYCHAIN: 'off', NIKA_GAUNTLET_RESULTS_DIR: scratch } });
+    await bounded((async () => {
+      const until = performance.now() + 1900;
+      while (!existsSync(marker) && performance.now() < until) await new Promise((resolve) => setTimeout(resolve, 10));
+      assert(existsSync(marker), 'fake build must start');
+    })(), 2000, 'fake build startup');
+    assert.equal(JSON.parse(readFileSync(report, 'utf8')).result, 'incomplete');
+    const buildPid = Number(readFileSync(marker, 'utf8'));
+    handle.signal('SIGINT');
+    const result = await handle.done;
+    retained = result.stderr.match(/hostile cleanup retained scratch: (.+)/)?.[1];
+    assert.equal(result.code, 1);
+    assert.equal(result.signal, null);
+    const proof = JSON.parse(readFileSync(report, 'utf8'));
+    assert.equal(proof.result, 'red');
+    assert.match(proof.supervision_error, /required SIGKILL/);
+    assert(retained && existsSync(retained));
+    gone(buildPid);
+    gone(handle.child.pid);
+  } finally {
+    await owned.close();
+    if (retained) rmSync(retained, { recursive: true, force: true });
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});

--- a/test/http-by-name.test.ts
+++ b/test/http-by-name.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Nika,
+  NikaEngineUnavailable,
+  NikaOperationError,
+  NikaProtocolError,
+  NikaTransportError,
+} from '../src/index.js';
+import type { NikaEvent } from '../src/index.js';
+import { resolveNikaEngine } from '../src/lib/binary/index.js';
+import { HttpTransport } from '../src/lib/http-transport.js';
+import {
+  HTTP_DEPTH_FIXTURE,
+  TOKEN_A,
+  collect,
+  healthResponse,
+  jsonResponse,
+  sseResponse,
+} from './helpers/http-depth-harness.js';
+
+// The digest is the resident's own: nothing was captured locally to bind it to.
+const RECEIPT = Object.freeze({
+  job_id: 'job-1',
+  execution_id: 'execution-1',
+  trace_id: 'trace-1',
+  snapshot_digest: 'f'.repeat(64),
+  origin: { kind: 'manual' },
+});
+
+const SETTLEMENT = Object.freeze({
+  cause: 'normal',
+  elapsed_ms: 12,
+  tasks: { total: 2, ok: 2, failed: 0, recovered: 0, skipped: 0, cancelled: 0, never_started: 0 },
+  spend: { priced_calls: 0, unpriced_calls: 0, qualifier: 'unmetered' },
+});
+
+const ACK = Object.freeze({
+  status: 'accepted',
+  snapshot_digest: 'f'.repeat(64),
+  root: 'daily.nika.yaml',
+  units: 3,
+});
+
+const NOT_FOUND = Object.freeze({
+  code: 'not_found',
+  message: 'no workflow by that name under the served registry, '
+    + 'GET /v1/workflows lists the names this resident admits',
+});
+
+/** A client built from `url` and `token` alone: no `bin`, so no local engine is reachable. */
+function remote(fetch: ReturnType<typeof vi.fn>): Nika {
+  return new Nika({
+    url: 'https://nika.example',
+    token: TOKEN_A,
+    fetch: fetch as typeof globalThis.fetch,
+  });
+}
+
+function transport(
+  fetch: ReturnType<typeof vi.fn>,
+  resolveEngine: () => ReturnType<typeof resolveNikaEngine>,
+): HttpTransport {
+  return new HttpTransport({
+    url: 'https://nika.example',
+    token: TOKEN_A,
+    fetch: fetch as typeof globalThis.fetch,
+    requestTimeout: 1_000,
+    machineBufferBytes: 64 * 1024,
+    resolveEngine,
+    retryDelay: async () => {},
+  });
+}
+
+function request(
+  fetch: ReturnType<typeof vi.fn>,
+  index: number,
+): { url: string; init: RequestInit } {
+  const [url, init] = fetch.mock.calls[index] as [string, RequestInit];
+  return { url: String(url), init };
+}
+
+async function failure(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (cause) {
+    return cause;
+  }
+  throw new Error('expected a refusal');
+}
+
+describe('run by served name (ADR-131)', () => {
+  it('posts {"workflow"} to /v1/jobs and settles from the stream without a local engine', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'queued' }, 202))
+      .mockResolvedValueOnce(sseResponse([
+        { sequence: 1, kind: 'execution.started', status: 'running' },
+        {
+          sequence: 2,
+          kind: 'execution.completed',
+          status: 'succeeded',
+          outputs: { answer: 42 },
+          receipt: RECEIPT,
+        },
+      ]));
+    const nika = remote(fetch);
+    const run = await nika.run('daily.nika.yaml', { idempotencyKey: 'daily-2026-09-04' });
+    expect(run.id).toBe('job-1');
+
+    const { url, init } = request(fetch, 1);
+    expect(url).toBe('https://nika.example/v1/jobs');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('{"workflow":"daily.nika.yaml"}');
+    const headers = new Headers(init.headers);
+    expect(headers.get('Idempotency-Key')).toBe('daily-2026-09-04');
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get('Authorization')).toBe(`Bearer ${TOKEN_A}`);
+
+    await expect(collect(nika.events(run))).resolves.toHaveLength(2);
+    await expect(run.done).resolves.toEqual({
+      id: 'job-1',
+      status: 'succeeded',
+      transport: 'http',
+      execution_id: 'execution-1',
+      trace_id: 'trace-1',
+      outputs: { answer: 42 },
+      receipt: RECEIPT,
+    });
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch.mock.calls.some(([called]) => String(called).includes('/v1/workflows'))).toBe(false);
+  });
+
+  it('generates one idempotency key when the caller omits it', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'queued' }, 202))
+      .mockResolvedValueOnce(sseResponse([
+        { sequence: 1, kind: 'execution.settled', status: 'succeeded', receipt: RECEIPT },
+      ]));
+    const run = await remote(fetch).run('daily.nika.yaml');
+    const key = new Headers(request(fetch, 1).init.headers).get('Idempotency-Key');
+    expect(key).toMatch(/^[0-9a-f-]{36}$/);
+    await expect(run.done).resolves.toMatchObject({ status: 'succeeded' });
+  });
+
+  it('carries the settlement the resident nests on the terminal frame', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'queued' }, 202))
+      .mockResolvedValueOnce(sseResponse([{
+        sequence: 1,
+        kind: 'execution.settled',
+        status: 'succeeded',
+        receipt: RECEIPT,
+        settlement: SETTLEMENT,
+      }]));
+    const run = await remote(fetch).run('daily.nika.yaml');
+    const result = await run.done;
+    expect(result.status).toBe('succeeded');
+    expect(result.settlement).toEqual(SETTLEMENT);
+  });
+
+  it('refuses a settlement that is not an object', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'queued' }, 202))
+      .mockResolvedValueOnce(sseResponse([{
+        sequence: 1,
+        kind: 'execution.settled',
+        status: 'succeeded',
+        receipt: RECEIPT,
+        settlement: 'private',
+      } as unknown as NikaEvent]));
+    const run = await remote(fetch).run('daily.nika.yaml');
+    await expect(run.done).rejects.toBeInstanceOf(NikaProtocolError);
+  });
+
+  it('accepts an idempotent replay (200) as the run for that job', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'queued' }, 200))
+      .mockResolvedValueOnce(sseResponse([
+        { sequence: 1, kind: 'execution.settled', status: 'succeeded', receipt: RECEIPT },
+      ]));
+    const run = await remote(fetch).run('daily.nika.yaml', { idempotencyKey: 'same-key' });
+    expect(run.id).toBe('job-1');
+    await expect(run.done).resolves.toMatchObject({ id: 'job-1', status: 'succeeded' });
+  });
+
+  it('rejects an unknown name with the typed not_found refusal', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ error: NOT_FOUND }, 404));
+    const refused = await failure(remote(fetch).run('missing.nika.yaml'));
+    expect(refused).toBeInstanceOf(NikaOperationError);
+    expect(refused).toMatchObject({
+      operation: 'run',
+      transport: 'http',
+      code: 'not_found',
+      machineCode: 'not_found',
+      status: 404,
+    });
+    expect(String(refused)).toContain('GET /v1/workflows');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the run option gap and the idempotency key rule ahead of any request', async () => {
+    const fetch = vi.fn();
+    const nika = remote(fetch);
+    for (const options of [{ vars: { x: 1 } }, { model: 'mock/echo' }, { maxCostUsd: 1 }]) {
+      await expect(nika.run('daily.nika.yaml', options))
+        .rejects.toMatchObject({ name: 'NikaCompatibilityError', capability: 'runOptions' });
+    }
+    await expect(nika.run('daily.nika.yaml', { idempotencyKey: '' }))
+      .rejects.toBeInstanceOf(NikaTransportError);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('check by served name (ADR-131)', () => {
+  it('returns the resident acknowledgement with clean: true and nothing invented', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(ACK));
+    const report = await remote(fetch).check('daily.nika.yaml');
+    expect(report).toEqual({ clean: true, ...ACK });
+    expect(report).not.toHaveProperty('report_version');
+    expect(report).not.toHaveProperty('findings');
+    expect(report).not.toHaveProperty('exitCode');
+    const { url, init } = request(fetch, 1);
+    expect(url).toBe('https://nika.example/v1/check');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('{"workflow":"daily.nika.yaml"}');
+    expect(new Headers(init.headers).has('Idempotency-Key')).toBe(false);
+  });
+
+  it.each([
+    ['a 422 with a message', 422, { code: 'malformed_snapshot', message: 'x' }],
+    ['a 422 with an empty valid message', 422, { code: 'NIKA-AUTH-006', message: '' }],
+    ['a 404 for a name the registry does not list', 404, NOT_FOUND],
+  ])('returns %s as a red result', async (_name, status, error) => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ error }, status));
+    await expect(remote(fetch).check('daily.nika.yaml'))
+      .resolves.toEqual({ clean: false, error });
+  });
+
+  it.each([
+    { error: { code: 'NIKA-AUTH-006' } },
+    { error: { code: 'NIKA-AUTH-006', message: null } },
+    { error: { code: 'NIKA-AUTH-006', message: 'refused', extra: true } },
+    { error: { code: 'NIKA-AUTH-006', message: 'refused' }, extra: true },
+  ])('rejects a malformed workflow refusal instead of returning a red check', async (body) => {
+    for (const status of [404, 422]) {
+      const fetch = vi.fn().mockResolvedValueOnce(healthResponse())
+        .mockResolvedValueOnce(jsonResponse(body, status));
+      await expect(remote(fetch).check('daily.nika.yaml'))
+        .rejects.toBeInstanceOf(NikaTransportError);
+    }
+  });
+
+  it('still throws when the refusal judges the request, not the workflow', async () => {
+    const unauthorized = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(
+        { error: { code: 'unauthorized', message: 'authentication required' } },
+        401,
+      ));
+    await expect(remote(unauthorized).check('daily.nika.yaml')).rejects.toMatchObject({
+      name: 'NikaOperationError',
+      operation: 'check',
+      code: 'unauthorized',
+      machineCode: 'unauthorized',
+      status: 401,
+    });
+    const untyped = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(new Response(`reflected ${TOKEN_A}`, { status: 503 }));
+    const failed = await failure(remote(untyped).check('daily.nika.yaml'));
+    expect(failed).toBeInstanceOf(NikaTransportError);
+    expect(String(failed)).toContain('[REDACTED]');
+    expect(String(failed)).not.toContain(TOKEN_A);
+  });
+
+  it.each([
+    ['an unknown field', { ...ACK, path: '/private/daily.nika.yaml' }],
+    ['a status other than accepted', { ...ACK, status: 'rejected' }],
+    ['a digest that is not canonical', { ...ACK, snapshot_digest: 'short' }],
+    ['a unit count below one', { ...ACK, units: 0 }],
+    ['an empty root', { ...ACK, root: '' }],
+  ])('refuses an acknowledgement with %s', async (_name, body) => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse(body));
+    await expect(remote(fetch).check('daily.nika.yaml'))
+      .rejects.toBeInstanceOf(NikaProtocolError);
+  });
+
+  it('keeps the check option gap ahead of any request', async () => {
+    const fetch = vi.fn();
+    await expect(remote(fetch).check('daily.nika.yaml', { model: 'mock/echo' }))
+      .rejects.toMatchObject({ capability: 'checkOptions', transport: 'http' });
+    await expect(remote(fetch).check('daily.nika.yaml', { nativeStrict: true }))
+      .rejects.toMatchObject({ capability: 'checkOptions', transport: 'http' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('the local capture path is unchanged', () => {
+  it('captures a local path through the local engine and posts the snapshot bytes', async () => {
+    const resolveEngine = vi.fn(() => resolveNikaEngine(HTTP_DEPTH_FIXTURE));
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'job-1', status: 'queued' }, 202))
+      .mockResolvedValueOnce(sseResponse([{
+        sequence: 1,
+        kind: 'execution.settled',
+        status: 'succeeded',
+        receipt: { ...RECEIPT, snapshot_digest: 'a'.repeat(64) },
+      }]));
+    const source = await transport(fetch, resolveEngine).startRun('./flow.nika.yaml', {});
+    expect(resolveEngine).toHaveBeenCalledTimes(1);
+    const body = String(request(fetch, 1).init.body);
+    expect(JSON.parse(body)).toMatchObject({ format_version: 1, digest: 'a'.repeat(64) });
+    expect(body).not.toContain('"workflow"');
+    // A transport run is observed by iterating its events; the facade does this eagerly.
+    await expect(collect(source.events)).resolves.toHaveLength(1);
+    await expect(source.done).resolves.toMatchObject({ status: 'succeeded' });
+  });
+
+  it.each([
+    ['a relative path', './flow.nika.yaml'],
+    ['a parent path', '../flow.nika.yaml'],
+    ['an absolute path', '/srv/flow.nika.yaml'],
+    ['a backslash path', 'dir\\flow.nika.yaml'],
+    ['a name without the extension', 'flow.yaml'],
+  ])('routes %s to the local engine, never to the by-name door', async (_name, workflow) => {
+    const fetch = vi.fn();
+    const unavailable = () => {
+      throw new NikaEngineUnavailable('darwin', 'arm64', '@supernovae-st/nika-darwin-arm64');
+    };
+    await expect(transport(fetch, unavailable).startRun(workflow, {}))
+      .rejects.toBeInstanceOf(NikaEngineUnavailable);
+    await expect(transport(fetch, unavailable).check(workflow, {}))
+      .rejects.toBeInstanceOf(NikaEngineUnavailable);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([['flow.nika.yaml'], ['nested/daily.nika.yaml']])(
+    'submits %s by name without resolving an engine',
+    async (workflow) => {
+      const resolveEngine = vi.fn(() => {
+        throw new Error('the local engine must not be touched on the by-name path');
+      });
+      const fetch = vi.fn()
+        .mockResolvedValueOnce(healthResponse())
+        .mockResolvedValueOnce(jsonResponse({ ...ACK, root: workflow }));
+      await expect(transport(fetch, resolveEngine).check(workflow, {}))
+        .resolves.toMatchObject({ clean: true, root: workflow });
+      expect(resolveEngine).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/test/http-depth-contract.test.ts
+++ b/test/http-depth-contract.test.ts
@@ -341,14 +341,15 @@ describe('cross-client concurrency contracts', () => {
       const firstClient = client(fetch as typeof globalThis.fetch, TOKEN_A, fixtureA.bin);
       const replayClient = client(fetch as typeof globalThis.fetch, TOKEN_A, fixtureA.bin);
       const conflictClient = client(fetch as typeof globalThis.fetch, TOKEN_A, fixtureB.bin);
-      const first = await firstClient.run('flow.nika.yaml', { idempotencyKey: 'shared-key' });
-      const replay = await replayClient.run('flow.nika.yaml', { idempotencyKey: 'shared-key' });
+      // Local paths: each client captures its own snapshot bytes, which the key binds.
+      const first = await firstClient.run('./flow.nika.yaml', { idempotencyKey: 'shared-key' });
+      const replay = await replayClient.run('./flow.nika.yaml', { idempotencyKey: 'shared-key' });
       expect(first.id).toBe(replay.id);
       await expect(Promise.all([first.done, replay.done])).resolves.toEqual([
         expect.objectContaining({ id: 'job-shared', status: 'succeeded' }),
         expect.objectContaining({ id: 'job-shared', status: 'succeeded' }),
       ]);
-      await expect(conflictClient.run('flow.nika.yaml', {
+      await expect(conflictClient.run('./flow.nika.yaml', {
         idempotencyKey: 'shared-key',
       })).rejects.toMatchObject({
         name: 'NikaOperationError',

--- a/test/http-depth-lifecycle.test.ts
+++ b/test/http-depth-lifecycle.test.ts
@@ -26,6 +26,13 @@ const RECEIPT = Object.freeze({
   origin: { kind: 'manual' },
 });
 
+const SETTLEMENT = Object.freeze({
+  cause: 'normal',
+  elapsed_ms: 12,
+  tasks: { total: 1, ok: 1 },
+  spend: { qualifier: 'unmetered' },
+});
+
 const SCHEDULE_ORIGIN = Object.freeze({
   kind: 'schedule',
   schedule_origin: 'api',
@@ -164,6 +171,42 @@ describe('independent event observers', () => {
 });
 
 describe('SSE replay, reconnect, and terminal authority', () => {
+  it.each([{ status: 'failed' }, { error: 'invalid' }, { tasks: [] }])(
+    'refuses malformed durable settlement %j before reattachment', async (settlement) => {
+      const fetch = vi.fn().mockResolvedValueOnce(healthResponse()).mockResolvedValueOnce(jsonResponse({
+        id: 'job-1', status: 'succeeded', settlement,
+      }));
+      await expect(client(fetch as typeof globalThis.fetch).attachRun('job-1'))
+        .rejects.toBeInstanceOf(NikaProtocolError);
+    },
+  );
+
+  it('a human pause settles this observation leg without answering the gate', async () => {
+    const settlement = { ...SETTLEMENT, status: 'paused', cause: 'human_gate' };
+    const fetch = admissionThen(sseResponse([{
+      sequence: 1, kind: 'execution.settled', status: 'paused', settlement, receipt: RECEIPT,
+    }]));
+    const nika = client(fetch as typeof globalThis.fetch);
+    const run = await nika.run('gate.nika.yaml');
+    await expect(run.done).resolves.toMatchObject({ status: 'paused', settlement });
+  });
+  it('reattaches a paused settlement at its terminal cursor without inventing a resumed result', async () => {
+    const settlement = { ...SETTLEMENT, status: 'paused', cause: 'human_gate' };
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const path = new URL(String(input)).pathname;
+      if (path === '/health') return healthResponse();
+      if (path === '/v1/jobs/job-1') return jsonResponse({
+        id: 'job-1', status: 'paused', settlement, receipt: RECEIPT,
+      });
+      if (path.endsWith('/events')) return sseResponse([]);
+      throw new Error(`unexpected ${path}`);
+    });
+    const nika = client(fetch as typeof globalThis.fetch);
+    const run = await nika.attachRun('job-1', { lastEventId: 1 });
+    await expect(run.done).resolves.toMatchObject({ status: 'paused', settlement, receipt: RECEIPT });
+    await expect(collect(nika.events(run))).resolves.toEqual([]);
+  });
+
   it('drops an exact duplicate replay and reconnects from the last accepted sequence', async () => {
     const running = { sequence: 1, kind: 'running', status: 'running' } as const;
     const fetch = admissionThen(
@@ -242,6 +285,27 @@ describe('SSE replay, reconnect, and terminal authority', () => {
     });
   });
 
+  it('preserves the runtime settlement when SSE ends before the terminal frame', async () => {
+    const fetch = admissionThen(sseText(''), jsonResponse({
+      id: 'job-1', status: 'succeeded', receipt: RECEIPT, settlement: SETTLEMENT,
+    }));
+    const source = await transport(fetch as typeof globalThis.fetch).startRun('flow.nika.yaml', {});
+    await expect(collect(source.events)).resolves.toEqual([]);
+    await expect(source.done).resolves.toMatchObject({ settlement: SETTLEMENT });
+  });
+
+  it('reattaches past the terminal cursor without losing the stored settlement', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(healthResponse())
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'job-1', status: 'succeeded', receipt: RECEIPT, settlement: SETTLEMENT,
+      }))
+      .mockResolvedValueOnce(sseText(''));
+    const nika = client(fetch as typeof globalThis.fetch);
+    const run = await nika.attachRun('job-1', { lastEventId: 2 });
+    await expect(run.done).resolves.toMatchObject({ settlement: SETTLEMENT });
+  });
+
   it('bounds durable JSON inspected during reconnect', async () => {
     const fetch = admissionThen(
       sseText(''),
@@ -268,6 +332,86 @@ describe('SSE replay, reconnect, and terminal authority', () => {
 });
 
 describe('cancellation and terminal identity', () => {
+  it('allows retry after a refused cancel without abandoning observation', async () => {
+    const stream = controlledByteStream();
+    let cancellations = 0;
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const path = new URL(String(input)).pathname;
+      if (path === '/health') return healthResponse();
+      if (path === '/v1/jobs') return jsonResponse({ id: 'job-1', status: 'queued' }, 202);
+      if (path.endsWith('/events')) return stream.response;
+      if (path.endsWith('/cancel')) {
+        cancellations += 1;
+        return cancellations === 1
+          ? jsonResponse({ error: { code: 'store_busy', message: 'retry the action' } }, 503)
+          : jsonResponse({ id: 'job-1', status: 'running' }, 202);
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const nika = client(fetch as typeof globalThis.fetch);
+    const run = await nika.run('flow.nika.yaml');
+    await expect(nika.cancel(run)).rejects.toThrow();
+    try {
+      await expect(nika.cancel(run)).resolves.toMatchObject({ status: 'cancellation_requested' });
+      expect(cancellations).toBe(2);
+    } finally {
+      stream.enqueue(sseFrame({ sequence: 1, kind: 'execution.settled', status: 'succeeded', receipt: RECEIPT }));
+      stream.close();
+      await expect(run.done).resolves.toMatchObject({ status: 'succeeded' });
+    }
+  });
+
+  it.each(['succeeded', 'failed', 'cancelled', 'interrupted'] as const)(
+    'an accepted cancel request waits for the actual %s result', async (status) => {
+      const stream = controlledByteStream();
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const path = new URL(String(input)).pathname;
+        if (path === '/health') return healthResponse();
+        if (path === '/v1/jobs') return jsonResponse({ id: 'job-1', status: 'queued' }, 202);
+        if (path.endsWith('/events')) return stream.response;
+        if (path.endsWith('/cancel')) return jsonResponse({ id: 'job-1', status: 'running' }, 202);
+        throw new Error(`unexpected ${path}`);
+      });
+      const nika = client(fetch as typeof globalThis.fetch);
+      const run = await nika.run('flow.nika.yaml');
+      let settled = false;
+      void run.done.then(() => { settled = true; });
+      await expect(nika.cancel(run)).resolves.toMatchObject({
+        accepted: true, status: 'cancellation_requested', transport: 'http',
+      });
+      expect(settled).toBe(false);
+      stream.enqueue(sseFrame({ sequence: 1, kind: 'execution.settled', status, receipt: RECEIPT }));
+      stream.close();
+      await expect(run.done).resolves.toMatchObject({ status, receipt: RECEIPT });
+    },
+  );
+
+  it('keeps a 202 paused acknowledgement separate from its later execution result', async () => {
+    const stream = controlledByteStream();
+    const paused = { ...SETTLEMENT, status: 'paused', cause: 'human_gate' };
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const path = new URL(String(input)).pathname;
+      if (path === '/health') return healthResponse();
+      if (path === '/v1/jobs') return jsonResponse({ id: 'job-1', status: 'queued' }, 202);
+      if (path.endsWith('/events')) return stream.response;
+      if (path.endsWith('/cancel')) return jsonResponse({ id: 'job-1', status: 'paused', settlement: paused }, 202);
+      throw new Error(`unexpected ${path}`);
+    });
+    const nika = client(fetch as typeof globalThis.fetch);
+    const run = await nika.run('flow.nika.yaml');
+    let settled = false;
+    void run.done.then(() => { settled = true; });
+    try {
+      await expect(nika.cancel(run)).resolves.toMatchObject({ accepted: true, status: 'cancellation_requested' });
+      expect(settled).toBe(false);
+    } finally {
+      stream.enqueue(sseFrame({ sequence: 1, kind: 'execution.settled', status: 'succeeded',
+        settlement: SETTLEMENT, receipt: RECEIPT }));
+      stream.close();
+    }
+    await expect(run.done).resolves.toMatchObject({ status: 'succeeded', settlement: SETTLEMENT });
+  });
+
   it('delivers one terminal cancellation event before closing active observers', async () => {
     const stream = controlledByteStream();
     const terminal = {
@@ -349,6 +493,7 @@ describe('cancellation and terminal identity', () => {
       status: 'succeeded',
       receipt: RECEIPT,
       outputs: { replayed: true },
+      settlement: SETTLEMENT,
     } as const;
     const fetch = vi.fn(async (input: string | URL | Request) => {
       const path = new URL(String(input)).pathname;
@@ -360,6 +505,7 @@ describe('cancellation and terminal identity', () => {
           execution_id: 'execution-1',
           trace_id: 'trace-1',
           outputs: { replayed: true },
+          settlement: SETTLEMENT,
           receipt: RECEIPT,
         });
       }
@@ -373,6 +519,7 @@ describe('cancellation and terminal identity', () => {
       id: 'job-1',
       status: 'succeeded',
       outputs: { replayed: true },
+      settlement: SETTLEMENT,
       receipt: RECEIPT,
     });
     await expect(collect(nika.events(run))).resolves.toEqual([terminal]);
@@ -580,7 +727,8 @@ describe('cancellation and terminal identity', () => {
       receipt: { ...RECEIPT, snapshot_digest: 'b'.repeat(64) },
     }]));
     const nika = client(fetch as typeof globalThis.fetch);
-    const run = await nika.run('flow.nika.yaml');
+    // A local path is captured here, so the admission digest is known and bound.
+    const run = await nika.run('./flow.nika.yaml');
     await expect(run.done).rejects.toBeInstanceOf(NikaProtocolError);
   });
 

--- a/test/http-sse.test.ts
+++ b/test/http-sse.test.ts
@@ -446,7 +446,8 @@ describe('HTTP engine resolution boundary', () => {
     const transport = lazyTransport(fetch, resolveEngine);
     await expect(transport.listWorkflows()).resolves.toEqual(['flow.nika.yaml']);
     expect(resolveEngine).not.toHaveBeenCalled();
-    await expect(transport.check('flow.nika.yaml', {}))
+    // A local path is caller-owned source: only that capture resolves the engine.
+    await expect(transport.check('./flow.nika.yaml', {}))
       .resolves.toMatchObject({ clean: true });
     expect(resolveEngine).toHaveBeenCalledTimes(1);
   });
@@ -456,9 +457,9 @@ describe('HTTP engine resolution boundary', () => {
     const transport = lazyTransport(fetch, () => {
       throw new NikaEngineUnavailable('darwin', 'arm64', '@supernovae-st/nika-darwin-arm64');
     });
-    await expect(transport.check('flow.nika.yaml', {}))
+    await expect(transport.check('./flow.nika.yaml', {}))
       .rejects.toBeInstanceOf(NikaEngineUnavailable);
-    await expect(transport.startRun('flow.nika.yaml', {}))
+    await expect(transport.startRun('./flow.nika.yaml', {}))
       .rejects.toBeInstanceOf(NikaEngineUnavailable);
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/test/native-failure-error.test.ts
+++ b/test/native-failure-error.test.ts
@@ -11,6 +11,20 @@ const FIXTURE = path.join(
 );
 
 describe('a failed native run carries the engine failure', () => {
+  it('a successful current settlement clears an earlier handled task error', async () => {
+    const nika = new Nika({ bin: FIXTURE });
+    const run = await nika.run('recovered-settled.nika.yaml');
+    const result = await run.done;
+    expect(result.status).toBe('succeeded');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('the resident error retains the runtime failing task', () => {
+    const error = { code: 'NIKA-EXEC-001', message: 'failed', task: 'build' };
+    expect(eventError({ kind: 'execution.settled', status: 'failed',
+      code: error.code, message: error.message, settlement: { error },
+    })).toEqual(error);
+  });
   it('reads the code, message and task from a task_failed frame', () => {
     expect(eventError({
       kind: 'task_failed',

--- a/test/npm-publication.test.mjs
+++ b/test/npm-publication.test.mjs
@@ -1,0 +1,111 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test, vi } from 'vitest';
+import { assertAbsent, publishExact } from '../scripts/npm-publication.mjs';
+
+const name = '@supernovae-st/nika-client';
+const version = '0.118.7';
+const bytes = Buffer.from('prepared immutable tarball');
+const integrity = `sha512-${createHash('sha512').update(bytes).digest('base64')}`;
+const tarball = 'https://registry.npmjs.org/@supernovae-st/nika-client/-/nika-client-0.118.7.tgz';
+const directories = [];
+afterEach(async () => { await Promise.all(directories.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))); });
+
+async function fixture() {
+  const dir = await mkdtemp(path.join(tmpdir(), 'nika-npm-proof-'));
+  directories.push(dir);
+  const file = path.join(dir, 'candidate.tgz');
+  await writeFile(file, bytes);
+  return file;
+}
+function metadata(overrides = {}) { return Response.json({ name, version, dist: { integrity, tarball }, ...overrides }); }
+function absent() { return Response.json({ error: 'Not found' }, { status: 404 }); }
+function registry(...responses) {
+  return vi.fn(async (_url, options) => {
+    expect(options.redirect).toBe('error');
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    if (!responses.length) throw new Error('unexpected registry read');
+    return responses.shift();
+  });
+}
+
+test('only explicit registry 404 proves absence', async () => {
+  await expect(assertAbsent(name, version, registry(absent()))).resolves.toBeUndefined();
+  await expect(assertAbsent(name, version, registry(metadata()))).rejects.toThrow('already exists');
+});
+
+test.each([401, 403, 429, 500, 503])('registry HTTP %i cannot become absence or authorize a publish', async (status) => {
+  const fetch = registry(new Response('unavailable', { status }));
+  const run = vi.fn();
+  await expect(publishExact(name, version, await fixture(), { fetch, run })).rejects.toThrow(`HTTP ${status}`);
+  expect(run).not.toHaveBeenCalled();
+});
+
+test('network refusal and malformed metadata remain failures', async () => {
+  await expect(assertAbsent(name, version, vi.fn().mockRejectedValue(new Error('offline')))).rejects.toThrow('offline');
+  await expect(assertAbsent(name, version, registry(new Response('not json')))).rejects.toThrow();
+});
+
+test('identical occupied bytes are independently downloaded and never republished', async () => {
+  const fetch = registry(metadata(), new Response(bytes));
+  const run = vi.fn();
+  await expect(publishExact(name, version, await fixture(), { fetch, run })).resolves.toEqual({ published: false, integrity });
+  expect(fetch.mock.calls[1][0]).toBe(tarball);
+  expect(run).not.toHaveBeenCalled();
+});
+
+test.each(['integrity', 'bytes', 'identity', 'redirect-target'])('occupied %s disagreement refuses without publishing', async (kind) => {
+  const dist = { integrity, tarball };
+  if (kind === 'integrity') dist.integrity = 'sha512-different';
+  if (kind === 'redirect-target') dist.tarball = 'https://example.com/package.tgz';
+  const fetch = registry(metadata({ dist, ...(kind === 'identity' ? { version: '0.118.0' } : {}) }), new Response('different bytes'));
+  const run = vi.fn();
+  await expect(publishExact(name, version, await fixture(), { fetch, run })).rejects.toThrow();
+  expect(run).not.toHaveBeenCalled();
+});
+
+test('absent version publishes the explicit prepared archive once then proves public bytes', async () => {
+  const file = await fixture();
+  const fetch = registry(absent(), metadata(), new Response(bytes));
+  const run = vi.fn();
+  await expect(publishExact(name, version, file, { fetch, run })).resolves.toEqual({ published: true, integrity });
+  expect(run).toHaveBeenCalledExactlyOnceWith('npm', ['publish', file, '--access', 'public', '--provenance', '--ignore-scripts', '--registry=https://registry.npmjs.org'], expect.objectContaining({ timeout: 180_000, killSignal: 'SIGKILL' }));
+});
+
+test('publication refusal is not followed by a success claim', async () => {
+  const fetch = registry(absent());
+  const run = vi.fn(() => { throw new Error('publish refused'); });
+  await expect(publishExact(name, version, await fixture(), { fetch, run })).rejects.toThrow('publish refused');
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test('success exit with absent public bytes is still a failed release', async () => {
+  await expect(publishExact(name, version, await fixture(), { fetch: registry(absent(), absent()), run: vi.fn() })).rejects.toThrow('not observable');
+});
+
+test('prepared bytes changing during publication cannot be accepted', async () => {
+  const file = await fixture();
+  const run = vi.fn(async () => { await writeFile(file, 'changed'); });
+  await expect(publishExact(name, version, file, { fetch: registry(absent(), metadata(), new Response(bytes)), run })).rejects.toThrow('changed');
+});
+
+test('untrusted coordinates, symlinks and oversized bodies refuse', async () => {
+  const fetch = registry(metadata());
+  await expect(assertAbsent('@other/package', version, fetch)).rejects.toThrow('coordinate');
+  await expect(assertAbsent(name, '01.118.1', fetch)).rejects.toThrow('coordinate');
+  expect(fetch).not.toHaveBeenCalled();
+  const file = await fixture();
+  await symlink(file, `${file}.link`);
+  await expect(publishExact(name, version, `${file}.link`, { fetch, run: vi.fn() })).rejects.toThrow('regular');
+  await expect(assertAbsent(name, version, registry(new Response('x', { headers: { 'content-length': '1048577' } })))).rejects.toThrow('limit');
+});
+
+test('both workflow decisions share the fail-closed npm owner', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
+  expect(workflow).toContain('node scripts/npm-publication.mjs assert-absent "$package_name" "$VERSION"');
+  expect(workflow).toContain('node scripts/npm-publication.mjs publish "$pkg" "$VERSION" "$tarball"');
+  expect(workflow).not.toContain('npm view "$pkg@$VERSION" version');
+  expect(workflow).not.toContain('npm view "$package_name@$VERSION" version');
+});

--- a/test/old-gauntlet-cancellation.test.mjs
+++ b/test/old-gauntlet-cancellation.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { cancelHeldRun } from '../scripts/gauntlet-cancellation.mjs';
+
+function fixture({ resultChange, eventChange, actionStatus = 'cancellation_requested', arrivalError } = {}) {
+  const order = [];
+  const settlement = { status: 'cancelled', cause: 'operator', elapsed_ms: 31,
+    tasks: { total: 2, ok: 1, failed: 0, recovered: 0, skipped: 0, cancelled: 1, never_started: 1 },
+    spend: { total_cost_usd: null, priced_calls: 0, unpriced_calls: 0, qualifier: 'unmetered' } };
+  const result = { id: 'same-run', status: 'cancelled', settlement };
+  const event = { kind: 'execution.settled', status: 'cancelled', settlement: structuredClone(settlement) };
+  resultChange?.(result);
+  eventChange?.(event);
+  let release;
+  const held = new Promise((resolve) => { release = resolve; });
+  const run = { id: 'same-run', done: held.then(() => result) };
+  const gate = {
+    arrived: arrivalError ? Promise.reject(new Error('rendezvous missing')) : Promise.resolve(),
+    async release() { order.push('release'); release(); },
+    finish() { order.push('finish'); return { requests: { hold: 1, dependent: 0 } }; },
+  };
+  const action = Promise.resolve({ accepted: true, status: actionStatus });
+  const client = {
+    cancel() { order.push('cancel'); return action; },
+    async *events(_run, { signal }) {
+      await new Promise((resolve) => {
+        const aborted = () => resolve();
+        signal.addEventListener('abort', aborted, { once: true });
+        held.then(() => { signal.removeEventListener('abort', aborted); resolve(); });
+        if (signal.aborted) aborted();
+      });
+      if (!signal.aborted) yield event;
+    },
+  };
+  return { client, run, gate, order };
+}
+
+test('older gauntlets acknowledge the action before releasing a real held task', async () => {
+  const f = fixture();
+  const proof = await cancelHeldRun(f.client, f.run, f.gate);
+  assert.deepEqual(f.order, ['cancel', 'cancel', 'release', 'finish']);
+  assert.equal(proof.result.status, 'cancelled');
+  assert.equal(proof.cancellation.status, 'cancellation_requested');
+  assert.equal(proof.events.at(-1).settlement.elapsed_ms, 31);
+});
+
+test.each(['succeeded', 'failed'])('older gauntlets reject fabricated cancellation over an actual %s event', async (status) => {
+  const f = fixture({ eventChange(event) { event.status = status; event.settlement.status = status; } });
+  await assert.rejects(cancelHeldRun(f.client, f.run, f.gate), /same-job/);
+});
+
+test.each([
+  (result) => { delete result.settlement; },
+  (result) => { result.settlement.tasks.never_started = 0; },
+  (result) => { result.settlement.elapsed_ms = 0; },
+])('older gauntlets reject missing, weakened or altered terminal facts', async (resultChange) => {
+  const f = fixture({ resultChange });
+  await assert.rejects(cancelHeldRun(f.client, f.run, f.gate));
+});
+
+test('an obsolete cancelled action status never releases the held task', async () => {
+  const f = fixture({ actionStatus: 'cancelled' });
+  await assert.rejects(cancelHeldRun(f.client, f.run, f.gate), /cancellation_requested/);
+  assert(!f.order.includes('release'));
+});
+
+test('a missing rendezvous fails instead of issuing cancellation on a timer', async () => {
+  const f = fixture({ arrivalError: true });
+  await assert.rejects(cancelHeldRun(f.client, f.run, f.gate), /rendezvous missing/);
+  assert.deepEqual(f.order, []);
+});
+
+test('depth incident proof preserves the original project workflow and rejects a failed plan', async () => {
+  const { exerciseIncident } = await import('../gauntlet/projects-depth/incident-response-controller/app.mjs');
+  const called = [];
+  const client = {
+    async check(workflow) { called.push(workflow); return { clean: true }; },
+    async run(workflow) { called.push(workflow); return { done: Promise.resolve({ status: 'failed' }) }; },
+  };
+  await assert.rejects(exerciseIncident(client, { arm() { throw new Error('must validate original workflow first'); } }), /succeeded/);
+  assert.deepEqual(called, ['workflow.nika.yaml', 'workflow.nika.yaml']);
+});

--- a/test/one-door-proof.test.mjs
+++ b/test/one-door-proof.test.mjs
@@ -1,0 +1,412 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { OwnedProcesses } from '../scripts/one-door/process.mjs';
+import { CancellationRendezvous } from '../scripts/one-door/cancellation.mjs';
+import { compareResult, compareSameJobResult, compareControlledCancellation, verdict } from '../scripts/one-door/contract.mjs';
+
+test('cancellation rendezvous holds the task until explicit release and observes dependent effects', async () => {
+  const gate = await CancellationRendezvous.listen();
+  try {
+    const control = gate.arm('test');
+    await assert.rejects(gate.release(), /held/);
+    let completed = false;
+    const task = fetch(`${gate.url}/hold`).then(async (response) => { completed = true; return response.json(); });
+    await gate.arrived;
+    assert.equal(completed, false);
+    assert.equal((await fetch(`${control}/arrived`)).status, 200);
+    assert.equal((await fetch(`${control}/release`, { method: 'POST' })).status, 200);
+    assert.deepEqual(await task, { held: true });
+    assert.deepEqual(gate.finish().requests, { hold: 1, dependent: 0 });
+    gate.arm('bad-dependent');
+    const second = fetch(`${gate.url}/hold`);
+    await gate.arrived;
+    await gate.release();
+    await (await second).text();
+    await (await fetch(`${gate.url}/dependent`)).text();
+    assert.throws(() => gate.finish(), /dependent/);
+  } finally { await gate.close(); }
+});
+
+test('controlled cancellation requires a completed in-flight task and an unstarted dependent', () => {
+  const result = { status: 'cancelled', cause: 'operator',
+    tasks: { total: 2, ok: 1, cancelled: 1, never_started: 1, failed: 0, recovered: 0, skipped: 0 },
+    spend: { qualifier: 'unmetered', priced_calls: 0, unpriced_calls: 0 }, outputs: {} };
+  compareControlledCancellation(result);
+  for (const changed of [
+    { ...result, status: 'succeeded', cause: 'normal' },
+    { ...result, tasks: { ...result.tasks, never_started: 0 } },
+    { ...result, tasks: { ...result.tasks, ok: 0 } },
+    { ...result, tasks: { ...result.tasks, cancelled: 0 } },
+  ]) assert.throws(() => compareControlledCancellation(changed));
+});
+
+test('a missing rendezvous fails on its deadline instead of releasing the fixture', async () => {
+  const gate = await CancellationRendezvous.listen();
+  try {
+    gate.arm('missing task', 25);
+    await assert.rejects(gate.arrived, /deadline exceeded/);
+    await assert.rejects(gate.release(), /held/);
+    assert.throws(() => gate.finish(), /deadline exceeded/);
+  } finally { await gate.close(); }
+});
+
+test('closing a held rendezvous rejects the request and closes its listener', async () => {
+  const gate = await CancellationRendezvous.listen();
+  gate.arm('cleanup');
+  const task = fetch(`${gate.url}/hold`);
+  const failedTask = assert.rejects(task);
+  await gate.arrived;
+  await gate.close();
+  await failedTask;
+  await assert.rejects(fetch(`${gate.url}/hold`));
+});
+
+test('same-job comparison rejects fabricated cancellation and preserves a racing success or failure', () => {
+  for (const status of ['succeeded', 'failed', 'cancelled']) {
+    const actual = { status, settlement: { status, cause: status === 'succeeded' ? 'normal' :
+      status === 'failed' ? 'task_failed' : 'operator', elapsed_ms: 19, tasks: { total: 1 },
+      spend: { qualifier: 'unmetered' } } };
+    const event = { kind: 'execution.settled', ...structuredClone(actual) };
+    compareSameJobResult(actual, event);
+    const fabricated = structuredClone(actual);
+    fabricated.status = status === 'cancelled' ? 'succeeded' : 'cancelled';
+    fabricated.settlement.status = fabricated.status;
+    assert.throws(() => compareSameJobResult(fabricated, event), /same-job/);
+    delete actual.settlement;
+    assert.throws(() => compareSameJobResult(actual, event), /same-job/);
+  }
+});
+
+test('consumer cancellation lane rejects fabricated cancellation and lost actual settlement', { timeout: 10000 }, async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-cancellation-mutation-'));
+  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika-client');
+  const owned = new OwnedProcesses();
+  const env = { ...process.env };
+  delete env.NIKA_BIN;
+  try {
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: '@supernovae-st/nika-client',
+      version: '0.118.1', type: 'module', exports: { '.': './index.js', './package.json': './package.json' } }));
+    // Test double for both the SDK and gate control: release is an explicit
+    // promise rendezvous, with no engine, installation, network, or sleep.
+    writeFileSync(path.join(packageRoot, 'index.js'), `
+      import { readFileSync } from 'node:fs';
+      const config = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+      let release;
+      const held = new Promise((resolve) => { release = resolve; });
+      globalThis.fetch = async (url) => {
+        if (url.endsWith('/release')) release();
+        return { ok: true, text: async () => '{}' };
+      };
+      export class Nika {
+        async run() { return { id: 'same-job', done: held.then(() => config.result) }; }
+        async cancel() { return { accepted: true, status: 'cancellation_requested' }; }
+        async *events() { await held; yield config.event; }
+        async attachRun() { return { done: Promise.resolve(config.attached) }; }
+      }
+    `);
+    for (const file of ['consumer.mjs', 'contract.mjs']) {
+      copyFileSync(new URL(`../scripts/one-door/${file}`, import.meta.url), path.join(scratch, file));
+    }
+    const settlement = { status: 'cancelled', cause: 'operator', elapsed_ms: 41,
+      tasks: { total: 2, ok: 1, failed: 0, recovered: 0, skipped: 0, cancelled: 1, never_started: 1 },
+      spend: { qualifier: 'unmetered', priced_calls: 0, unpriced_calls: 0 } };
+    const result = { status: 'cancelled', settlement, receipt: { execution_id: 'same-execution' } };
+    const event = { ...result, kind: 'execution.cancelled', sequence: 1 };
+    const config = { action: 'run', name: 'cancelled', door: 'sdk-name', version: '0.118.1',
+      consumer: scratch, absentBinary: path.join(scratch, 'no-binary'), cancellationControl: 'test://control',
+      expected: verdict(result), result: structuredClone(result), event: structuredClone(event),
+      attached: structuredClone(result) };
+    const configPath = path.join(scratch, 'request.json');
+    const run = async (value) => {
+      writeFileSync(configPath, JSON.stringify(value));
+      return owned.run(process.execPath, [path.join(scratch, 'consumer.mjs'), configPath],
+        { cwd: scratch, env, timeoutMs: 2000 });
+    };
+    await run(config);
+    for (const boundary of ['result', 'event', 'attached']) {
+      const lost = structuredClone(config);
+      delete lost[boundary].settlement;
+      await assert.rejects(run(lost), /settlement|terminal|same-job/, `${boundary}: missing actual settlement`);
+      const changed = structuredClone(config);
+      changed[boundary].settlement.elapsed_ms = 0;
+      await assert.rejects(run(changed), /same-job/, `${boundary}: changed actual settlement`);
+    }
+    for (const status of ['succeeded', 'failed']) {
+      const fabricated = structuredClone(config);
+      // SDK run.done falsely claims cancelled while the engine event says
+      // success/failure. The accepted action receipt cannot make it green.
+      fabricated.event.status = fabricated.event.settlement.status = status;
+      fabricated.event.kind = 'execution.settled';
+      fabricated.event.outputs = {};
+      await assert.rejects(run(fabricated), /terminal event/, `fabricated cancelled over ${status}`);
+    }
+  } finally {
+    await owned.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+const terminal = { status: 'failed', cause: 'task_failed', tasks: { total: 1, failed: 1 },
+  spend: { qualifier: 'unmetered' }, outputs: { answer: { retained: true } },
+  error: { code: 'NIKA-1234', task: 'named_failure', message: 'private text' } };
+
+test('comparator rejects missing or changed workflow outputs', () => {
+  const expected = verdict(terminal);
+  const missing = structuredClone(terminal);
+  delete missing.outputs;
+  assert.throws(() => compareResult(missing, expected));
+  assert.throws(() => compareResult({ ...terminal, outputs: {} }, expected));
+  assert.throws(() => compareResult({ ...terminal, outputs: { answer: { retained: false } } }, expected));
+});
+
+test('comparator rejects dropped and changed named error tasks but permits redacted prose', () => {
+  const expected = verdict(terminal);
+  assert.throws(() => compareResult({ ...terminal, error: { code: terminal.error.code } }, expected));
+  assert.throws(() => compareResult({ ...terminal, error: { ...terminal.error, task: 'wrong_task' } }, expected));
+  compareResult({ ...terminal, error: { ...terminal.error, message: '[redacted]' } }, expected);
+  const { cause, tasks, spend, error, ...fields } = terminal;
+  compareResult({ ...fields, settlement: { status: fields.status, cause, tasks, spend, error } }, expected);
+});
+
+const fullSettlement = { status: terminal.status, cause: terminal.cause,
+  elapsed_ms: 17, tasks: terminal.tasks, spend: terminal.spend,
+  error: { ...terminal.error, future_diagnostic: { message: 'engine detail' } },
+  future_detail: { revision: 1, diagnostic: { message: 'keep this detail' } } };
+const originalResult = { id: 'same-job', status: terminal.status, settlement: fullSettlement,
+  error: fullSettlement.error, outputs: terminal.outputs, receipt: { execution_id: 'same-execution' } };
+const settlementMutations = [
+  ['dropped elapsed_ms', (result) => { delete result.settlement.elapsed_ms; }],
+  ['changed elapsed_ms', (result) => { result.settlement.elapsed_ms = 0; }],
+  ['dropped diagnostic message', (result) => { delete result.settlement.error.message; }],
+  ['changed diagnostic message', (result) => { result.settlement.error.message = '[redacted again]'; }],
+  ['dropped additive field', (result) => { delete result.settlement.future_detail; }],
+  ['changed additive field', (result) => { result.settlement.future_detail.diagnostic.message = 'changed'; }],
+];
+
+test('native flat projection preserves optional presence without copying event metadata', () => {
+  const event = { kind: 'run_settled', ...terminal, elapsed_ms: 17, sequence: 42 };
+  const { outputs, sequence, kind, ...settlement } = event;
+  const result = { status: event.status, settlement, error: event.error };
+  compareSameJobResult(result, event);
+  for (const field of ['elapsed_ms', 'error']) {
+    const absentEvent = structuredClone(event);
+    delete absentEvent[field];
+    const absentResult = structuredClone(result);
+    delete absentResult.settlement[field];
+    if (field === 'error') delete absentResult.error;
+    compareSameJobResult(absentResult, absentEvent);
+    const added = structuredClone(absentResult);
+    added.settlement[field] = undefined;
+    assert.throws(() => compareSameJobResult(added, absentEvent), /same-job/);
+    const explicitEvent = { ...absentEvent, [field]: undefined };
+    const explicitResult = structuredClone(added);
+    if (field === 'error') explicitResult.error = undefined;
+    compareSameJobResult(explicitResult, explicitEvent);
+    assert.throws(() => compareSameJobResult(absentResult, explicitEvent), /same-job/);
+  }
+});
+
+test.each(settlementMutations)('same-job comparator rejects %s in HTTP settlements', (label, mutate) => {
+  const changed = structuredClone(originalResult);
+  mutate(changed);
+  compareResult(changed, verdict(originalResult));
+  const httpEvent = { kind: 'execution.settled', status: terminal.status, settlement: fullSettlement };
+  compareSameJobResult(structuredClone(originalResult), httpEvent);
+  assert.throws(() => compareSameJobResult(changed, httpEvent), /same-job/);
+  // Unknown top-level native event keys are not settlement fields. Their
+  // nested counterparts inside known fields still compare in full.
+  const { future_detail, ...nativeSettlement } = fullSettlement;
+  const nativeEvent = { kind: 'run_settled', ...nativeSettlement };
+  const nativeResult = { ...originalResult, settlement: nativeSettlement };
+  compareSameJobResult(structuredClone(nativeResult), nativeEvent);
+  if (!label.includes('additive field')) {
+    const nativeChanged = structuredClone(nativeResult);
+    mutate(nativeChanged);
+    assert.throws(() => compareSameJobResult(nativeChanged, nativeEvent), /same-job/);
+  }
+});
+
+test('same-job comparator checks the separate error copy and all additive diagnostic fields', () => {
+  for (const mutate of [
+    (result) => { delete result.error; },
+    (result) => { result.error.message = 'changed outer message'; },
+    (result) => { delete result.error.future_diagnostic; },
+    (result) => { result.error.future_diagnostic.message = 'changed outer detail'; },
+    (result) => { delete result.settlement.error.future_diagnostic; },
+  ]) {
+    const changed = structuredClone(originalResult);
+    changed.error = structuredClone(changed.error); // Mutate only one copy.
+    mutate(changed);
+    assert.throws(() => compareSameJobResult(changed, originalResult), /same-job/);
+  }
+});
+
+test.each(['event', 'attach', 'replay'])('consumer rejects same-job settlement loss at %s', { timeout: 10000 }, async (boundary) => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-settlement-test-'));
+  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika-client');
+  const owned = new OwnedProcesses();
+  const env = { ...process.env };
+  delete env.NIKA_BIN;
+  try {
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: '@supernovae-st/nika-client',
+      version: '0.118.1', type: 'module', exports: { '.': './index.js', './package.json': './package.json' } }));
+    // A transport double only: no engine, build, npm install, or network.
+    writeFileSync(path.join(packageRoot, 'index.js'), `
+      import { readFileSync } from 'node:fs';
+      const config = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+      let runs = 0;
+      const changedResult = () => config.mutateOriginal
+        ? Object.assign(config.original, config.changed) : config.changed;
+      export class Nika {
+        async run() {
+          const changed = config.boundary === 'event' || (config.boundary === 'replay' && ++runs > 1);
+          return { id: 'same-job', done: Promise.resolve(changed ? changedResult() : config.original) };
+        }
+        async *events() {
+          yield config.event;
+          if (config.mutateOriginal && config.boundary === 'event') Object.assign(config.event.settlement, config.changed.settlement);
+        }
+        async attachRun() { return { done: Promise.resolve(config.boundary === 'attach' ? changedResult() : config.original) }; }
+      }
+    `);
+    for (const file of ['consumer.mjs', 'contract.mjs']) {
+      copyFileSync(new URL(`../scripts/one-door/${file}`, import.meta.url), path.join(scratch, file));
+    }
+    const configPath = path.join(scratch, 'request.json');
+    const config = { boundary, action: boundary === 'replay' ? 'replay' : 'execute',
+      name: 'failed', door: 'sdk-name', version: '0.118.1', consumer: scratch, project: scratch,
+      absentBinary: path.join(scratch, 'no-binary'), expected: verdict(originalResult), original: originalResult,
+      event: { kind: 'execution.settled', sequence: 1, status: terminal.status,
+        settlement: fullSettlement, outputs: terminal.outputs } };
+    const run = async (changed, mutateOriginal = false) => {
+      writeFileSync(configPath, JSON.stringify({ ...config, changed, mutateOriginal }));
+      return owned.run(process.execPath, [path.join(scratch, 'consumer.mjs'), configPath],
+        { cwd: scratch, env, timeoutMs: 2000 });
+    };
+    await run(structuredClone(originalResult));
+    for (const [label, mutate] of settlementMutations) {
+      const changed = structuredClone(originalResult);
+      mutate(changed);
+      // These differences remain valid between separate executions.
+      compareResult(changed, config.expected, label);
+      await assert.rejects(run(changed), /same-job/, `${boundary}: ${label}`);
+    }
+    const changed = structuredClone(originalResult);
+    changed.settlement.elapsed_ms = 0;
+    await assert.rejects(run(changed, true), /same-job/, `${boundary}: mutation must not rewrite the original observation`);
+  } finally {
+    await owned.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test('supervisor refuses a subprocess without a finite deadline', async () => {
+  const owned = new OwnedProcesses();
+  assert.throws(() => owned.start(process.execPath, ['-e', '']), /finite timeout/);
+  await owned.close();
+});
+
+function gone(pid) {
+  assert.throws(() => process.kill(pid, 0), (error) => error.code === 'ESRCH', `process ${pid} must be reaped`);
+}
+
+test('timeout reaps a consumer and its native-like child before deleting scratch', { timeout: 6000 }, async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-supervision-test-'));
+  const marker = path.join(scratch, 'reaped');
+  const owned = new OwnedProcesses();
+  let handle;
+  try {
+    handle = owned.start(process.execPath, ['-e', `
+      const { spawn } = require('node:child_process');
+      const { writeFileSync } = require('node:fs');
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+      console.log(JSON.stringify({ parent: process.pid, child: child.pid }));
+      process.on('SIGTERM', () => {});
+      child.on('close', () => { writeFileSync(${JSON.stringify(marker)}, 'child reaped'); process.exit(0); });
+    `], { timeoutMs: 500, graceMs: 1000, killMs: 1000 });
+    await assert.rejects(handle.done, /timed out/);
+    const pids = JSON.parse(handle.stdout);
+    gone(pids.parent);
+    gone(pids.child);
+    assert(existsSync(marker), 'scratch remained available until the child was reaped');
+  } finally {
+    await owned.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test('timeout escalates an uncooperative owned child to KILL and awaits exit', { timeout: 6000 }, async () => {
+  const owned = new OwnedProcesses();
+  const handle = owned.start(process.execPath,
+    ['-e', "process.on('SIGTERM', () => {}); console.log(process.pid); setInterval(() => {}, 1000)"],
+    { timeoutMs: 500, graceMs: 100, killMs: 1000 });
+  try {
+    await assert.rejects(handle.done, /timed out/);
+    gone(Number(handle.stdout.trim()));
+    assert.equal(handle.child.signalCode, 'SIGKILL');
+  } finally { await owned.close(); }
+});
+
+test('supervisor bounds output and preserves unrelated owned groups until explicitly closed', { timeout: 6000 }, async () => {
+  const owned = new OwnedProcesses();
+  const unrelated = owned.start(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { timeoutMs: 5000 });
+  const noisy = owned.start(process.execPath, ['-e', "console.log('x'.repeat(10000)); setInterval(() => {}, 1000)"],
+    { timeoutMs: 2000, maxBuffer: 100 });
+  try {
+    await assert.rejects(noisy.done, /exceeded/);
+    assert.equal(process.kill(unrelated.child.pid, 0), true, 'cleanup selected only the noisy group');
+  } finally { await owned.close(); }
+  gone(unrelated.child.pid);
+});
+
+test('consumer uses installed bare exports and rejects a malformed export despite valid dist code', { timeout: 6000 }, async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-export-test-'));
+  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika-client');
+  const owned = new OwnedProcesses();
+  const env = { ...process.env };
+  delete env.NIKA_BIN;
+  try {
+    mkdirSync(path.join(packageRoot, 'dist'), { recursive: true });
+    writeFileSync(path.join(packageRoot, 'dist/index.js'), 'export class Nika { async listWorkflows() { return []; } }\n');
+    for (const file of ['consumer.mjs', 'contract.mjs']) {
+      copyFileSync(new URL(`../scripts/one-door/${file}`, import.meta.url), path.join(scratch, file));
+    }
+    const manifest = { name: '@supernovae-st/nika-client', version: '0.118.1', type: 'module',
+      exports: { '.': './dist/index.js', './package.json': './package.json' } };
+    const config = path.join(scratch, 'request.json');
+    writeFileSync(config, JSON.stringify({ action: 'catalog', names: [], door: 'sdk-name', version: manifest.version,
+      consumer: scratch, absentBinary: path.join(scratch, 'no-binary') }));
+    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify(manifest));
+    const args = [path.join(scratch, 'consumer.mjs'), config];
+    const options = { cwd: scratch, env, timeoutMs: 2000 };
+    assert.equal(JSON.parse(await owned.run(process.execPath, args, options)).installed_package.version, manifest.version);
+    manifest.exports['.'] = './missing-public-export.js';
+    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify(manifest));
+    await assert.rejects(owned.run(process.execPath, args, options), /ERR_MODULE_NOT_FOUND/);
+  } finally {
+    await owned.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test('a failed invocation invalidates a prior green report before engine validation', { timeout: 6000 }, async () => {
+  const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-stale-report-test-'));
+  const report = path.join(scratch, 'report.json');
+  writeFileSync(report, '{"result":"green"}');
+  const owned = new OwnedProcesses();
+  try {
+    const result = await owned.start(process.execPath,
+      [new URL('../scripts/run-one-door-e2e.mjs', import.meta.url).pathname],
+      { env: { ...process.env, NIKA_BIN: 'relative-is-invalid', NIKA_ONE_DOOR_REPORT: report }, timeoutMs: 2000 }).done;
+    assert.notEqual(result.code, 0);
+    assert.equal(JSON.parse(readFileSync(report, 'utf8')).result, 'incomplete');
+  } finally {
+    await owned.close();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});

--- a/test/one-sdk.test.ts
+++ b/test/one-sdk.test.ts
@@ -665,7 +665,7 @@ describe('HTTP transport', () => {
         { sequence: 3, kind: 'settled', status: 'succeeded' },
       ]));
     const client = remote(fetch as typeof globalThis.fetch);
-    const run = await client.run('nested/flow.nika.yaml', { idempotencyKey: 'stable-key' });
+    const run = await client.run('./nested/flow.nika.yaml', { idempotencyKey: 'stable-key' });
     await expect(run.done).resolves.toEqual({
       id: 'remote-1',
       status: 'succeeded',
@@ -755,7 +755,7 @@ describe('HTTP transport', () => {
         root: 'other.nika.yaml',
         units: 1,
       }));
-    await expect(remote(fetch as typeof globalThis.fetch).check('flow.nika.yaml'))
+    await expect(remote(fetch as typeof globalThis.fetch).check('./flow.nika.yaml'))
       .rejects.toMatchObject({ name: 'NikaProtocolError', transport: 'http' });
   });
 
@@ -788,7 +788,7 @@ describe('HTTP transport', () => {
   });
 
   it('refuses dirty or tampered local capture before network admission', async () => {
-    for (const workflow of ['dirty.nika.yaml', 'tampered.nika.yaml']) {
+    for (const workflow of ['./dirty.nika.yaml', './tampered.nika.yaml']) {
       const fetch = vi.fn().mockResolvedValueOnce(healthResponse());
       await expect(remote(fetch as typeof globalThis.fetch).run(workflow))
         .rejects.toBeInstanceOf(NikaCompatibilityError);
@@ -799,7 +799,7 @@ describe('HTTP transport', () => {
 
   it('returns a parse-fatal remote check report without misclassifying identity', async () => {
     const fetch = vi.fn().mockResolvedValueOnce(healthResponse());
-    const report = await remote(fetch as typeof globalThis.fetch).check('parse-fatal.nika.yaml');
+    const report = await remote(fetch as typeof globalThis.fetch).check('./parse-fatal.nika.yaml');
     expect(report).toMatchObject({
       clean: false,
       parse_fatal: true,
@@ -1039,11 +1039,11 @@ describe('remote observation without a local engine', () => {
       bin: '/nonexistent/nika-engine',
       fetch: fetch as typeof globalThis.fetch,
     });
-    await expect(client.check('flow.nika.yaml')).rejects.toMatchObject({
+    await expect(client.check('./flow.nika.yaml')).rejects.toMatchObject({
       name: 'NikaCompatibilityError',
       capability: 'engineIdentity',
     });
-    await expect(client.run('flow.nika.yaml')).rejects.toMatchObject({
+    await expect(client.run('./flow.nika.yaml')).rejects.toMatchObject({
       name: 'NikaCompatibilityError',
       capability: 'engineIdentity',
     });
@@ -1062,11 +1062,11 @@ describe('remote observation without a local engine', () => {
           token: SERVER_TOKEN,
           fetch: fetch as typeof globalThis.fetch,
         });
-        await expect(client.check('flow.nika.yaml')).rejects.toMatchObject({
+        await expect(client.check('./flow.nika.yaml')).rejects.toMatchObject({
           name: 'NikaEngineUnavailable',
           code: 'NIKA_ENGINE_UNAVAILABLE',
         });
-        await expect(client.run('flow.nika.yaml')).rejects.toMatchObject({
+        await expect(client.run('./flow.nika.yaml')).rejects.toMatchObject({
           name: 'NikaEngineUnavailable',
           code: 'NIKA_ENGINE_UNAVAILABLE',
         });

--- a/test/packed-gauntlet-supervision.test.mjs
+++ b/test/packed-gauntlet-supervision.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { bounded } from '../scripts/gauntlet-cancellation.mjs';
+import { OwnedProcesses } from '../scripts/one-door/process.mjs';
+import { supervisedGauntlet } from '../scripts/gauntlet.mjs';
+
+const runners = [
+  ['mini-saas', 'run-mini-saas-gauntlet.mjs'],
+  ['recovery-e2e', 'run-recovery-e2e.mjs'],
+];
+const gone = (pid) => assert.throws(() => process.kill(pid, 0), { code: 'ESRCH' });
+
+for (const [name, script] of runners) {
+  for (const selection of ['missing', 'relative', 'legacy']) {
+    test(`${name} refuses ${selection} engine selection and invalidates old green`, async () => {
+      const scratch = mkdtempSync(path.join(tmpdir(), 'packed-selection-test-'));
+      const owned = new OwnedProcesses();
+      const reportPath = path.join(scratch, `${name}.json`);
+      const marker = path.join(scratch, 'build-started');
+      writeFileSync(reportPath, '{"result":"green"}');
+      writeFileSync(path.join(scratch, 'npm'), `#!${process.execPath}\nrequire('node:fs').writeFileSync(${JSON.stringify(marker)}, 'unexpected'); process.exit(23);\n`, { mode: 0o755 });
+      try {
+        const env = { PATH: scratch, HOME: scratch, NIKA_KEYCHAIN: 'off', NIKA_GAUNTLET_RESULTS_DIR: scratch };
+        if (selection === 'relative') env.NIKA_BIN = 'nika';
+        if (selection === 'legacy') env.NIKA_GAUNTLET_BIN = process.execPath;
+        const result = await owned.start(process.execPath, [new URL(`../scripts/${script}`, import.meta.url).pathname],
+          { env, timeoutMs: 3000 }).done;
+        assert.equal(result.code, 1);
+        assert.equal(result.signal, null);
+        assert.match(result.stderr, /NIKA_BIN must name an absolute engine binary/);
+        assert(!existsSync(marker), 'refusal must precede npm and engine execution');
+        assert.equal(JSON.parse(readFileSync(reportPath, 'utf8')).result, 'red');
+      } finally {
+        await owned.close();
+        rmSync(scratch, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test(`${name} interruption reaps an uncooperative build before recording red`, { timeout: 10_000 }, async () => {
+    const scratch = mkdtempSync(path.join(tmpdir(), 'packed-interrupt-test-'));
+    const owned = new OwnedProcesses();
+    const reportPath = path.join(scratch, `${name}.json`);
+    const marker = path.join(scratch, 'build.pid');
+    mkdirSync(path.join(scratch, 'home'));
+    writeFileSync(reportPath, '{"result":"green"}');
+    writeFileSync(path.join(scratch, 'npm'), `#!${process.execPath}
+      const { writeFileSync } = require('node:fs');
+      process.on('SIGTERM', () => {});
+      writeFileSync(${JSON.stringify(marker)}, String(process.pid));
+      setInterval(() => {}, 1000);
+    `, { mode: 0o755 });
+    try {
+      const handle = owned.start(process.execPath, [new URL(`../scripts/${script}`, import.meta.url).pathname],
+        { timeoutMs: 7000, graceMs: 2500, env: { PATH: scratch, HOME: path.join(scratch, 'home'),
+          NIKA_BIN: process.execPath, NIKA_KEYCHAIN: 'off', NIKA_GAUNTLET_RESULTS_DIR: scratch } });
+      await bounded((async () => {
+        const until = performance.now() + 1900;
+        while (!existsSync(marker) && performance.now() < until) await new Promise((resolve) => setTimeout(resolve, 10));
+        assert(existsSync(marker), 'fake build must start');
+      })(), 2000, 'fake build startup');
+      const during = JSON.parse(readFileSync(reportPath, 'utf8'));
+      const buildPid = Number(readFileSync(marker, 'utf8'));
+      handle.signal('SIGINT');
+      const result = await handle.done;
+      gone(buildPid);
+      gone(handle.child.pid);
+      assert.equal(during.result, 'incomplete');
+      assert.equal(result.code, 1);
+      assert.equal(result.signal, null);
+      const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+      assert.equal(report.result, 'red');
+      assert.match(report.error, /required SIGKILL/);
+    } finally {
+      await owned.close();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+}
+
+test.each(['success', 'failure', 'interrupted'])('packed evidence remains incomplete until cleanup settles (%s)', async (mode) => {
+  const root = mkdtempSync(path.join(tmpdir(), 'packed-commit-test-'));
+  const reportPath = path.join(root, 'proof.json');
+  let resolveCleanup;
+  let rejectCleanup;
+  let reachedCleanup;
+  let scratch;
+  const closing = new Promise((resolve, reject) => { resolveCleanup = resolve; rejectCleanup = reject; });
+  const entered = new Promise((resolve) => { reachedCleanup = resolve; });
+  const owned = { close: () => { reachedCleanup(); return closing; } };
+  try {
+    const proof = supervisedGauntlet({ name: 'proof', root, owned,
+      env: { NIKA_BIN: process.execPath, NIKA_GAUNTLET_RESULTS_DIR: root } }, async (context) => {
+      scratch = context.scratch;
+      return { measured: true };
+    });
+    const observed = proof.then((value) => ({ value }), (error) => ({ error }));
+    await entered;
+    assert.equal(JSON.parse(readFileSync(reportPath, 'utf8')).result, 'incomplete');
+    assert(existsSync(scratch));
+    if (mode === 'interrupted') process.emit('SIGINT');
+    if (mode === 'failure') rejectCleanup(new Error('exit not established'));
+    else resolveCleanup();
+    const result = await observed;
+    const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+    assert.equal(report.result, mode === 'success' ? 'green' : 'red');
+    assert.equal(Boolean(result.error), mode !== 'success');
+    assert.equal(existsSync(scratch), mode === 'failure', 'only unproven process exit retains scratch');
+  } finally {
+    resolveCleanup();
+    // The injected owner never spawned children, so this exact fixture is safe.
+    if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true });
+    rmSync(root, { recursive: true });
+  }
+});
+
+test('an unawaited live consumer is reaped but cannot produce green', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'packed-live-test-'));
+  let handle;
+  try {
+    await assert.rejects(supervisedGauntlet({ name: 'proof', root,
+      env: { NIKA_BIN: process.execPath, NIKA_GAUNTLET_RESULTS_DIR: root } }, async ({ start }) => {
+      let ready;
+      const started = new Promise((resolve) => { ready = resolve; });
+      handle = start(process.execPath, ['-e', "console.log('ready'); setInterval(() => {}, 1000)"],
+        { timeoutMs: 2000, onStdout: ready });
+      await started;
+      return { measured: true };
+    }), /required SIGTERM/);
+    gone(handle.child.pid);
+    assert.equal(JSON.parse(readFileSync(path.join(root, 'proof.json'), 'utf8')).result, 'red');
+  } finally { rmSync(root, { recursive: true }); }
+});
+
+test('the packed runner deadline aborts and reaps a blocked build', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'packed-deadline-test-'));
+  let handle;
+  try {
+    await assert.rejects(supervisedGauntlet({ name: 'proof', root, timeoutMs: 50,
+      env: { NIKA_BIN: process.execPath, NIKA_GAUNTLET_RESULTS_DIR: root } }, async ({ start }) => {
+      handle = start(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { timeoutMs: 2000 });
+      await handle.done;
+      return { measured: true };
+    }), /proof exceeded 50ms/);
+    gone(handle.child.pid);
+    assert.equal(JSON.parse(readFileSync(path.join(root, 'proof.json'), 'utf8')).result, 'red');
+  } finally { rmSync(root, { recursive: true }); }
+});

--- a/test/release-replay.test.ts
+++ b/test/release-replay.test.ts
@@ -63,7 +63,7 @@ describe('public release evidence replay', () => {
     expect(hostileRunner).toContain('tools: ["nika:wait"]');
     expect(hostileRunner).toContain('args: { duration: "10s" }');
     expect(hostileRunner).toContain("assert.equal(statusBeforeCancellation, 'running')");
-    expect(hostileRunner).toContain('cancellationTerminalMatches(cancellation.status, events.at(-1))');
+    expect(hostileRunner).toContain('cancellationTerminalMatches(waitCancellation.status, waitTerminal)');
     expect(hostileRunner).not.toContain("events.includes('execution.cancelled')");
     expect(hostileRunner).not.toContain("events.includes('execution.interrupted')");
     expect(hostileRunner).not.toContain('command: ["sleep"');
@@ -332,7 +332,7 @@ describe('public release evidence replay', () => {
       engine: ENGINE,
       workflows: 100,
       hostileScenarios: 14,
-      realEngineRuns: 70,
+      realEngineRuns: 72,
     });
   });
 

--- a/test/release-stamp.test.ts
+++ b/test/release-stamp.test.ts
@@ -94,7 +94,8 @@ describe('release commit stamping', () => {
 
     expect(workflow).toContain('cargo test --manifest-path nika-source/Cargo.toml');
     expect(workflow).toContain('npm run check:coverage');
-    expect(workflow).toContain('gh attestation verify "$asset" --repo supernovae-st/nika');
+    expect(workflow).toContain('scripts/verify-engine-archive.mjs');
+    expect(workflow).not.toContain('gh attestation verify "$asset" --repo supernovae-st/nika');
     expect(workflow).toContain('engine_commit=$(git -C nika-source rev-parse HEAD)');
     expect(workflow).toContain('"$engine_commit" engine-assets/SHA256SUMS');
     expect(workflow).toContain('scripts/verify-packed-install.mjs');

--- a/test/settlement.test.ts
+++ b/test/settlement.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { Nika } from '../src/index.js';
+import { Nika, NikaProtocolError } from '../src/index.js';
 import { eventSettlement } from '../src/lib/machine.js';
 import type { NikaEvent } from '../src/index.js';
 
@@ -12,6 +12,16 @@ const FIXTURE = path.join(
 );
 
 describe('the settlement rides run.done (engine 0.118+ · ADR-128)', () => {
+  it.each([
+    'not an object', [], null,
+    { status: 'failed' }, { status: 7 }, { cause: 8 }, { elapsed_ms: -1 },
+    { tasks: [] }, { spend: null }, { error: 'not an object' },
+    { error: { code: 42 } }, { error: { task: [] } },
+  ].map((settlement) => [settlement]))('rejects malformed or contradictory present settlement fields: %j', (settlement) => {
+    expect(() => eventSettlement({ kind: 'execution.settled', status: 'succeeded', settlement } as NikaEvent))
+      .toThrow(NikaProtocolError);
+  });
+
   it('reads cause · elapsed · tasks · spend from a flattened run_settled frame', () => {
     const frame = {
       kind: 'run_settled',
@@ -22,12 +32,27 @@ describe('the settlement rides run.done (engine 0.118+ · ADR-128)', () => {
       spend: { qualifier: 'unmetered' },
     } as unknown as NikaEvent;
     expect(eventSettlement(frame)).toEqual({
+      status: 'succeeded',
       cause: 'normal',
       elapsed_ms: 3,
       tasks: { total: 1, ok: 1 },
       spend: { qualifier: 'unmetered' },
     });
   });
+
+  it('preserves nullable native pricing and the complete named failure', () => {
+    const settlement = { status: 'failed', cause: 'task_failed', elapsed_ms: 1,
+      spend: { pricing_as_of: null, total_cost_usd: null, qualifier: 'unmetered' },
+      error: { code: 'NIKA-TEST-001', message: 'fixture failure', task: 'fetch' } };
+    expect(eventSettlement({ kind: 'run_settled', ...settlement }, 'native-process')).toEqual(settlement);
+  });
+
+  it.each([{ code: 'NIKA-TEST-001' }, { message: 'missing code' }, {}])(
+    'rejects incomplete errors on flat native settlements: %j', (error) => {
+      expect(() => eventSettlement({ kind: 'run_settled', status: 'failed', cause: 'task_failed', error }, 'native-process'))
+        .toThrow(NikaProtocolError);
+    },
+  );
 
   it('reads a nested settlement from the resident and nothing from an older frame', () => {
     const nested = {
@@ -41,12 +66,21 @@ describe('the settlement rides run.done (engine 0.118+ · ADR-128)', () => {
     expect(eventSettlement(undefined)).toBeUndefined();
   });
 
+  it('preserves the resident settlement whole, including additive engine fields', () => {
+    const settlement = {
+      status: 'failed', cause: 'task_failed', tasks: { failed: 1 },
+      error: { code: 'NIKA-TEST-001', message: 'fixture failure', task: 'fetch' }, future_evidence: { known: false },
+    };
+    expect(eventSettlement({ kind: 'execution.settled', settlement })).toEqual(settlement);
+  });
+
   it('carries the settlement on run.done over the native transport', async () => {
     const client = new Nika({ bin: FIXTURE });
     const run = await client.run('settled.nika.yaml');
     const result = await run.done;
     expect(result.status).toBe('succeeded');
     expect(result.settlement).toEqual({
+      status: 'succeeded',
       cause: 'normal',
       elapsed_ms: 12,
       tasks: { total: 2, ok: 2, failed: 0, recovered: 1, skipped: 0, cancelled: 0, never_started: 0 },

--- a/test/teaching-reports.test.ts
+++ b/test/teaching-reports.test.ts
@@ -47,7 +47,7 @@ describe('the engine teaching report survives every transport', () => {
   it('falls back to the plain check report when snapshot capture is red', async () => {
     const fetch = vi.fn().mockResolvedValueOnce(healthResponse());
     const report = await remote(fetch as typeof globalThis.fetch)
-      .check('red-snapshot.nika.yaml');
+      .check('./red-snapshot.nika.yaml');
 
     expect(report).toMatchObject({ clean: false, exitCode: 2, report_version: 1 });
     expect(findings(report)[0]).toMatchObject({
@@ -74,7 +74,7 @@ describe('the engine teaching report survives every transport', () => {
         root: 'fixture.nika.yaml',
         units: 1,
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
-    const report = await remote(fetch as typeof globalThis.fetch).check('flow.nika.yaml');
+    const report = await remote(fetch as typeof globalThis.fetch).check('./flow.nika.yaml');
 
     expect(report).toMatchObject({ clean: true, exitCode: 0 });
     expect(report).not.toHaveProperty('snapshot_error');


### PR DESCRIPTION
HTTP callers can now check and run a served workflow name without a local engine; explicit local paths retain immutable snapshot capture and digest verification. Pending cancellation, paused observations and recovered native settlements keep the current 0.118 wire contracts.

This selectively recovers the useful work from #86 on current main. It adds bounded child-process supervision, validated resident shutdown and six-door parity, and makes release admission verify the exact attested engine archive and prepared npm tarball bytes. Malformed by-name errors remain failures. Two independent review findings were corrected before this candidate.

Validation: 541 tests pass with four workers; build, contract coverage and packed ESM/CJS surfaces pass. Fresh measurements use the attested public engine `nika 0.118.7 (f3a31a6ee)`: 100 workflows, five mini-SaaS projects, five depth projects, 14 hostile scenarios (72 real engine runs), two-process recovery, and five scenarios across six execution doors. Committed ledgers were replaced with those measured outputs; their previous bytes remain in Git history. CI independently repeats the exact public-asset replay. No npm publication or paid-provider campaign is part of this PR.
