### PR TITLE
feat(package): publish as @supernovae-st/nika · fix the log race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,10 @@ jobs:
           umask 077
           printf '%s' "$NIKA_SERVE_TOKEN" > "$token_file"
           chmod 600 "$token_file"
+          # The log exists before the resident is launched: the discovery loop
+          # reads it at once, and a background subshell that has not yet opened
+          # its redirection would otherwise leave nothing to read.
+          : >"$probe_root/server.log"
           (
             cd "$project_dir"
             exec nika serve \

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -62,7 +62,7 @@ jobs:
             @supernovae-st/nika-darwin-x64
             @supernovae-st/nika-linux-arm64
             @supernovae-st/nika-linux-x64
-            @supernovae-st/nika-client
+            @supernovae-st/nika
           )
           for package_name in "${packages[@]}"; do
             published="$(npm view "$package_name@$VERSION" version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,11 @@ jobs:
           token="nika-release-openapi-probe-token-0116"
           printf '%s\n' "$token" > "$token_file"
           chmod 600 "$token_file"
+          # The log exists before the resident is launched: the discovery loop
+          # below reads it at once, and a background subshell that has not yet
+          # opened its redirection would otherwise leave nothing to read (the
+          # race that failed the prepare job on 2026-09-10).
+          : >"$probe_root/server.log"
           (
             cd "$project_dir"
             exec "$probe_root/nika" serve \
@@ -293,7 +298,7 @@ jobs:
             @supernovae-st/nika-darwin-x64
             @supernovae-st/nika-linux-arm64
             @supernovae-st/nika-linux-x64
-            @supernovae-st/nika-client
+            @supernovae-st/nika
           )
           for package_name in "${packages[@]}"; do
             node scripts/npm-publication.mjs assert-absent "$package_name" "$VERSION"
@@ -372,7 +377,7 @@ jobs:
         run: |
           npm install --global npm@11.19.1
           node scripts/verify-packed-install.mjs \
-            "release-candidate/release-tarballs/supernovae-st-nika-client-$VERSION.tgz" \
+            "release-candidate/release-tarballs/supernovae-st-nika-$VERSION.tgz" \
             "release-candidate/release-tarballs/$NATIVE_TARBALL-$VERSION.tgz" \
             "$VERSION" "$PREPARED_SHA" "$NATIVE_PACKAGE"
 
@@ -431,7 +436,7 @@ jobs:
           publish_once "@supernovae-st/nika-darwin-x64" "$tarballs/supernovae-st-nika-darwin-x64-$VERSION.tgz"
           publish_once "@supernovae-st/nika-linux-arm64" "$tarballs/supernovae-st-nika-linux-arm64-$VERSION.tgz"
           publish_once "@supernovae-st/nika-linux-x64" "$tarballs/supernovae-st-nika-linux-x64-$VERSION.tgz"
-          publish_once "@supernovae-st/nika-client" "$tarballs/supernovae-st-nika-client-$VERSION.tgz"
+          publish_once "@supernovae-st/nika" "$tarballs/supernovae-st-nika-$VERSION.tgz"
 
       - name: Release summary
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add six-door runtime parity and bounded, owned process supervision for the
   corpus and packed application harnesses.
 
+### Changed
+
+- The package is published as `@supernovae-st/nika`, the product's name: one
+  namespace for the owner, one artifact name per registry. The native payloads
+  were already `@supernovae-st/nika-<os>-<arch>`; the repository keeps its
+  name. Release evidence, packed-install checks and the publication gates
+  follow the new tarball name `supernovae-st-nika-<version>.tgz`.
+
+### Deprecated
+
+- `@supernovae-st/nika-client` receives no further versions. The name stays
+  installable for the versions it already holds and is marked deprecated on
+  npm after the first `@supernovae-st/nika` publication.
+
 ### Fixed
 
+- The release preparation and the CI type-drift probes create the resident's
+  `server.log` before launching it; the discovery loop no longer races a
+  background subshell that has not opened its redirection yet, the failure
+  that stopped the 2026-09-10 release preparation.
 - Resolve HTTP workflow names at the resident without a local engine; explicit
   local paths retain snapshot capture and digest verification.
 - Preserve pending cancellation, paused observation and recovered native

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
 </p>
 
-<h1 align="center">@supernovae-st/nika-client</h1>
+<h1 align="center">@supernovae-st/nika</h1>
 
 <p align="center"><strong>One TypeScript surface for local Nika processes and authenticated Nika servers.</strong></p>
 
@@ -43,8 +43,8 @@ not parse YAML or reconstruct proof in TypeScript.
 ## Install
 
 ```sh
-npm view @supernovae-st/nika-client@0.118.7 version  # must report 0.118.7
-npm install @supernovae-st/nika-client@0.118.7
+npm view @supernovae-st/nika@0.118.7 version  # must report 0.118.7
+npm install @supernovae-st/nika@0.118.7
 ```
 
 If the registry reports any other version, the 0.118.7 release train is not
@@ -53,10 +53,16 @@ not implement the root facade documented below. The publication is complete
 only when the four matching native payload packages and this root client are
 all visible on npm.
 
