### PR TITLE
fix(release): the publication proof waits for the registry's archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The publication proof waits for the registry: after `npm publish` the
+  version's metadata and its archive become visible in two steps, and the
+  darwin-arm64 payload's tarball answered 404 for minutes on 2026-09-10 while
+  its metadata was already served. Both post-publish reads now retry a 404 or
+  a 5xx for a bounded window (sixty attempts, fifteen seconds apart) and keep
+  their original failure words when it closes; a 4xx other than 404 still
+  refuses at once.
 - The release preparation and the CI type-drift probes create the resident's
   `server.log` before launching it; the discovery loop no longer races a
   background subshell that has not opened its redirection yet, the failure

--- a/scripts/npm-publication.mjs
+++ b/scripts/npm-publication.mjs
@@ -77,15 +77,33 @@ async function localIntegrity(file) {
   return `sha512-${hash.digest('base64')}`;
 }
 
-async function verifyBytes(value, name, version, integrity, fetch) {
+// A publication becomes visible in two steps: the version's metadata first, its
+// archive on the registry's CDN later. Measured 2026-09-10: the darwin-arm64
+// payload answered `+ @supernovae-st/nika-darwin-arm64@0.118.7`, its metadata
+// was readable at once, and its tarball URL kept answering 404 for minutes. Both
+// post-publish reads therefore wait, bounded and loud: a 404 or a 5xx on the
+// archive is « not served yet », never « different bytes »; the failure keeps its
+// original words once the window closes.
+const REGISTRY_WAIT = Object.freeze({ attempts: 60, waitMs: 15_000 }); // fifteen minutes
+
+function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
+
+async function verifyBytes(value, name, version, integrity, fetch, wait = REGISTRY_WAIT, sleep = defaultSleep) {
   const leaf = name.split('/')[1];
   const expectedUrl = `${REGISTRY}/${name}/-/${leaf}-${version}.tgz`;
   if (value.dist?.integrity !== integrity || value.dist?.tarball !== expectedUrl) {
     throw new Error('occupied npm version differs from prepared integrity or canonical URL');
   }
-  const reply = await response(expectedUrl, fetch);
-  if (reply.status !== 200) {
+  let reply;
+  for (let attempt = 1; ; attempt += 1) {
+    reply = await response(expectedUrl, fetch);
+    if (reply.status === 200) break;
     await reply.body?.cancel();
+    if ((reply.status === 404 || reply.status >= 500) && attempt < wait.attempts) {
+      console.error(`npm archive HTTP ${reply.status} · not served yet · attempt ${attempt}/${wait.attempts} · waiting ${wait.waitMs} ms`);
+      await sleep(wait.waitMs);
+      continue;
+    }
     throw new Error(`npm archive HTTP ${reply.status}`);
   }
   const hash = createHash('sha512');
@@ -98,7 +116,9 @@ async function verifyBytes(value, name, version, integrity, fetch) {
 // The prepared artifact is already pack-inspected and platform-tested upstream.
 // This boundary proves immutable byte convergence, not cross-package atomicity
 // or provenance on replay. It never adopts a version merely because it exists.
-export async function publishExact(name, version, file, { fetch = globalThis.fetch, run = execFileSync } = {}) {
+export async function publishExact(name, version, file, {
+  fetch = globalThis.fetch, run = execFileSync, wait = REGISTRY_WAIT, sleep = defaultSleep,
+} = {}) {
   coordinate(name, version);
   file = path.resolve(file);
   const integrity = await localIntegrity(file);
@@ -110,9 +130,14 @@ export async function publishExact(name, version, file, { fetch = globalThis.fet
       stdio: 'inherit', timeout: 180_000, killSignal: 'SIGKILL',
     });
     value = await published(name, version, fetch);
+    for (let attempt = 1; value === null && attempt < wait.attempts; attempt += 1) {
+      console.error(`published npm version not observable yet · attempt ${attempt}/${wait.attempts} · waiting ${wait.waitMs} ms`);
+      await sleep(wait.waitMs);
+      value = await published(name, version, fetch);
+    }
     if (value === null) throw new Error('published npm version is not observable');
   }
-  await verifyBytes(value, name, version, integrity, fetch);
+  await verifyBytes(value, name, version, integrity, fetch, wait, sleep);
   if (await localIntegrity(file) !== integrity) throw new Error('prepared npm bytes changed during publication');
   return { published: didPublish, integrity };
 }

--- a/test/npm-publication.test.mjs
+++ b/test/npm-publication.test.mjs
@@ -82,7 +82,45 @@ test('publication refusal is not followed by a success claim', async () => {
 });
 
 test('success exit with absent public bytes is still a failed release', async () => {
-  await expect(publishExact(name, version, await fixture(), { fetch: registry(absent(), absent()), run: vi.fn() })).rejects.toThrow('not observable');
+  const wait = { attempts: 1, waitMs: 0 };
+  await expect(publishExact(name, version, await fixture(), { fetch: registry(absent(), absent()), run: vi.fn(), wait })).rejects.toThrow('not observable');
+});
+
+// Measured 2026-09-10 on @supernovae-st/nika-darwin-arm64@0.118.7: `npm publish`
+// answered `+ …@0.118.7`, the metadata was readable at once, and the tarball URL
+// kept answering 404 for minutes. The registry serves a publication in two steps.
+test('a freshly published archive that lags its metadata is re-read until served', async () => {
+  const file = await fixture();
+  const notYet = () => new Response('later', { status: 404 });
+  const outage = () => new Response('later', { status: 503 });
+  const fetch = registry(absent(), metadata(), notYet(), outage(), new Response(bytes));
+  const sleep = vi.fn(async () => {});
+  await expect(publishExact(name, version, file, { fetch, run: vi.fn(), wait: { attempts: 5, waitMs: 7 }, sleep })).resolves.toEqual({ published: true, integrity });
+  expect(fetch).toHaveBeenCalledTimes(5);
+  expect(sleep).toHaveBeenCalledTimes(2);
+  expect(sleep).toHaveBeenCalledWith(7);
+});
+
+test('metadata that lags a publish is re-read before the archive', async () => {
+  const fetch = registry(absent(), absent(), metadata(), new Response(bytes));
+  await expect(publishExact(name, version, await fixture(), { fetch, run: vi.fn(), wait: { attempts: 3, waitMs: 0 } })).resolves.toEqual({ published: true, integrity });
+  expect(fetch).toHaveBeenCalledTimes(4);
+});
+
+test('the archive wait is bounded and keeps its words', async () => {
+  const notYet = () => new Response('later', { status: 404 });
+  const fetch = registry(absent(), metadata(), notYet(), notYet());
+  const run = vi.fn();
+  await expect(publishExact(name, version, await fixture(), { fetch, run, wait: { attempts: 2, waitMs: 0 } })).rejects.toThrow('npm archive HTTP 404');
+  expect(run).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenCalledTimes(4);
+});
+
+test('an occupied version whose archive is not served yet waits too, and a 4xx other than 404 still refuses', async () => {
+  const fetch = registry(metadata(), new Response('later', { status: 404 }), new Response(bytes));
+  await expect(publishExact(name, version, await fixture(), { fetch, run: vi.fn(), wait: { attempts: 3, waitMs: 0 } })).resolves.toEqual({ published: false, integrity });
+  const forbidden = registry(metadata(), new Response('no', { status: 403 }));
+  await expect(publishExact(name, version, await fixture(), { fetch: forbidden, run: vi.fn(), wait: { attempts: 3, waitMs: 0 } })).rejects.toThrow('npm archive HTTP 403');
 });
 
 test('prepared bytes changing during publication cannot be accepted', async () => {


### PR DESCRIPTION
The 0.118.7 train (run 34482714378) published `@supernovae-st/nika-darwin-arm64@0.118.7` with provenance, then died on `npm archive HTTP 404`: the byte proof re-downloads the archive right after `npm publish`, and the registry serves a version in two steps (metadata at once, the CDN archive minutes later; the tarball URL still answered 404 eight minutes after the publish).

Both post-publish reads now wait, bounded and loud: a 404 or a 5xx on the archive is « not served yet », never « different bytes »; sixty attempts fifteen seconds apart, then the original failure words. A 4xx other than 404 still refuses at once; the pre-publish reads keep their fail-closed semantics. Four tests pin the archive lag, the metadata lag, the bounded window and the occupied replay (26/26 on the two publication files).

After merge, the same dispatch replays: the occupied darwin-arm64 coordinate is byte-verified (once its archive is served) and the three payloads and the root publish.

Co-Authored-By: Nika 🦋 <nika@supernovae.studio>