### PR TITLE
fix(release): use npm trusted publishing and preserve release gates

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,16 +1,16 @@
 name: release-finalize
 
-# Staged npm packages require a maintainer's 2FA approval. This second,
+# Publication and repository tagging are separate receipts. This second,
 # explicit ceremony creates the repository tag and GitHub Release only after
 # all five packages are publicly observable at the exact prepared version.
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Approved SDK release version (e.g. 0.116.0)'
+        description: 'Published SDK release version (e.g. 0.116.0)'
         required: true
       prepared_sha:
-        description: 'Exact 40-hex commit printed by the staging job'
+        description: 'Exact 40-hex commit printed by the publishing job'
         required: true
 
 concurrency:
@@ -67,7 +67,7 @@ jobs:
           for package_name in "${packages[@]}"; do
             published="$(npm view "$package_name@$VERSION" version)"
             if [ "$published" != "$VERSION" ]; then
-              echo "::error::$package_name@$VERSION is not public after staged approval"
+              echo "::error::$package_name@$VERSION is not publicly observable"
               exit 1
             fi
             release_commit="$(npm view "$package_name@$VERSION" nikaRelease.preparedCommit)"

--- a/.github/workflows/release-heal.yml
+++ b/.github/workflows/release-heal.yml
@@ -38,5 +38,5 @@ jobs:
             echo "::warning::engine is $ver but the prepared SDK train is $repo_v; waiting for its version PR"
             exit 0
           fi
-          gh workflow run Release --repo "$GITHUB_REPOSITORY" -f version="$ver"
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main -f version="$ver"
           echo "dispatched Release $ver (npm was $npm_v)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
 
 # SECURITY: no github.event text is interpolated directly into shell source.
-# npm publishes with the repository's NPM_TOKEN and a Sigstore provenance
-# attestation bound to this workflow identity (id-token). npm trusted
-# publishing (OIDC, no write token) replaces the token the day a trusted
-# publisher is registered for all five packages on npmjs.com.
+# npm trusted publishing exchanges this GitHub-hosted job's OIDC identity.
+# Register all five packages for supernovae-st/nika-client, release.yml,
+# environment npm-publish, with direct npm publish allowed. No npm write
+# token is supplied. Sigstore provenance remains bound to this workflow.
 on:
   workflow_dispatch:
     inputs:
@@ -408,8 +408,6 @@ jobs:
         run: npm install --global npm@11.19.1
 
       - name: Publish payloads, then the SDK, with provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           prepared_sha="$(jq -r .prepared_sha release-candidate/release-metadata.json)"
@@ -417,8 +415,8 @@ jobs:
             echo "::error::artifact commit and checked-out publishing commit differ"
             exit 1
           fi
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN is not set on this repository · nothing can publish"
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "::error::GitHub OIDC is unavailable · id-token: write is required before publication"
             exit 1
           fi
           # A partial-publish replay accepts occupied coordinates only after
@@ -441,7 +439,7 @@ jobs:
             echo "### Nika client release published"
             echo "- Version: $VERSION"
             echo "- Order: four native payloads, then root SDK"
-            echo "- Authentication: repository NPM_TOKEN · Sigstore provenance attested through this workflow identity"
+            echo "- Authentication: npm trusted publishing (GitHub OIDC) · release.yml / npm-publish · Sigstore provenance"
             echo "- Prepared commit: $(jq -r .prepared_sha release-candidate/release-metadata.json)"
             echo "- Next: release-finalize.yml tags the SDK once all five versions are observable on npm"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -124,8 +124,16 @@ The release ceremony is deliberately two-step. `release.yml` validates the
 tagged engine assets, starts the released Linux binary, proves the live
 OpenAPI/types pin, embeds the exact prepared commit and release version in all
 five package manifests before packing, and publishes four payloads plus the SDK