+This package carries the product's name. Up to 0.115.0 it was published as
+`@supernovae-st/nika-client`; that name is deprecated on npm, stays installable
+for the versions it already holds, and receives no further releases. The
+native payloads were already `@supernovae-st/nika-<os>-<arch>`, and the
+repository keeps its name (`supernovae-st/nika-client`).
+
 Verify the package that the current project actually resolved:
 
 ```sh
-node -p "require('@supernovae-st/nika-client/package.json').version"
+node -p "require('@supernovae-st/nika/package.json').version"
 ```
 
 This package metadata subpath is exported for CommonJS, ESM build tools and CI
@@ -94,7 +100,7 @@ outputs:
 Then drive the installed engine:
 
 ```ts
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const nika = new Nika({
   cwd: process.cwd(),
@@ -233,7 +239,7 @@ Connect from Node:
 
 ```ts
 import { readFile } from 'node:fs/promises';
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const token = (await readFile('.nika/serve.token', 'utf8')).trim();
 const nika = new Nika({
@@ -530,7 +536,7 @@ drift without treating it as a workflow failure.
 ```sh
 nika doctor
 brew upgrade nika
-npm update @supernovae-st/nika-client
+npm update @supernovae-st/nika
 ```
 
 <!-- city:map -->

--- a/gauntlet/projects-depth/REPORT.md
+++ b/gauntlet/projects-depth/REPORT.md
@@ -22,7 +22,7 @@ All workflows use the public envelope and task-map form, the canonical `invoke` 
 - `git diff --check` — passed.
 
 The final release-candidate replay used the public release engine `nika 0.118.7 (f3a31a6ee)`
-with `supernovae-st-nika-client-0.118.7.tgz`; all five projects
+with `supernovae-st-nika-0.118.7.tgz`; all five projects
 remained green. The generated JSON records installed-from-pack proof, stable
 scenario facts, typed error names/codes, receipt verdicts, event observations,
 concurrency, cancellation, CAS, and restart evidence.

--- a/gauntlet/projects-depth/deployment-gate/app.mjs
+++ b/gauntlet/projects-depth/deployment-gate/app.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { Nika, NikaCompatibilityError } from '@supernovae-st/nika-client';
+import { Nika, NikaCompatibilityError } from '@supernovae-st/nika';
 
 const engine = process.env.NIKA_BIN;
 assert(engine, 'NIKA_BIN is required');

--- a/gauntlet/projects-depth/evidence-provenance-pipeline/app.mjs
+++ b/gauntlet/projects-depth/evidence-provenance-pipeline/app.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const engine = process.env.NIKA_BIN;
 assert(engine, 'NIKA_BIN is required');

--- a/gauntlet/projects-depth/incident-response-controller/app.mjs
+++ b/gauntlet/projects-depth/incident-response-controller/app.mjs
@@ -120,10 +120,10 @@ export async function stopIncidentServer(server, graceMs = 5_000) {
 async function main() {
   const engine = process.env.NIKA_BIN;
   assert(engine, 'NIKA_BIN is required');
-  const sdkEntry = realpathSync(fileURLToPath(import.meta.resolve('@supernovae-st/nika-client')));
-  const installedPackage = path.join(process.cwd(), 'node_modules', '@supernovae-st', 'nika-client');
+  const sdkEntry = realpathSync(fileURLToPath(import.meta.resolve('@supernovae-st/nika')));
+  const installedPackage = path.join(process.cwd(), 'node_modules', '@supernovae-st', 'nika');
   assert(sdkEntry.startsWith(`${installedPackage}${path.sep}`), 'SDK must resolve inside this installed npm-pack consumer');
-  const { Nika } = await import('@supernovae-st/nika-client');
+  const { Nika } = await import('@supernovae-st/nika');
   const executedAppSha256 = createHash('sha256').update(readFileSync(fileURLToPath(import.meta.url))).digest('hex');
   const runtime = path.join(process.cwd(), '.runtime');
   mkdirSync(runtime, { recursive: true });

--- a/gauntlet/projects-depth/multi-tenant-webhook-router/app.mjs
+++ b/gauntlet/projects-depth/multi-tenant-webhook-router/app.mjs
@@ -4,7 +4,7 @@ import { chmod, mkdir, writeFile } from 'node:fs/promises';
 import { createServer as createHttpServer } from 'node:http';
 import { createServer as createNetServer } from 'node:net';
 import path from 'node:path';
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const engine = process.env.NIKA_BIN;
 assert(engine, 'NIKA_BIN is required');

--- a/gauntlet/projects-depth/results.json
+++ b/gauntlet/projects-depth/results.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "engine": "nika 0.118.7 (f3a31a6ee)",
-  "package": "supernovae-st-nika-client-0.118.7.tgz",
-  "package_sha256": "e7ab4d2b41df91233b570689e57ed87e50ea8d9f1e5faace542b6a7e9c411b3d",
+  "package": "supernovae-st-nika-0.118.7.tgz",
+  "package_sha256": "690b4ff8a45058a74db8cb0798f001f1c324aa66b55a470889a398c5c787d77a",
   "install_mode": "npm pack + isolated npm install --omit=optional + explicit NIKA_BIN",
   "projects": [
     {
@@ -32,8 +32,8 @@
       "deterministic_cost_cap_usd": 0,
       "installed_from_pack": true,
       "app_identity": {
-        "source_sha256": "6f4d68c35a397b829b92e27e3016d9b96650747a7b93540e9aa3658fe5849efb",
-        "executed_sha256": "6f4d68c35a397b829b92e27e3016d9b96650747a7b93540e9aa3658fe5849efb",
+        "source_sha256": "0fcf0ebb4f14049546f1cbe8bdac8971e7f5b3c97580c14986e5357e4d91a3b8",
+        "executed_sha256": "0fcf0ebb4f14049546f1cbe8bdac8971e7f5b3c97580c14986e5357e4d91a3b8",
         "byte_identical": true
       }
     },
@@ -56,8 +56,8 @@
       "deterministic_cost_cap_usd": 0,
       "installed_from_pack": true,
       "app_identity": {
-        "source_sha256": "f0c75462e0bf03cbde94df62cf8870ef05f238aa560b07d3d81d13a80d57d912",
-        "executed_sha256": "f0c75462e0bf03cbde94df62cf8870ef05f238aa560b07d3d81d13a80d57d912",
+        "source_sha256": "f368900fbb27dfae8fce41ab0acfc0a880d8024ce648126243831859a3d522b9",
+        "executed_sha256": "f368900fbb27dfae8fce41ab0acfc0a880d8024ce648126243831859a3d522b9",
         "byte_identical": true
       }
     },
@@ -119,12 +119,12 @@
         "forced": false,
         "reaped": true
       },
-      "executed_app_sha256": "91740d8068f15e7432e6750bb419be0fbfd2772962dee19ab4a650a2729b4380",
-      "sdk_entry": "node_modules/@supernovae-st/nika-client/dist/index.js",
+      "executed_app_sha256": "d246f9b3bc670a8c63f9b3118388885db9df97b9a026312814c4f167daaa5fbb",
+      "sdk_entry": "node_modules/@supernovae-st/nika/dist/index.js",
       "installed_from_pack": true,
       "app_identity": {
-        "source_sha256": "91740d8068f15e7432e6750bb419be0fbfd2772962dee19ab4a650a2729b4380",
-        "executed_sha256": "91740d8068f15e7432e6750bb419be0fbfd2772962dee19ab4a650a2729b4380",
+        "source_sha256": "d246f9b3bc670a8c63f9b3118388885db9df97b9a026312814c4f167daaa5fbb",
+        "executed_sha256": "d246f9b3bc670a8c63f9b3118388885db9df97b9a026312814c4f167daaa5fbb",
         "byte_identical": true
       }
     },
@@ -143,8 +143,8 @@
       "deterministic_cost_cap_usd": 0,
       "installed_from_pack": true,
       "app_identity": {
-        "source_sha256": "141d4b3b3d32e160aed3e7872cb21beb2389221d99ed28804e11015f2439092c",
-        "executed_sha256": "141d4b3b3d32e160aed3e7872cb21beb2389221d99ed28804e11015f2439092c",
+        "source_sha256": "f6295fba387b9e28ffe48b5ddf398b5d613312258602f4a0586bbf90180955e5",
+        "executed_sha256": "f6295fba387b9e28ffe48b5ddf398b5d613312258602f4a0586bbf90180955e5",
         "byte_identical": true
       }
     },
@@ -165,8 +165,8 @@
       "deterministic_cost_cap_usd": 0,
       "installed_from_pack": true,
       "app_identity": {
-        "source_sha256": "de35e211fef5f7999f8420affe598e864136b3a50ff4dcd218a11e406393d348",
-        "executed_sha256": "de35e211fef5f7999f8420affe598e864136b3a50ff4dcd218a11e406393d348",
+        "source_sha256": "3738a70feb93260d9d167027f6bf877363e66b20bb580dc9c200954999868857",
+        "executed_sha256": "3738a70feb93260d9d167027f6bf877363e66b20bb580dc9c200954999868857",
         "byte_identical": true
       }
     }

--- a/gauntlet/projects-depth/scheduled-research-monitor/app.mjs
+++ b/gauntlet/projects-depth/scheduled-research-monitor/app.mjs
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 import { chmod, mkdir, writeFile } from 'node:fs/promises';
 import { createServer as createNetServer } from 'node:net';
 import path from 'node:path';
-import { Nika, NikaOperationError } from '@supernovae-st/nika-client';
+import { Nika, NikaOperationError } from '@supernovae-st/nika';
 
 const engine = process.env.NIKA_BIN;
 assert(engine, 'NIKA_BIN is required');

--- a/gauntlet/projects/commerce-enrichment/app.mjs
+++ b/gauntlet/projects/commerce-enrichment/app.mjs
@@ -1,4 +1,4 @@
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const nika = new Nika({ cwd: process.cwd(), eventBufferSize: 64 });
 const checked = await nika.check('workflow.nika.yaml', { nativeStrict: true });

--- a/gauntlet/projects/document-evidence/app.mjs
+++ b/gauntlet/projects/document-evidence/app.mjs
@@ -1,4 +1,4 @@
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const nika = new Nika({ cwd: process.cwd() });
 const checked = await nika.check('workflow.nika.yaml', { nativeStrict: true });

--- a/gauntlet/projects/operator-console/app.mjs
+++ b/gauntlet/projects/operator-console/app.mjs
@@ -1,4 +1,4 @@
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const nika = new Nika({ cwd: process.cwd() });
 const checked = await nika.check('workflow.nika.yaml', { nativeStrict: true });