-with the repository's npm token and a Sigstore provenance attestation bound to
-the workflow identity. An occupied version is accepted only after its exact
+through npm trusted publishing with GitHub OIDC and Sigstore provenance bound
+to the workflow identity. Every package registers organization `supernovae-st`,
+repository `nika-client`, workflow filename `release.yml`, and environment
+`npm-publish`, with direct `npm publish` enabled. The GitHub-hosted publish job
+uses Node 24, npm 11.19.1 and `id-token: write`; it receives no npm write token.
+`release-heal.yml` dispatches that same file on `main`; it does not publish or
+exchange an OIDC token itself. All five package manifests identify the SDK
+repository; native `SOURCE.json` still identifies the separate engine source.
+See [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/).
+An occupied version is accepted only after its exact
 prepared tarball integrity and fetched registry bytes match; errors other than
 an explicit registry 404 refuse publication. `release-finalize.yml` refuses to create the SDK tag and GitHub
 Release until all five exact versions are publicly observable on npm and every

--- a/gauntlet/projects-depth/results.json
+++ b/gauntlet/projects-depth/results.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "engine": "nika 0.118.7 (f3a31a6ee)",
   "package": "supernovae-st-nika-client-0.118.7.tgz",
-  "package_sha256": "f5e8c0cbc7475a944f06ec7e75ecf18a5f225e666a1a71af5a1bcfa4f23acbc4",
+  "package_sha256": "e7ab4d2b41df91233b570689e57ed87e50ea8d9f1e5faace542b6a7e9c411b3d",
   "install_mode": "npm pack + isolated npm install --omit=optional + explicit NIKA_BIN",
   "projects": [
     {

--- a/packages/native/darwin-arm64/package.json
+++ b/packages/native/darwin-arm64/package.json
@@ -21,5 +21,10 @@
   "preferUnplugged": true,
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/supernovae-st/nika-client.git",
+    "directory": "packages/native/darwin-arm64"
   }
 }

--- a/packages/native/darwin-x64/package.json
+++ b/packages/native/darwin-x64/package.json
@@ -21,5 +21,10 @@
   "preferUnplugged": true,
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/supernovae-st/nika-client.git",
+    "directory": "packages/native/darwin-x64"
   }
 }

--- a/packages/native/linux-arm64-gnu/package.json
+++ b/packages/native/linux-arm64-gnu/package.json
@@ -24,5 +24,10 @@
   "preferUnplugged": true,
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/supernovae-st/nika-client.git",
+    "directory": "packages/native/linux-arm64-gnu"
   }
 }

--- a/packages/native/linux-x64-gnu/package.json
+++ b/packages/native/linux-x64-gnu/package.json
@@ -24,5 +24,10 @@
   "preferUnplugged": true,
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/supernovae-st/nika-client.git",
+    "directory": "packages/native/linux-x64-gnu"
   }
 }