--- a/gauntlet/projects/research-monitor/app.mjs
+++ b/gauntlet/projects/research-monitor/app.mjs
@@ -1,4 +1,4 @@
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const nika = new Nika({ cwd: process.cwd() });
 const checked = await nika.check('workflow.nika.yaml', { nativeStrict: true });

--- a/gauntlet/projects/support-webhook/app.mjs
+++ b/gauntlet/projects/support-webhook/app.mjs
@@ -1,5 +1,5 @@
 import { createServer } from 'node:http';
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const nika = new Nika({ cwd: process.cwd() });
 const server = createServer(async (request, response) => {

--- a/gauntlet/recovery-e2e/client.mjs
+++ b/gauntlet/recovery-e2e/client.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const mode = process.argv[2];
 const config = {

--- a/gauntlet/results/mini-saas.json
+++ b/gauntlet/results/mini-saas.json
@@ -1,6 +1,6 @@
 {
   "engine": "nika 0.118.7 (f3a31a6ee)",
-  "package": "supernovae-st-nika-client-0.118.7.tgz",
+  "package": "supernovae-st-nika-0.118.7.tgz",
   "install_mode": "npm pack + npm install --omit=optional + explicit NIKA_BIN",
   "projects": [
     {

--- a/gauntlet/results/recovery-e2e.json
+++ b/gauntlet/results/recovery-e2e.json
@@ -1,11 +1,11 @@
 {
   "engine": "nika 0.118.7 (f3a31a6ee)",
-  "package": "supernovae-st-nika-client-0.118.7.tgz",
+  "package": "supernovae-st-nika-0.118.7.tgz",
   "process_count": 2,
   "installed_from_pack": true,
   "project": "two-process-durable-recovery",
   "status": "succeeded",
-  "job_id": "63b53116-4bae-4b81-b037-3a8f55e06d0c",
+  "job_id": "05304340-381a-45b3-893e-99d2b1783367",
   "producer_last_event_id": 1,
   "resumed_sequences": [
     2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@supernovae-st/nika-client",
+  "name": "@supernovae-st/nika",
   "version": "0.118.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@supernovae-st/nika-client",
+      "name": "@supernovae-st/nika",
       "version": "0.118.7",
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@supernovae-st/nika-client",
+  "name": "@supernovae-st/nika",
   "version": "0.118.7",
   "description": "One TypeScript SDK for local and remote Nika execution",
   "repository": {

--- a/scripts/gauntlet.mjs
+++ b/scripts/gauntlet.mjs
@@ -87,7 +87,7 @@ export async function installProject(source, project, tarball, run) {
   cpSync(source, project, { recursive: true });
   const manifestPath = path.join(project, 'package.json');
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  manifest.dependencies = { '@supernovae-st/nika-client': `file:${tarball}` };
+  manifest.dependencies = { '@supernovae-st/nika': `file:${tarball}` };
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
   await run('npm', ['install', '--ignore-scripts', '--omit=optional', '--no-audit', '--no-fund'],
     { cwd: project, timeoutMs: 60_000 });

--- a/scripts/media/render.sh
+++ b/scripts/media/render.sh
@@ -34,7 +34,7 @@ outputs:
   brief: ${{ tasks.brief.output }}
 EOF
 cat > /tmp/sdk-demo/demo.mjs <<'EOF'
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 
 const nika = new Nika({ cwd: process.cwd() });
 const report = await nika.check('flow.nika.yaml');

--- a/scripts/npm-publication.mjs
+++ b/scripts/npm-publication.mjs
@@ -13,7 +13,7 @@ function coordinate(name, version) {
   if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
     throw new Error('invalid stable npm coordinate');
   }
-  if (name !== '@supernovae-st/nika-client') {
+  if (name !== '@supernovae-st/nika') {
     try { nativeTarget(name, version); } catch { throw new Error('invalid npm package coordinate'); }
   }
   return `${REGISTRY}/${encodeURIComponent(name)}/${version}`;

--- a/scripts/one-door/consumer.mjs
+++ b/scripts/one-door/consumer.mjs
@@ -1,14 +1,14 @@
 // This file is COPIED into a fresh npm consumer before execution. The bare
 // import must resolve its public exports; importing a repository dist path
 // would conceal broken package metadata and is deliberately not supported.
-import { Nika } from '@supernovae-st/nika-client';
+import { Nika } from '@supernovae-st/nika';
 import assert from 'node:assert/strict';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { compareResult, compareSameJobResult, compareControlledCancellation, identity, verdict } from './contract.mjs';
 
 const config = JSON.parse(readFileSync(process.argv[2], 'utf8'));
-const installed = createRequire(import.meta.url)('@supernovae-st/nika-client/package.json');
+const installed = createRequire(import.meta.url)('@supernovae-st/nika/package.json');
 assert.equal(installed.version, config.version, 'installed SDK version');
 assert.equal(process.env.NIKA_BIN, undefined, 'consumer must not inherit NIKA_BIN');
 const remote = new Nika({ url: config.url, token: config.token, allowInsecureHttp: true,

--- a/scripts/run-depth-projects.mjs
+++ b/scripts/run-depth-projects.mjs
@@ -22,7 +22,7 @@ export function stageDepthProject(source, project, tarball) {
   cpSync(source, project, { recursive: true });
   const manifestPath = path.join(project, 'package.json');
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  manifest.dependencies = { '@supernovae-st/nika-client': `file:${tarball}` };
+  manifest.dependencies = { '@supernovae-st/nika': `file:${tarball}` };
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
   return assertAppIdentity(source, project);
 }

--- a/scripts/run-one-door-e2e.mjs
+++ b/scripts/run-one-door-e2e.mjs
@@ -66,7 +66,7 @@ try {
     assert.equal(publicVersion, version, 'public SDK and repository release train');
     assert.match(engine.version, new RegExp(`^nika ${version.replaceAll('.', '\\.')} \\([0-9a-f]+\\)$`));
   }
-  let dependency = `@supernovae-st/nika-client@${publicVersion}`;
+  let dependency = `@supernovae-st/nika@${publicVersion}`;
   if (!publicVersion) {
     await owned.run('npm', ['run', 'build'], { cwd: root, env, timeoutMs: 60_000 });
     const [packed] = JSON.parse(await owned.run('npm', [

--- a/scripts/verify-client-pack.mjs
+++ b/scripts/verify-client-pack.mjs
@@ -52,7 +52,7 @@ const expectedExports = {
   './package.json': './package.json',
 };
 if (
-  manifest.name !== '@supernovae-st/nika-client'
+  manifest.name !== '@supernovae-st/nika'
   || manifest.type !== 'module'
   || manifest.main !== './dist/index.cjs'
   || manifest.module !== './dist/index.js'

--- a/scripts/verify-packed-install.mjs
+++ b/scripts/verify-packed-install.mjs
@@ -54,7 +54,7 @@ try {
   ]);
 
   const clientManifest = await readJson(
-    path.join(project, 'node_modules/@supernovae-st/nika-client/package.json'),
+    path.join(project, 'node_modules/@supernovae-st/nika/package.json'),
   );
   const nativeManifest = await readJson(
     path.join(project, 'node_modules', ...nativePackageName.split('/'), 'package.json'),
@@ -79,7 +79,7 @@ try {
     '',
   ].join('\n'));
   run(process.execPath, ['--input-type=module', '--eval', [
-    "import { Nika } from '@supernovae-st/nika-client';",
+    "import { Nika } from '@supernovae-st/nika';",
     'const nika = new Nika({ cwd: process.cwd() });',
     "if (nika.transportKind !== 'native-process') process.exit(1);",
     "const report = await nika.check('packed-release-smoke.nika.yaml');",

--- a/scripts/verify-packed-module-surfaces.mjs
+++ b/scripts/verify-packed-module-surfaces.mjs
@@ -34,7 +34,7 @@ try {
 
   const expectedVersion = packed[0]?.version;
   if (typeof expectedVersion !== 'string') throw new Error('npm pack returned no version');
-  const packageName = '@supernovae-st/nika-client';
+  const packageName = '@supernovae-st/nika';
   const commonJs = [
     `const sdk = require('${packageName}');`,
     `const manifest = require('${packageName}/package.json');`,

--- a/scripts/verify-release-evidence.mjs
+++ b/scripts/verify-release-evidence.mjs
@@ -57,7 +57,7 @@ export function verifyReleaseEvidence(root = path.resolve(import.meta.dirname, "
     throw new Error(`missing current release evidence: ${missing.join(", ")}`);
   }
 
-  const expectedPackage = `supernovae-st-nika-client-${version}.tgz`;
+  const expectedPackage = `supernovae-st-nika-${version}.tgz`;
   const currentIdentities = new Set();
   let currentFiles = 0;
   let historicalFiles = 0;

--- a/test/native-lock.test.ts
+++ b/test/native-lock.test.ts
@@ -151,7 +151,7 @@ describe('native package lock coverage', () => {
 
 function assertRootManifest(manifest: RootManifest): void {
   expect(manifest).toMatchObject({
-    name: '@supernovae-st/nika-client',
+    name: '@supernovae-st/nika',
     type: 'module',
     exports: {
       '.': {

--- a/test/npm-publication.test.mjs
+++ b/test/npm-publication.test.mjs
@@ -5,11 +5,11 @@ import path from 'node:path';
 import { afterEach, expect, test, vi } from 'vitest';
 import { assertAbsent, publishExact } from '../scripts/npm-publication.mjs';
 
-const name = '@supernovae-st/nika-client';
+const name = '@supernovae-st/nika';
 const version = '0.118.7';
 const bytes = Buffer.from('prepared immutable tarball');
 const integrity = `sha512-${createHash('sha512').update(bytes).digest('base64')}`;
-const tarball = 'https://registry.npmjs.org/@supernovae-st/nika-client/-/nika-client-0.118.7.tgz';
+const tarball = 'https://registry.npmjs.org/@supernovae-st/nika/-/nika-0.118.7.tgz';
 const directories = [];
 afterEach(async () => { await Promise.all(directories.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))); });
 

--- a/test/npm-trusted-publishing.test.mjs
+++ b/test/npm-trusted-publishing.test.mjs
@@ -45,7 +45,7 @@ test('the publishing shell accepts GitHub OIDC without an npm write token', asyn
   expect(result.calls.map((call) => call.split(' ')[2])).toEqual([
     '@supernovae-st/nika-darwin-arm64', '@supernovae-st/nika-darwin-x64',
     '@supernovae-st/nika-linux-arm64', '@supernovae-st/nika-linux-x64',
-    '@supernovae-st/nika-client',
+    '@supernovae-st/nika',
   ]);
   expect(publishStep).not.toContain('secrets.NPM_TOKEN');
 });

--- a/test/one-door-proof.test.mjs
+++ b/test/one-door-proof.test.mjs
@@ -83,13 +83,13 @@ test('same-job comparison rejects fabricated cancellation and preserves a racing
 
 test('consumer cancellation lane rejects fabricated cancellation and lost actual settlement', { timeout: 10000 }, async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-cancellation-mutation-'));
-  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika-client');
+  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika');
   const owned = new OwnedProcesses();
   const env = { ...process.env };
   delete env.NIKA_BIN;
   try {
     mkdirSync(packageRoot, { recursive: true });
-    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: '@supernovae-st/nika-client',
+    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: '@supernovae-st/nika',
       version: '0.118.1', type: 'module', exports: { '.': './index.js', './package.json': './package.json' } }));
     // Test double for both the SDK and gate control: release is an explicit
     // promise rendezvous, with no engine, installation, network, or sleep.
@@ -248,13 +248,13 @@ test('same-job comparator checks the separate error copy and all additive diagno
 
 test.each(['event', 'attach', 'replay'])('consumer rejects same-job settlement loss at %s', { timeout: 10000 }, async (boundary) => {
   const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-settlement-test-'));
-  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika-client');
+  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika');
   const owned = new OwnedProcesses();
   const env = { ...process.env };
   delete env.NIKA_BIN;
   try {
     mkdirSync(packageRoot, { recursive: true });
-    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: '@supernovae-st/nika-client',
+    writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name: '@supernovae-st/nika',
       version: '0.118.1', type: 'module', exports: { '.': './index.js', './package.json': './package.json' } }));
     // A transport double only: no engine, build, npm install, or network.
     writeFileSync(path.join(packageRoot, 'index.js'), `
@@ -367,7 +367,7 @@ test('supervisor bounds output and preserves unrelated owned groups until explic
 
 test('consumer uses installed bare exports and rejects a malformed export despite valid dist code', { timeout: 6000 }, async () => {
   const scratch = mkdtempSync(path.join(tmpdir(), 'one-door-export-test-'));
-  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika-client');
+  const packageRoot = path.join(scratch, 'node_modules/@supernovae-st/nika');
   const owned = new OwnedProcesses();
   const env = { ...process.env };
   delete env.NIKA_BIN;
@@ -377,7 +377,7 @@ test('consumer uses installed bare exports and rejects a malformed export despit
     for (const file of ['consumer.mjs', 'contract.mjs']) {
       copyFileSync(new URL(`../scripts/one-door/${file}`, import.meta.url), path.join(scratch, file));
     }
-    const manifest = { name: '@supernovae-st/nika-client', version: '0.118.1', type: 'module',
+    const manifest = { name: '@supernovae-st/nika', version: '0.118.1', type: 'module',
       exports: { '.': './dist/index.js', './package.json': './package.json' } };
     const config = path.join(scratch, 'request.json');
     writeFileSync(config, JSON.stringify({ action: 'catalog', names: [], door: 'sdk-name', version: manifest.version,

--- a/test/packed-native.test.ts
+++ b/test/packed-native.test.ts
@@ -46,7 +46,7 @@ describe.skipIf(!posix || !HOST_PACKAGE)('packed native distribution', () => {
   it('loads the supported host payload from an ESM import', () => {
     const project = stageProject(HOST_PACKAGE);
     const result = runNode(project, 'esm.mjs', `
-      import { Nika } from '@supernovae-st/nika-client';
+      import { Nika } from '@supernovae-st/nika';
       const report = await new Nika().check('esm-packed.nika.yaml');
       console.log(JSON.stringify(report.argv));
     `);
@@ -57,7 +57,7 @@ describe.skipIf(!posix || !HOST_PACKAGE)('packed native distribution', () => {
   it('loads the supported host payload from a CJS require', () => {
     const project = stageProject(HOST_PACKAGE);
     const result = runNode(project, 'cjs.cjs', `
-      const { Nika } = require('@supernovae-st/nika-client');
+      const { Nika } = require('@supernovae-st/nika');
       new Nika().check('cjs-packed.nika.yaml').then((report) => {
         console.log(JSON.stringify(report.argv));
       });
@@ -69,7 +69,7 @@ describe.skipIf(!posix || !HOST_PACKAGE)('packed native distribution', () => {
   it('lets the Node process exit immediately after a durable schedule apply', () => {
     const project = stageProject(HOST_PACKAGE);
     const result = runNode(project, 'schedule-exit.mjs', `
-      import { Nika } from '@supernovae-st/nika-client';
+      import { Nika } from '@supernovae-st/nika';
       const identity = {
         status: 'ok',
         service: 'nika-serve',
@@ -147,7 +147,7 @@ describe.skipIf(!posix || !HOST_PACKAGE)('packed native distribution', () => {
       'nika',
     ), '\n// tampered\n');
     const result = runNode(project, 'tampered.mjs', `
-      import { Nika } from '@supernovae-st/nika-client';
+      import { Nika } from '@supernovae-st/nika';
       try { await new Nika().check('must-not-run.nika.yaml'); } catch (error) {
         console.log(JSON.stringify({ name: error.name, capability: error.capability }));
       }
@@ -165,7 +165,7 @@ describe.skipIf(!posix || !HOST_PACKAGE)('packed native distribution', () => {
       project,
       'node_modules',
       '@supernovae-st',
-      'nika-client',
+      'nika',
       'dist',
       'bin',
       'nika.js',
@@ -185,7 +185,7 @@ describe.skipIf(!posix || !HOST_PACKAGE)('packed native distribution', () => {
       project,
       'node_modules',
       '@supernovae-st',
-      'nika-client',
+      'nika',
       'dist',
       'bin',
       'nika.js',
@@ -212,7 +212,7 @@ function stageProject(payloadPackage?: string): string {
   const project = mkdtempSync(path.join(SCRATCH, 'project-'));
   const scope = path.join(project, 'node_modules', '@supernovae-st');
   mkdirSync(scope, { recursive: true });
-  cpSync(PACKED_CLIENT, path.join(scope, 'nika-client'), { recursive: true });
+  cpSync(PACKED_CLIENT, path.join(scope, 'nika'), { recursive: true });
   if (payloadPackage) installFixturePayload(scope, payloadPackage);
   return project;
 }
@@ -247,7 +247,7 @@ function installFixturePayload(scope: string, packageName: string): void {
 
 function runUnavailable(project: string) {
   return runNode(project, 'missing.mjs', `
-    import { Nika } from '@supernovae-st/nika-client';
+    import { Nika } from '@supernovae-st/nika';
     try { new Nika(); } catch (error) {
       console.log(JSON.stringify({
         name: error.name,

--- a/test/packed-release-install.test.ts
+++ b/test/packed-release-install.test.ts
@@ -57,7 +57,7 @@ function packedFixture(engineVersion: string): { client: string; native: string 
   mkdirSync(tarballs);
 
   writeFileSync(path.join(clientRoot, 'package.json'), JSON.stringify({
-    name: '@supernovae-st/nika-client',
+    name: '@supernovae-st/nika',
     version: VERSION,
     type: 'module',
     exports: './dist/index.js',

--- a/test/readme-surface.test.ts
+++ b/test/readme-surface.test.ts
@@ -28,12 +28,12 @@ describe('packed public documentation', () => {
 
   it('exports package metadata so consumers can prove the installed pin', () => {
     expect(manifest.exports?.['./package.json']).toBe('./package.json');
-    expect(readme).toContain("require('@supernovae-st/nika-client/package.json').version");
+    expect(readme).toContain("require('@supernovae-st/nika/package.json').version");
   });
 
   it('does not regress to removed APIs or claim a webhook verifier', () => {
     for (const publicSurface of [readme, mediaScript]) {
-      expect(publicSurface).not.toContain("from '@supernovae-st/nika-client/local'");
+      expect(publicSurface).not.toContain("from '@supernovae-st/nika/local'");
       expect(publicSurface).not.toContain('new LocalNika');
       expect(publicSurface).not.toContain('runToEnd(');
     }

--- a/test/release-evidence.test.ts
+++ b/test/release-evidence.test.ts
@@ -7,7 +7,7 @@ import { verifyReleaseEvidence } from '../scripts/verify-release-evidence.mjs';
 const ROOT = path.resolve(import.meta.dirname, '..');
 const VERSION = '0.118.7';
 const ENGINE = 'nika 0.118.7 (f3a31a6ee)';
-const PACKAGE = 'supernovae-st-nika-client-0.118.7.tgz';
+const PACKAGE = 'supernovae-st-nika-0.118.7.tgz';
 const currentEvidence = [
   'gauntlet/projects-depth/results.json',
   'gauntlet/results/hostile.json',
@@ -94,11 +94,11 @@ describe('release evidence identity', () => {
     writeJson(fixture, 'gauntlet/results/mini-saas.json', {
       schema_version: 1,
       engine: ENGINE,
-      package: 'supernovae-st-nika-client-0.116.0.tgz',
+      package: 'supernovae-st-nika-0.116.0.tgz',
     });
 
     expect(() => verifyReleaseEvidence(fixture)).toThrow(
-      `records package supernovae-st-nika-client-0.116.0.tgz, expected ${PACKAGE}`,
+      `records package supernovae-st-nika-0.116.0.tgz, expected ${PACKAGE}`,
     );
   });
 

--- a/test/release-pack-verification.test.ts
+++ b/test/release-pack-verification.test.ts
@@ -27,7 +27,7 @@ function fixture(
   mkdirSync(packageRoot);
   mkdirSync(tarballs);
   writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({
-    name: '@supernovae-st/nika-client',
+    name: '@supernovae-st/nika',
     version,
     type: 'module',
     exports: {
@@ -44,11 +44,11 @@ function fixture(
     nikaRelease: { preparedCommit, version },
     ...manifestOverrides,
   }));
-  const filename = 'supernovae-st-nika-client-0.116.0.tgz';
+  const filename = 'supernovae-st-nika-0.116.0.tgz';
   execFileSync('tar', ['-czf', path.join(tarballs, filename), '-C', root, 'package']);
   const report = path.join(root, 'pack.json');
   writeFileSync(report, JSON.stringify([{
-    name: '@supernovae-st/nika-client',
+    name: '@supernovae-st/nika',
     version,
     filename,
     files: [

--- a/test/release-replay.test.ts
+++ b/test/release-replay.test.ts
@@ -502,7 +502,7 @@ function depthReport(incident: Record<string, unknown>): any {
   return {
     schema_version: 1,
     engine: ENGINE,
-    package: 'supernovae-st-nika-client-0.118.7.tgz',
+    package: 'supernovae-st-nika-0.118.7.tgz',
     projects: [{
       project: 'incident-response-controller',
       status: 'succeeded',

--- a/test/release-stamp.test.ts
+++ b/test/release-stamp.test.ts
@@ -139,7 +139,7 @@ function createFixture(version: string): string {
   scratch.push(fixture);
   for (const [index, relativePath] of manifestPaths.entries()) {
     writeManifest(fixture, relativePath, {
-      name: index === 0 ? '@supernovae-st/nika-client' : `@supernovae-st/native-${index}`,
+      name: index === 0 ? '@supernovae-st/nika' : `@supernovae-st/native-${index}`,
       version,
     });
   }


### PR DESCRIPTION
## Why

The product's public names now follow one law: where a namespace exists it names the owner (`supernovae-st`), the artifact carries the product's name (`nika`) once per registry, and a role suffix names a satellite only. On npm this package was the one exception: it is the product's JavaScript door (the `nika` bin that execs the resolved engine, the `Nika` class, the four platform payloads already named `@supernovae-st/nika-<os>-<arch>`), published under a role name. npm had even recorded the intent: `@supernovae-st/nika` 0.71.0 is deprecated with the note « a fresh rebuild ships under the same name ».

## What changes

- **Package name** `@supernovae-st/nika-client` → `@supernovae-st/nika` in `package.json`, the lockfile root, README, scripts, tests, gauntlet consumers and the two publication workflows. The packed tarball becomes `supernovae-st-nika-<version>.tgz`; the release-evidence verifier, its tests and the publication gates read the new name. The repository keeps its name; the five-package invariant of the trusted-publishing tests is unchanged (one root package, four payloads).
- **Release gate race fixed** in `release.yml` (`Prove the pinned contract and generated types against the released binary`) and in the CI type-drift probe: the resident's `server.log` is created before the background launch, so the discovery loop never reads a file that the subshell has not opened yet. This is the failure of the 2026-09-10 preparation run (bash reports the enclosing `for` line, 44; reproduced locally under bash 3.2 and 5.3).
- **Receipts regenerated** (`gauntlet/results/mini-saas.json`, `gauntlet/results/recovery-e2e.json`, `gauntlet/projects-depth/results.json`, the depth report line) from a fresh pack against the public `nika 0.118.7 (f3a31a6ee)` asset, `mock/echo` only.
- CHANGELOG: Changed, Deprecated, Fixed entries under Unreleased. Version stays 0.118.7 (never published under either name).

## Validation

- `npm run build` · `npm test` 545/545 against the released macOS arm64 0.118.7 binary (`NIKA_BIN`), after the packed-native path fixture followed the rename.
- `npm run check:release-evidence` and `check:package-surface` on the regenerated receipts.
- `actionlint` on the three workflows.

## What this PR does not do (operator gestures)

1. **npm trusted publishers.** The 2026-09-09 release run reached `npm publish --provenance` and got `E404 Not Found - PUT …/@supernovae-st%2fnika-darwin-arm64`: npm answers 404 when the OIDC identity is not trusted by the package. Configure, on npmjs.com, for each of the five packages (`@supernovae-st/nika`, `@supernovae-st/nika-darwin-arm64`, `@supernovae-st/nika-darwin-x64`, `@supernovae-st/nika-linux-arm64`, `@supernovae-st/nika-linux-x64`): repository `supernovae-st/nika-client`, workflow `release.yml`, environment `npm-publish`, direct publication enabled (PR #94's contract, now for the new root name).
2. **Deprecate the old name** after the first `@supernovae-st/nika` publication: `npm deprecate @supernovae-st/nika-client@"*" "Renamed: install @supernovae-st/nika"` (a login-scoped gesture, not something the OIDC token can do).
3. **Teaching surfaces** follow once the package is public: docs.nika.sh (eight `sdk/*.mdx` pages name the old package), the Lab, and any consumer pinned by name.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>