--- a/test/canonical-incident.test.mjs
+++ b/test/canonical-incident.test.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -22,7 +23,7 @@ test('a failed depth invocation invalidates its previous green report', async ()
     writeFileSync(report, JSON.stringify({ summary: { result: 'green' } }));
     writeFileSync(path.join(scratch, 'npm'), `#!${process.execPath}\nprocess.exitCode = 13;\n`, { mode: 0o755 });
     const result = await owned.start(process.execPath,
-      [new URL('../scripts/run-depth-projects.mjs', import.meta.url).pathname],
+      [fileURLToPath(new URL('../scripts/run-depth-projects.mjs', import.meta.url))],
       { timeoutMs: 3000, env: { PATH: scratch, HOME: scratch, NIKA_KEYCHAIN: 'off',
         NIKA_BIN: process.execPath, NIKA_GAUNTLET_RESULTS_DIR: scratch } }).done;
     assert.equal(result.code, 1);

--- a/test/corpus-check-supervision.test.mjs
+++ b/test/corpus-check-supervision.test.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -5,8 +6,8 @@ import path from 'node:path';
 import { test } from 'vitest';
 import { OwnedProcesses } from '../scripts/one-door/process.mjs';
 
-const runner = new URL('../scripts/verify-gauntlet-corpus.mjs', import.meta.url).pathname;
-const repo = path.resolve(new URL('..', import.meta.url).pathname);
+const runner = fileURLToPath(new URL('../scripts/verify-gauntlet-corpus.mjs', import.meta.url));
+const repo = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 for (const mode of ['success', 'invalid-json', 'not-ready', 'interrupted']) {
   test(`corpus check is an isolated, supervised observation: ${mode}`, { timeout: 15_000 }, async () => {

--- a/test/corpus-project.test.mjs
+++ b/test/corpus-project.test.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -5,7 +6,7 @@ import path from 'node:path';
 import { test } from 'vitest';
 import { stageCorpus } from '../scripts/corpus-project.mjs';
 
-const repo = path.resolve(new URL('..', import.meta.url).pathname);
+const repo = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 for (const mode of ['clean', 'undeclared-file', 'symlink-workflow']) {
   test(`corpus staging admits only the declared regular workflows: ${mode}`, () => {

--- a/test/corpus-supervision.test.mjs
+++ b/test/corpus-supervision.test.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -5,8 +6,8 @@ import path from 'node:path';
 import { test } from 'vitest';
 import { OwnedProcesses } from '../scripts/one-door/process.mjs';
 
-const runner = new URL('../scripts/execute-gauntlet-corpus.mjs', import.meta.url).pathname;
-const repo = path.resolve(new URL('..', import.meta.url).pathname);
+const runner = fileURLToPath(new URL('../scripts/execute-gauntlet-corpus.mjs', import.meta.url));
+const repo = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 for (const mode of ['missing', 'version-failed', 'run-failed', 'invalid-json', 'success', 'interrupted']) {
   test(`corpus owns its isolated execution and replaces stale evidence: ${mode}`, { timeout: 20_000 }, async () => {

--- a/test/hostile-supervision.test.mjs
+++ b/test/hostile-supervision.test.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import { once } from 'node:events';
@@ -171,7 +172,7 @@ test('runner interruption reaps an uncooperative build and replaces stale green 
   writeFileSync(path.join(scratch, 'package.json'), '{"type":"module"}');
   let retained;
   try {
-    const handle = owned.start(process.execPath, [new URL('../scripts/run-hostile-gauntlet.mjs', import.meta.url).pathname],
+    const handle = owned.start(process.execPath, [fileURLToPath(new URL('../scripts/run-hostile-gauntlet.mjs', import.meta.url))],
       { timeoutMs: 7000, graceMs: 2500, env: { PATH: scratch, HOME: path.join(scratch, 'home'),
         NIKA_BIN: process.execPath, NIKA_KEYCHAIN: 'off', NIKA_GAUNTLET_RESULTS_DIR: scratch } });
     await bounded((async () => {

--- a/test/npm-trusted-publishing.test.mjs
+++ b/test/npm-trusted-publishing.test.mjs
@@ -1,0 +1,62 @@
+import { afterEach, expect, test } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const scratch = [];
+const workflow = await readFile(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
+const publishStep = workflow.split('      - name: Publish payloads, then the SDK, with provenance\n')[1]
+  .split('      - name: Release summary\n')[0];
+const script = publishStep.split('        run: |\n')[1]
+  .split('\n').map((line) => line.replace(/^          /, '')).join('\n');
+
+afterEach(async () => {
+  await Promise.all(scratch.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function execute(oidc) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'nika-oidc-workflow-'));
+  scratch.push(dir);
+  for (const [name, body] of Object.entries({
+    git: 'printf "%s\\n" prepared-commit',
+    jq: 'printf "%s\\n" prepared-commit',
+    node: 'printf "%s\\n" "$*" >> "$CALL_LOG"',
+  })) {
+    await writeFile(path.join(dir, name), `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  }
+  const log = path.join(dir, 'calls');
+  await writeFile(log, '');
+  const result = spawnSync('/bin/bash', ['-c', script], {
+    cwd: dir,
+    env: { PATH: `${dir}:/usr/bin:/bin`, VERSION: '0.118.7', CALL_LOG: log, ...oidc },
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  return { ...result, calls: (await readFile(log, 'utf8')).trim().split('\n').filter(Boolean) };
+}
+
+test('the publishing shell accepts GitHub OIDC without an npm write token', async () => {
+  const result = await execute({
+    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.invalid/oidc',
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fixture-only',
+  });
+  expect(result.status, result.stderr + result.stdout).toBe(0);
+  expect(result.calls.map((call) => call.split(' ')[2])).toEqual([
+    '@supernovae-st/nika-darwin-arm64', '@supernovae-st/nika-darwin-x64',
+    '@supernovae-st/nika-linux-arm64', '@supernovae-st/nika-linux-x64',
+    '@supernovae-st/nika-client',
+  ]);
+  expect(publishStep).not.toContain('secrets.NPM_TOKEN');
+});
+
+test.each([
+  {},
+  { ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.invalid/oidc' },
+  { ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fixture-only' },
+])('the publishing shell refuses incomplete OIDC before invoking publication', async (oidc) => {
+  const result = await execute(oidc);
+  expect(result.status).not.toBe(0);
+  expect(result.stdout + result.stderr).toContain('GitHub OIDC');
+  expect(result.calls).toEqual([]);
+});

--- a/test/one-door-proof.test.mjs
+++ b/test/one-door-proof.test.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -401,7 +402,7 @@ test('a failed invocation invalidates a prior green report before engine validat
   const owned = new OwnedProcesses();
   try {
     const result = await owned.start(process.execPath,
-      [new URL('../scripts/run-one-door-e2e.mjs', import.meta.url).pathname],
+      [fileURLToPath(new URL('../scripts/run-one-door-e2e.mjs', import.meta.url))],
       { env: { ...process.env, NIKA_BIN: 'relative-is-invalid', NIKA_ONE_DOOR_REPORT: report }, timeoutMs: 2000 }).done;
     assert.notEqual(result.code, 0);
     assert.equal(JSON.parse(readFileSync(report, 'utf8')).result, 'incomplete');

--- a/test/packed-gauntlet-supervision.test.mjs
+++ b/test/packed-gauntlet-supervision.test.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -26,7 +27,7 @@ for (const [name, script] of runners) {
         const env = { PATH: scratch, HOME: scratch, NIKA_KEYCHAIN: 'off', NIKA_GAUNTLET_RESULTS_DIR: scratch };
         if (selection === 'relative') env.NIKA_BIN = 'nika';
         if (selection === 'legacy') env.NIKA_GAUNTLET_BIN = process.execPath;
-        const result = await owned.start(process.execPath, [new URL(`../scripts/${script}`, import.meta.url).pathname],
+        const result = await owned.start(process.execPath, [fileURLToPath(new URL(`../scripts/${script}`, import.meta.url))],
           { env, timeoutMs: 3000 }).done;
         assert.equal(result.code, 1);
         assert.equal(result.signal, null);
@@ -54,7 +55,7 @@ for (const [name, script] of runners) {
       setInterval(() => {}, 1000);
     `, { mode: 0o755 });
     try {
-      const handle = owned.start(process.execPath, [new URL(`../scripts/${script}`, import.meta.url).pathname],
+      const handle = owned.start(process.execPath, [fileURLToPath(new URL(`../scripts/${script}`, import.meta.url))],
         { timeoutMs: 7000, graceMs: 2500, env: { PATH: scratch, HOME: path.join(scratch, 'home'),
           NIKA_BIN: process.execPath, NIKA_KEYCHAIN: 'off', NIKA_GAUNTLET_RESULTS_DIR: scratch } });
       await bounded((async () => {


### PR DESCRIPTION
The release job stops supplying NPM_TOKEN and authenticates directly with its GitHub OIDC identity. The five npm packages must trust supernovae-st/nika-client, release.yml, environment npm-publish, with direct publication enabled. Native manifests now declare the SDK repository required by npm provenance; SOURCE.json continues identifying the engine source.

Preparation, four native runtime gates, exact prepared commit, artifact attestation, public absence checks, SRI validation and byte-identical partial replay remain intact. Release Heal dispatches the exact trusted workflow on main; Finalize still waits for all five observable packages before tagging. No publication was triggered by this change.

The SDK harness also decodes file URLs before spawning fixture runners, fixing failures in checkout paths containing spaces.

Validation: 545 tests passed in the existing checkout with spaces; 54 release/provenance/publication tests passed; SDK build and contract coverage passed; actionlint passed. New regression tests execute the publish step with complete, missing and partial OIDC environments and check that all five publications remain ordered.

The first full public-engine replay reproduced every behavioral result; the depth receipt changed only its package SHA-256 because documentation ships in npm pack. That digest was refreshed from CI run 34402485273, artifact 10124047537. Strict replay comparison and 69 verifier tests pass against the downloaded evidence; no normalization or gate was weakened.
